### PR TITLE
Add AI fallback for multi-recipe detection

### DIFF
--- a/internal/service/import.go
+++ b/internal/service/import.go
@@ -740,19 +740,15 @@ func (s *ImportService) PreviewFromURLWithMultiCheck(ctx context.Context, rawURL
 		return nil, err // pass through ExtractionError (not_found, site_blocked, etc.)
 	}
 
-	// Check for multiple JSON-LD recipes before extracting
+	// Check for multiple recipes (JSON-LD first, then AI fallback)
 	if resolver != nil {
-		cards := extractAllJSONLDRecipes(html, rawURL)
-		if len(cards) > 1 {
-			log.Info("multi-recipe page detected on click", zap.Int("recipe_count", len(cards)))
-			entry := resolver.ResolveFromHTML(rawURL, html)
-			if entry != nil {
-				return &PreviewResult{
-					IsMulti:    true,
-					MultiID:    entry.ID,
-					MultiCards: entry.GetCards(),
-				}, nil
-			}
+		entry := resolver.ResolveFromHTML(ctx, rawURL, html)
+		if entry != nil {
+			return &PreviewResult{
+				IsMulti:    true,
+				MultiID:    entry.ID,
+				MultiCards: entry.GetCards(),
+			}, nil
 		}
 	}
 

--- a/internal/service/multi_recipe.go
+++ b/internal/service/multi_recipe.go
@@ -290,13 +290,14 @@ Page content:
 		return nil
 	}
 
+	const maxCards = 20 // cap to prevent runaway extraction from malformed responses
 	lines := strings.Split(response, "\n")
 	var cards []MultiRecipeCard
 	seen := make(map[string]bool)
 	for _, line := range lines {
 		title := strings.TrimSpace(line)
-		// Skip empty lines, "SINGLE", and common non-recipe patterns
-		if title == "" || title == "SINGLE" || len(title) < 3 || seen[title] {
+		// Skip empty lines, "SINGLE", and noisy/too-long lines
+		if title == "" || title == "SINGLE" || len(title) < 3 || len(title) > 200 || seen[title] {
 			continue
 		}
 		seen[title] = true
@@ -305,6 +306,9 @@ Page content:
 			SourceURL:        sourceURL,
 			ExtractionStatus: "pending",
 		})
+		if len(cards) >= maxCards {
+			break
+		}
 	}
 
 	if len(cards) <= 1 {

--- a/internal/service/multi_recipe.go
+++ b/internal/service/multi_recipe.go
@@ -9,6 +9,7 @@ import (
 	"sync"
 	"time"
 
+	"github.com/windoze95/saltybytes-api/internal/ai"
 	"github.com/windoze95/saltybytes-api/internal/logger"
 	"github.com/windoze95/saltybytes-api/internal/models"
 	"go.uber.org/zap"
@@ -252,6 +253,71 @@ func stringField(obj map[string]interface{}, key string) string {
 	return ""
 }
 
+// detectMultipleRecipesFromHTML uses AI to detect recipe titles in HTML when
+// JSON-LD detection finds zero or one Recipe blocks. Returns individual cards
+// if multiple recipes found, nil otherwise.
+func detectMultipleRecipesFromHTML(ctx context.Context, provider ai.TextProvider, html string, sourceURL string) []MultiRecipeCard {
+	if provider == nil {
+		return nil
+	}
+
+	// Truncate HTML for the detection prompt
+	const maxDetectBytes = 80_000
+	truncated := html
+	if len(truncated) > maxDetectBytes {
+		truncated = truncated[:maxDetectBytes]
+	}
+
+	prompt := `This page may contain multiple recipes. List ALL distinct recipe titles found on the page.
+
+Rules:
+- Only list actual recipes with ingredients/instructions, not article titles or navigation links
+- If there is only 0 or 1 recipe, respond with just: SINGLE
+- If there are multiple recipes, respond with one title per line, nothing else
+- Do not add numbering, bullets, or formatting — just the recipe name per line
+
+Page content:
+` + truncated
+
+	result, err := provider.CookingQA(ctx, prompt, "")
+	if err != nil {
+		return nil
+	}
+
+	// Parse the response
+	response := strings.TrimSpace(result)
+	if response == "SINGLE" || response == "" {
+		return nil
+	}
+
+	lines := strings.Split(response, "\n")
+	var cards []MultiRecipeCard
+	seen := make(map[string]bool)
+	for _, line := range lines {
+		title := strings.TrimSpace(line)
+		// Skip empty lines, "SINGLE", and common non-recipe patterns
+		if title == "" || title == "SINGLE" || len(title) < 3 || seen[title] {
+			continue
+		}
+		seen[title] = true
+		cards = append(cards, MultiRecipeCard{
+			Title:            title,
+			SourceURL:        sourceURL,
+			ExtractionStatus: "pending",
+		})
+	}
+
+	if len(cards) <= 1 {
+		return nil
+	}
+
+	logger.Get().Info("AI detected multiple recipes on page",
+		zap.String("url", sourceURL),
+		zap.Int("count", len(cards)),
+	)
+	return cards
+}
+
 // MultiRecipeResolver handles detection and background extraction of multi-recipe pages.
 type MultiRecipeResolver struct {
 	Registry      *MultiRecipeRegistry
@@ -267,9 +333,24 @@ func NewMultiRecipeResolver(registry *MultiRecipeRegistry, importService *Import
 }
 
 // ResolveFromHTML detects and begins resolving a multi-recipe page from fetched HTML.
+// Uses JSON-LD detection first, then falls back to AI-based detection.
 // Returns the entry if multi-recipe, or nil if single-recipe.
-func (r *MultiRecipeResolver) ResolveFromHTML(sourceURL string, html string) *MultiRecipeEntry {
+func (r *MultiRecipeResolver) ResolveFromHTML(ctx context.Context, sourceURL string, html string) *MultiRecipeEntry {
+	// Try JSON-LD detection first (fast, no AI call)
 	cards := extractAllJSONLDRecipes(html, sourceURL)
+
+	// Fall back to AI detection if JSON-LD found 0-1 recipes
+	if len(cards) <= 1 {
+		provider := r.ImportService.PreviewProvider
+		if provider == nil {
+			provider = r.ImportService.TextProvider
+		}
+		aiCards := detectMultipleRecipesFromHTML(ctx, provider, html, sourceURL)
+		if aiCards != nil {
+			cards = aiCards
+		}
+	}
+
 	if len(cards) <= 1 {
 		return nil
 	}
@@ -306,7 +387,7 @@ func (r *MultiRecipeResolver) ResolveFromURL(ctx context.Context, sourceURL stri
 	}
 
 	// Check for multiple recipes
-	return r.ResolveFromHTML(sourceURL, html)
+	return r.ResolveFromHTML(ctx, sourceURL, html)
 }
 
 // extractAllRecipes runs full extraction for each card in the entry.


### PR DESCRIPTION
## Summary
Fixes multi-recipe pages always showing a single recipe.

**Root cause:** Detection relied entirely on JSON-LD `Recipe` blocks, but most listicle pages ("Top 10 Pasta Recipes") don't embed separate JSON-LD per recipe — they use plain HTML cards. So detection always returned <=1 recipes and fell through to single-recipe extraction.

**Fix:** When JSON-LD finds <=1 recipes, use Claude (via `CookingQA`) to scan the page and list all distinct recipe titles. If multiple found, create cards and start background extraction.

- `detectMultipleRecipesFromHTML()`: AI-based detection with truncated HTML (80KB)
- `ResolveFromHTML()`: tries JSON-LD first, then AI fallback
- `PreviewFromURLWithMultiCheck`: delegates all detection to `ResolveFromHTML`

## Test plan
- [ ] `go build && go vet && go test ./internal/...` pass
- [ ] Click a multi-recipe search result (e.g. "top 10 pasta recipes") — returns `is_multi: true` with individual cards
- [ ] Click a single-recipe result — normal preview, no AI detection call

🤖 Generated with [Claude Code](https://claude.com/claude-code)