### PR TITLE
Finish the app: vector search, unit-system correctness, auth hardening, cooking WS, full test coverage

### DIFF
--- a/cmd/api/main.go
+++ b/cmd/api/main.go
@@ -39,10 +39,11 @@ func main() {
 		logger.Get().Fatal("missing required config fields", zap.Error(err))
 	}
 
-	// Load prompts from YAML
-	prompts, err := config.LoadPrompts("configs/prompts.yaml")
+	// Load prompts from YAML. The path defaults to the Docker workdir-relative
+	// configs/prompts.yaml and can be overridden via PROMPTS_PATH.
+	prompts, err := config.LoadPrompts(cfg.EnvVars.PromptsPath)
 	if err != nil {
-		logger.Get().Fatal("failed to load prompts", zap.Error(err))
+		logger.Get().Fatal("failed to load prompts", zap.String("path", cfg.EnvVars.PromptsPath), zap.Error(err))
 	}
 	cfg.Prompts = prompts
 

--- a/configs/prompts.yaml
+++ b/configs/prompts.yaml
@@ -143,7 +143,13 @@ cooking_qa:
 dietary_interview:
   system_prefix: |
     You are conducting a dietary interview for a family cooking app. Ask about allergies, intolerances, dietary preferences (vegetarian, vegan, keto, etc.), disliked foods, and cultural/religious dietary restrictions.
-    Ask one question at a time. Be conversational and friendly. After gathering enough information, summarize the dietary profile.
+    Ask ONE focused question at a time. Be conversational and friendly. Keep questions short.
+    Cover these areas before finishing: food allergies (including severity and any specific forms, e.g. "raw egg but baked egg is fine"), food intolerances, dietary restrictions (lifestyle, cultural, or religious), and food preferences or dislikes.
+    Once — and ONLY once — you have gathered enough information to fill out a complete dietary profile, call the save_dietary_profile tool with the structured profile, and include a short friendly wrap-up message summarizing what you recorded. Do NOT call the tool while any of the areas above are still unasked; until then, reply with plain text containing only your next question.
+    Allergy severity must be one of: mild, moderate, severe, life_threatening. Use empty arrays/strings for areas where the person reported nothing.
+    Examples:
+    - Areas still uncovered → plain text: "Got it, no nut allergies. Are there any foods that upset their stomach, like dairy or gluten?"
+    - All areas covered → call save_dietary_profile (e.g. {"allergies": [{"name": "peanuts", "severity": "severe", "sub_forms": [], "notes": "carries an EpiPen"}], "intolerances": ["lactose"], "restrictions": ["vegetarian"], "preferences": ["dislikes cilantro"], "medical_notes": ""}) with a wrap-up like: "Perfect, I've saved the profile: a severe peanut allergy, lactose intolerance, vegetarian, and no cilantro."
   system: |
     You are interviewing {{.MemberName}}.
 

--- a/internal/ai/anthropic.go
+++ b/internal/ai/anthropic.go
@@ -1021,7 +1021,7 @@ func (p *AnthropicProvider) ExtractRecipeFromText(ctx context.Context, text stri
 		var promptTemplate string
 		var templateData map[string]interface{}
 
-		if unitSystem == "preserve source" {
+		if unitSystem == UnitSystemPreserveSource {
 			sysPrefix = p.prompts.Import.URL.SystemPrefix
 			promptTemplate = p.prompts.Import.URL.System
 			templateData = map[string]interface{}{

--- a/internal/ai/anthropic.go
+++ b/internal/ai/anthropic.go
@@ -29,25 +29,44 @@ func (p *AnthropicProvider) WithMiddleware(mw AIMiddleware) {
 	p.middleware = mw
 }
 
-// NewAnthropicProvider creates a new AnthropicProvider with the given API key
-// and prompt configuration.
-func NewAnthropicProvider(apiKey string, prompts *config.Prompts) *AnthropicProvider {
+// Default Anthropic model IDs used when no override is configured.
+// claude-3-5-sonnet-20241022 (the previous default) was retired on 2025-10-28;
+// claude-sonnet-4-6 is its recommended replacement. The vendored SDK version
+// predates the 4.6 family, so these are string literals rather than SDK
+// constants. The code is already 4.6-compatible: it never sets temperature or
+// top_p, never prefills a trailing assistant turn, uses no extended-thinking
+// config, and parses tool inputs via json.Unmarshal.
+const (
+	DefaultAnthropicModel      = "claude-sonnet-4-6"
+	DefaultAnthropicLightModel = "claude-haiku-4-5-20251001"
+)
+
+// NewAnthropicProvider creates a new AnthropicProvider with the given API key,
+// model ID and prompt configuration. An empty model falls back to
+// DefaultAnthropicModel.
+func NewAnthropicProvider(apiKey string, model string, prompts *config.Prompts) *AnthropicProvider {
+	if model == "" {
+		model = DefaultAnthropicModel
+	}
 	client := anthropic.NewClient(option.WithAPIKey(apiKey))
 	return &AnthropicProvider{
 		client:  client,
-		model:   anthropic.ModelClaude3_5Sonnet20241022,
+		model:   anthropic.Model(model),
 		prompts: prompts,
 	}
 }
 
 // NewAnthropicLightProvider creates an AnthropicProvider using the cheaper
 // Haiku model. Suitable for preview/extraction tasks where cost matters more
-// than maximum quality.
-func NewAnthropicLightProvider(apiKey string, prompts *config.Prompts) *AnthropicProvider {
+// than maximum quality. An empty model falls back to DefaultAnthropicLightModel.
+func NewAnthropicLightProvider(apiKey string, model string, prompts *config.Prompts) *AnthropicProvider {
+	if model == "" {
+		model = DefaultAnthropicLightModel
+	}
 	client := anthropic.NewClient(option.WithAPIKey(apiKey))
 	return &AnthropicProvider{
 		client:  client,
-		model:   anthropic.Model("claude-haiku-4-5-20251001"),
+		model:   anthropic.Model(model),
 		prompts: prompts,
 	}
 }

--- a/internal/ai/anthropic.go
+++ b/internal/ai/anthropic.go
@@ -91,8 +91,8 @@ func createRecipeTool(summaryPrompt string) anthropic.ToolUnionParam {
 						"items": map[string]interface{}{
 							"type": "object",
 							"properties": map[string]interface{}{
-								"name":   map[string]interface{}{"type": "string", "description": "Name of the ingredient, do not include unit or amount in this field"},
-								"unit":   map[string]interface{}{"type": "string", "description": "Unit for the ingredient, comply with UnitSystem specified.", "enum": []string{"pieces", "tsp", "tbsp", "fl oz", "cup", "pt", "qt", "gal", "oz", "lb", "mL", "L", "mg", "g", "kg", "pinch", "dash", "drop", "bushel"}},
+								"name":          map[string]interface{}{"type": "string", "description": "Name of the ingredient, do not include unit or amount in this field"},
+								"unit":          map[string]interface{}{"type": "string", "description": "Unit for the ingredient, comply with UnitSystem specified.", "enum": []string{"pieces", "tsp", "tbsp", "fl oz", "cup", "pt", "qt", "gal", "oz", "lb", "mL", "L", "mg", "g", "kg", "pinch", "dash", "drop", "bushel"}},
 								"amount":        map[string]interface{}{"type": "number", "description": "Amount of the ingredient"},
 								"metric_unit":   map[string]interface{}{"type": "string", "description": "Metric equivalent unit. Always metric (g, kg, mL, L, mg). Duplicate primary if already metric.", "enum": []string{"mg", "g", "kg", "mL", "L"}},
 								"metric_amount": map[string]interface{}{"type": "number", "description": "Metric equivalent amount. Use accurate cooking conversions (1 cup flour=120g, 1 cup butter=227g, 1 cup water=240mL). Round to practical amounts."},

--- a/internal/ai/anthropic.go
+++ b/internal/ai/anthropic.go
@@ -266,6 +266,55 @@ func estimatePortionsTool() anthropic.ToolUnionParam {
 	}
 }
 
+// saveDietaryProfileTool builds the Claude tool definition for saving a
+// completed dietary profile at the end of a dietary interview. The input
+// schema mirrors models.DietaryProfile's snake_case JSON shape.
+func saveDietaryProfileTool() anthropic.ToolUnionParam {
+	return anthropic.ToolUnionParam{
+		OfTool: &anthropic.ToolParam{
+			Name:        "save_dietary_profile",
+			Description: anthropic.String("Save the completed dietary profile. Call this ONLY once the interview has gathered enough information to fill out the profile (allergies, intolerances, restrictions, and preferences have all been asked about)."),
+			InputSchema: anthropic.ToolInputSchemaParam{
+				Type: "object",
+				Properties: map[string]interface{}{
+					"allergies": map[string]interface{}{
+						"type":        "array",
+						"description": "Food allergies. Empty array if none.",
+						"items": map[string]interface{}{
+							"type": "object",
+							"properties": map[string]interface{}{
+								"name":      map[string]interface{}{"type": "string", "description": "Name of the allergen (e.g. 'peanuts', 'shellfish')"},
+								"severity":  map[string]interface{}{"type": "string", "description": "Severity of the allergy", "enum": []string{"mild", "moderate", "severe", "life_threatening"}},
+								"sub_forms": map[string]interface{}{"type": "array", "items": map[string]interface{}{"type": "string"}, "description": "Specific forms or sub-ingredients that trigger the allergy (e.g. 'raw egg' but not 'baked egg'). Empty array if it applies to all forms."},
+								"notes":     map[string]interface{}{"type": "string", "description": "Additional notes about the allergy (reactions, cross-contamination concerns, etc.)"},
+							},
+						},
+					},
+					"intolerances": map[string]interface{}{
+						"type":        "array",
+						"description": "Food intolerances (e.g. 'lactose', 'gluten'). Empty array if none.",
+						"items":       map[string]interface{}{"type": "string"},
+					},
+					"restrictions": map[string]interface{}{
+						"type":        "array",
+						"description": "Dietary restrictions including lifestyle, cultural, or religious (e.g. 'vegetarian', 'halal', 'keto'). Empty array if none.",
+						"items":       map[string]interface{}{"type": "string"},
+					},
+					"preferences": map[string]interface{}{
+						"type":        "array",
+						"description": "Food preferences and dislikes (e.g. 'dislikes cilantro', 'loves spicy food'). Empty array if none.",
+						"items":       map[string]interface{}{"type": "string"},
+					},
+					"medical_notes": map[string]interface{}{
+						"type":        "string",
+						"description": "Medically relevant dietary notes (e.g. 'low sodium for hypertension'). Empty string if none.",
+					},
+				},
+			},
+		},
+	}
+}
+
 // allergenToolResult is the JSON structure returned by the analyze_allergens tool call.
 type allergenToolResult struct {
 	IngredientAnalyses []ingredientAnalysisToolRes `json:"ingredient_analyses"`
@@ -295,6 +344,23 @@ type portionToolResult struct {
 	Portions    int     `json:"portions"`
 	PortionSize string  `json:"portion_size"`
 	Confidence  float64 `json:"confidence"`
+}
+
+// dietaryProfileToolResult is the JSON structure returned by the
+// save_dietary_profile tool call.
+type dietaryProfileToolResult struct {
+	Allergies    []dietaryAllergyToolRes `json:"allergies"`
+	Intolerances []string                `json:"intolerances"`
+	Restrictions []string                `json:"restrictions"`
+	Preferences  []string                `json:"preferences"`
+	MedicalNotes string                  `json:"medical_notes"`
+}
+
+type dietaryAllergyToolRes struct {
+	Name     string   `json:"name"`
+	Severity string   `json:"severity"`
+	SubForms []string `json:"sub_forms"`
+	Notes    string   `json:"notes"`
 }
 
 func toolResultToAllergenResult(tr *allergenToolResult) *AllergenResult {
@@ -330,6 +396,25 @@ func toolResultToPortionEstimate(tr *portionToolResult) *PortionEstimate {
 		Portions:    tr.Portions,
 		PortionSize: tr.PortionSize,
 		Confidence:  tr.Confidence,
+	}
+}
+
+func toolResultToDietaryProfile(tr *dietaryProfileToolResult) *DietaryProfileResult {
+	allergies := make([]DietaryAllergyResult, len(tr.Allergies))
+	for i, a := range tr.Allergies {
+		allergies[i] = DietaryAllergyResult{
+			Name:     a.Name,
+			Severity: a.Severity,
+			SubForms: a.SubForms,
+			Notes:    a.Notes,
+		}
+	}
+	return &DietaryProfileResult{
+		Allergies:    allergies,
+		Intolerances: tr.Intolerances,
+		Restrictions: tr.Restrictions,
+		Preferences:  tr.Preferences,
+		MedicalNotes: tr.MedicalNotes,
 	}
 }
 
@@ -521,6 +606,52 @@ func extractPortionFromToolUse(msg *anthropic.Message) (*PortionEstimate, error)
 		}
 	}
 	return nil, errors.New("no tool_use block found in Claude response")
+}
+
+// dietaryWrapUpFallback is used when the model calls save_dietary_profile
+// without any accompanying wrap-up text.
+const dietaryWrapUpFallback = "Thanks! I have everything I need and saved the dietary profile."
+
+// extractDietaryInterviewFromMessage parses a dietary interview response.
+// When the response contains a save_dietary_profile tool-use block, the
+// interview is complete and the structured profile is returned alongside the
+// model's wrap-up text. Otherwise the text content (the next interview
+// question) is returned with Complete=false.
+func extractDietaryInterviewFromMessage(msg *anthropic.Message) (*DietaryInterviewResult, error) {
+	var text string
+	var profile *DietaryProfileResult
+
+	for _, block := range msg.Content {
+		switch block.Type {
+		case "text":
+			text += block.Text
+		case "tool_use":
+			if block.Name != "save_dietary_profile" {
+				continue
+			}
+			raw, err := json.Marshal(block.Input)
+			if err != nil {
+				return nil, NewAIError(FailureContentParse, fmt.Errorf("failed to marshal tool input: %w", err), "failed to parse dietary profile tool result")
+			}
+			var tr dietaryProfileToolResult
+			if err := json.Unmarshal(raw, &tr); err != nil {
+				return nil, NewAIError(FailureContentParse, fmt.Errorf("failed to unmarshal dietary profile: %w", err), "failed to parse dietary profile tool result")
+			}
+			profile = toolResultToDietaryProfile(&tr)
+		}
+	}
+
+	if profile != nil {
+		if text == "" {
+			text = dietaryWrapUpFallback
+		}
+		return &DietaryInterviewResult{Response: text, Complete: true, Profile: profile}, nil
+	}
+
+	if text == "" {
+		return nil, NewAIError(FailureContentEmpty, errors.New("no text content in Claude response"), "no text content in response")
+	}
+	return &DietaryInterviewResult{Response: text}, nil
 }
 
 // extractTextContent returns the concatenated text blocks from a Claude response.
@@ -1126,8 +1257,11 @@ func (p *AnthropicProvider) CookingQA(ctx context.Context, question string, reci
 	})
 }
 
-// DietaryInterview conducts a multi-turn dietary interview.
-func (p *AnthropicProvider) DietaryInterview(ctx context.Context, messages []Message, memberName string) (string, error) {
+// DietaryInterview conducts a multi-turn dietary interview. The model is
+// given the save_dietary_profile tool with tool choice left on auto: it keeps
+// asking questions (plain text turns) until it has gathered enough
+// information, then calls the tool to emit the structured profile.
+func (p *AnthropicProvider) DietaryInterview(ctx context.Context, messages []Message, memberName string) (*DietaryInterviewResult, error) {
 	op := AIOperation{
 		Name:      "DietaryInterview",
 		Provider:  "anthropic",
@@ -1135,29 +1269,32 @@ func (p *AnthropicProvider) DietaryInterview(ctx context.Context, messages []Mes
 		StartTime: time.Now(),
 	}
 
-	return runWithMiddleware(ctx, p.middleware, op, func(ctx context.Context) (string, error) {
+	return runWithMiddleware(ctx, p.middleware, op, func(ctx context.Context) (*DietaryInterviewResult, error) {
 		sysSuffix, err := config.RenderPrompt(p.prompts.DietaryInterview.System, map[string]interface{}{
 			"MemberName": memberName,
 		})
 		if err != nil {
-			return "", fmt.Errorf("render system prompt: %w", err)
+			return nil, fmt.Errorf("render system prompt: %w", err)
 		}
 
 		_, msgParams := messagesToAnthropicParams(messages)
 
+		// No ToolChoice is set: the default ("auto") lets the model decide
+		// when the interview has enough information to call the tool.
 		params := anthropic.MessageNewParams{
 			Model:     p.model,
 			MaxTokens: 1024,
 			System:    buildCachedSystemPrompt(p.prompts.DietaryInterview.SystemPrefix, sysSuffix),
 			Messages:  msgParams,
+			Tools:     []anthropic.ToolUnionParam{saveDietaryProfileTool()},
 		}
 
 		resp, err := p.createMessageWithRetry(ctx, params)
 		if err != nil {
-			return "", err
+			return nil, err
 		}
 
-		return extractTextContent(resp)
+		return extractDietaryInterviewFromMessage(resp)
 	})
 }
 

--- a/internal/ai/anthropic_dietary_test.go
+++ b/internal/ai/anthropic_dietary_test.go
@@ -1,0 +1,142 @@
+package ai
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/anthropics/anthropic-sdk-go"
+)
+
+func TestExtractDietaryInterview_TextOnly_Incomplete(t *testing.T) {
+	msg := &anthropic.Message{
+		Content: []anthropic.ContentBlockUnion{
+			{Type: "text", Text: "Do you have any food allergies?"},
+		},
+	}
+
+	result, err := extractDietaryInterviewFromMessage(msg)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if result.Complete {
+		t.Error("Complete = true, want false for a text-only turn")
+	}
+	if result.Profile != nil {
+		t.Errorf("Profile = %+v, want nil for a text-only turn", result.Profile)
+	}
+	if result.Response != "Do you have any food allergies?" {
+		t.Errorf("Response = %q, want passthrough of the text content", result.Response)
+	}
+}
+
+func TestExtractDietaryInterview_ToolCall_Complete(t *testing.T) {
+	input := `{
+		"allergies": [
+			{"name": "peanuts", "severity": "severe", "sub_forms": ["raw peanuts", "peanut butter"], "notes": "carries an EpiPen"},
+			{"name": "egg", "severity": "mild", "sub_forms": ["raw egg"], "notes": "baked egg is fine"}
+		],
+		"intolerances": ["lactose"],
+		"restrictions": ["vegetarian"],
+		"preferences": ["dislikes cilantro"],
+		"medical_notes": "low sodium for hypertension"
+	}`
+	msg := &anthropic.Message{
+		Content: []anthropic.ContentBlockUnion{
+			{Type: "text", Text: "All set! I've saved the profile."},
+			{Type: "tool_use", Name: "save_dietary_profile", Input: json.RawMessage(input)},
+		},
+	}
+
+	result, err := extractDietaryInterviewFromMessage(msg)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !result.Complete {
+		t.Fatal("Complete = false, want true for a tool-call turn")
+	}
+	if result.Response != "All set! I've saved the profile." {
+		t.Errorf("Response = %q, want the wrap-up text", result.Response)
+	}
+	p := result.Profile
+	if p == nil {
+		t.Fatal("Profile = nil, want populated profile")
+	}
+	if len(p.Allergies) != 2 {
+		t.Fatalf("len(Allergies) = %d, want 2", len(p.Allergies))
+	}
+	first := p.Allergies[0]
+	if first.Name != "peanuts" || first.Severity != "severe" || first.Notes != "carries an EpiPen" {
+		t.Errorf("Allergies[0] = %+v, want peanuts/severe/EpiPen note", first)
+	}
+	if len(first.SubForms) != 2 || first.SubForms[0] != "raw peanuts" || first.SubForms[1] != "peanut butter" {
+		t.Errorf("Allergies[0].SubForms = %v, want [raw peanuts, peanut butter]", first.SubForms)
+	}
+	if len(p.Intolerances) != 1 || p.Intolerances[0] != "lactose" {
+		t.Errorf("Intolerances = %v, want [lactose]", p.Intolerances)
+	}
+	if len(p.Restrictions) != 1 || p.Restrictions[0] != "vegetarian" {
+		t.Errorf("Restrictions = %v, want [vegetarian]", p.Restrictions)
+	}
+	if len(p.Preferences) != 1 || p.Preferences[0] != "dislikes cilantro" {
+		t.Errorf("Preferences = %v, want [dislikes cilantro]", p.Preferences)
+	}
+	if p.MedicalNotes != "low sodium for hypertension" {
+		t.Errorf("MedicalNotes = %q, want medical note passthrough", p.MedicalNotes)
+	}
+}
+
+func TestExtractDietaryInterview_ToolCallWithoutText_UsesFallbackWrapUp(t *testing.T) {
+	msg := &anthropic.Message{
+		Content: []anthropic.ContentBlockUnion{
+			{Type: "tool_use", Name: "save_dietary_profile", Input: json.RawMessage(`{"allergies": [], "intolerances": [], "restrictions": [], "preferences": [], "medical_notes": ""}`)},
+		},
+	}
+
+	result, err := extractDietaryInterviewFromMessage(msg)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !result.Complete || result.Profile == nil {
+		t.Fatal("want complete result with non-nil profile")
+	}
+	if result.Response != dietaryWrapUpFallback {
+		t.Errorf("Response = %q, want fallback wrap-up text", result.Response)
+	}
+}
+
+func TestExtractDietaryInterview_UnknownToolIgnored(t *testing.T) {
+	msg := &anthropic.Message{
+		Content: []anthropic.ContentBlockUnion{
+			{Type: "text", Text: "Next question?"},
+			{Type: "tool_use", Name: "some_other_tool", Input: json.RawMessage(`{}`)},
+		},
+	}
+
+	result, err := extractDietaryInterviewFromMessage(msg)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if result.Complete || result.Profile != nil {
+		t.Error("unknown tool should not mark the interview complete")
+	}
+}
+
+func TestExtractDietaryInterview_EmptyMessage_Error(t *testing.T) {
+	msg := &anthropic.Message{}
+
+	if _, err := extractDietaryInterviewFromMessage(msg); err == nil {
+		t.Fatal("expected error for empty response, got nil")
+	}
+}
+
+func TestExtractDietaryInterview_MalformedToolInput_Error(t *testing.T) {
+	msg := &anthropic.Message{
+		Content: []anthropic.ContentBlockUnion{
+			{Type: "tool_use", Name: "save_dietary_profile", Input: json.RawMessage(`{"allergies": "not-an-array"}`)},
+		},
+	}
+
+	if _, err := extractDietaryInterviewFromMessage(msg); err == nil {
+		t.Fatal("expected error for malformed tool input, got nil")
+	}
+}

--- a/internal/ai/embeddings_test.go
+++ b/internal/ai/embeddings_test.go
@@ -1,0 +1,36 @@
+package ai
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	openai "github.com/sashabaranov/go-openai"
+)
+
+func TestNewEmbeddingProvider_Defaults(t *testing.T) {
+	p := NewEmbeddingProvider("test-key")
+	if p.apiKey != "test-key" {
+		t.Errorf("apiKey = %q, want 'test-key'", p.apiKey)
+	}
+	if p.model != openai.SmallEmbedding3 {
+		t.Errorf("model = %v, want SmallEmbedding3", p.model)
+	}
+}
+
+func TestGenerateEmbedding_EmptyTextRejected(t *testing.T) {
+	// The empty-input guard fires before any client or HTTP request is
+	// constructed, so this stays fully offline.
+	p := NewEmbeddingProvider("test-key")
+
+	got, err := p.GenerateEmbedding(context.Background(), "")
+	if err == nil {
+		t.Fatal("expected error for empty text, got nil")
+	}
+	if got != nil {
+		t.Errorf("expected nil embedding, got %v", got)
+	}
+	if !strings.Contains(err.Error(), "embedding text is empty") {
+		t.Errorf("error = %q, want mention of empty embedding text", err.Error())
+	}
+}

--- a/internal/ai/errors_test.go
+++ b/internal/ai/errors_test.go
@@ -1,0 +1,209 @@
+package ai
+
+import (
+	"errors"
+	"fmt"
+	"net/http"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/anthropics/anthropic-sdk-go"
+	openai "github.com/sashabaranov/go-openai"
+)
+
+func TestNewAIError_RetryabilityTaxonomy(t *testing.T) {
+	tests := []struct {
+		name      string
+		kind      AIFailureKind
+		retryable bool
+	}{
+		{"transient is retryable", FailureTransient, true},
+		{"auth is not retryable", FailureAuth, false},
+		{"content empty is retryable", FailureContentEmpty, true},
+		{"content parse is not retryable", FailureContentParse, false},
+		{"content quality is not retryable", FailureContentQuality, false},
+		{"vision ambiguous is not retryable", FailureVisionAmbiguous, false},
+		{"quota exhausted is not retryable", FailureQuotaExhausted, false},
+		{"unknown is not retryable", FailureUnknown, false},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			aiErr := NewAIError(tc.kind, errors.New("boom"), "detail")
+			if aiErr.Retryable != tc.retryable {
+				t.Errorf("Retryable = %v, want %v", aiErr.Retryable, tc.retryable)
+			}
+			if aiErr.Kind != tc.kind {
+				t.Errorf("Kind = %v, want %v", aiErr.Kind, tc.kind)
+			}
+		})
+	}
+}
+
+func TestAIError_ErrorStringIncludesKindAndDetail(t *testing.T) {
+	tests := []struct {
+		kind     AIFailureKind
+		wantKind string
+	}{
+		{FailureTransient, "transient"},
+		{FailureAuth, "auth"},
+		{FailureContentEmpty, "content_empty"},
+		{FailureContentParse, "content_parse"},
+		{FailureContentQuality, "content_quality"},
+		{FailureVisionAmbiguous, "vision_ambiguous"},
+		{FailureQuotaExhausted, "quota_exhausted"},
+		{FailureUnknown, "unknown"},
+		{AIFailureKind(99), "unknown"}, // out-of-range kinds fall back to "unknown"
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.wantKind, func(t *testing.T) {
+			aiErr := &AIError{Kind: tc.kind, Err: errors.New("boom"), Detail: "some detail"}
+			msg := aiErr.Error()
+			if !strings.Contains(msg, "["+tc.wantKind+"]") {
+				t.Errorf("Error() = %q, want kind tag [%s]", msg, tc.wantKind)
+			}
+			if !strings.Contains(msg, "some detail") {
+				t.Errorf("Error() = %q, want detail included", msg)
+			}
+			if !strings.Contains(msg, "boom") {
+				t.Errorf("Error() = %q, want wrapped error included", msg)
+			}
+		})
+	}
+}
+
+func TestAIError_UnwrapExposesInnerError(t *testing.T) {
+	sentinel := errors.New("sentinel failure")
+	aiErr := NewAIError(FailureTransient, sentinel, "wrapping")
+
+	if !errors.Is(aiErr, sentinel) {
+		t.Error("errors.Is did not find the wrapped sentinel error")
+	}
+
+	// And through a further layer of wrapping.
+	wrapped := fmt.Errorf("outer: %w", aiErr)
+	var got *AIError
+	if !errors.As(wrapped, &got) {
+		t.Fatal("errors.As did not find *AIError through an outer wrap")
+	}
+	if got.Kind != FailureTransient {
+		t.Errorf("Kind = %v, want FailureTransient", got.Kind)
+	}
+}
+
+func newAnthropicAPIError(t *testing.T, status int) *anthropic.Error {
+	t.Helper()
+	req, err := http.NewRequest(http.MethodPost, "https://api.anthropic.com/v1/messages", nil)
+	if err != nil {
+		t.Fatalf("building request: %v", err)
+	}
+	return &anthropic.Error{
+		StatusCode: status,
+		Request:    req,
+		Response:   &http.Response{StatusCode: status},
+	}
+}
+
+func TestClassifyAnthropicError(t *testing.T) {
+	tests := []struct {
+		name      string
+		err       func(t *testing.T) error
+		wantKind  AIFailureKind
+		retryable bool
+	}{
+		{
+			name:      "429 rate limited is transient",
+			err:       func(t *testing.T) error { return newAnthropicAPIError(t, http.StatusTooManyRequests) },
+			wantKind:  FailureTransient,
+			retryable: true,
+		},
+		{
+			name:      "500 server error is transient",
+			err:       func(t *testing.T) error { return newAnthropicAPIError(t, http.StatusInternalServerError) },
+			wantKind:  FailureTransient,
+			retryable: true,
+		},
+		{
+			name:      "502 bad gateway is transient",
+			err:       func(t *testing.T) error { return newAnthropicAPIError(t, http.StatusBadGateway) },
+			wantKind:  FailureTransient,
+			retryable: true,
+		},
+		{
+			name:      "503 unavailable is transient",
+			err:       func(t *testing.T) error { return newAnthropicAPIError(t, http.StatusServiceUnavailable) },
+			wantKind:  FailureTransient,
+			retryable: true,
+		},
+		{
+			name:      "401 unauthorized is auth, not retryable",
+			err:       func(t *testing.T) error { return newAnthropicAPIError(t, http.StatusUnauthorized) },
+			wantKind:  FailureAuth,
+			retryable: false,
+		},
+		{
+			name:      "400 bad request is unknown, not retryable",
+			err:       func(t *testing.T) error { return newAnthropicAPIError(t, http.StatusBadRequest) },
+			wantKind:  FailureUnknown,
+			retryable: false,
+		},
+		{
+			name:      "plain error is unknown, not retryable",
+			err:       func(t *testing.T) error { return errors.New("connection reset") },
+			wantKind:  FailureUnknown,
+			retryable: false,
+		},
+		{
+			name: "wrapped API error is still classified",
+			err: func(t *testing.T) error {
+				return fmt.Errorf("call failed: %w", newAnthropicAPIError(t, http.StatusTooManyRequests))
+			},
+			wantKind:  FailureTransient,
+			retryable: true,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			aiErr := classifyAnthropicError(tc.err(t))
+			if aiErr.Kind != tc.wantKind {
+				t.Errorf("Kind = %v, want %v", aiErr.Kind, tc.wantKind)
+			}
+			if aiErr.Retryable != tc.retryable {
+				t.Errorf("Retryable = %v, want %v", aiErr.Retryable, tc.retryable)
+			}
+		})
+	}
+}
+
+func TestClassifyOpenAIError(t *testing.T) {
+	tests := []struct {
+		name      string
+		err       error
+		wantRetry bool
+		wantWait  time.Duration
+	}{
+		{"429 retries", &openai.APIError{HTTPStatusCode: 429}, true, 2 * time.Second},
+		{"500 retries", &openai.APIError{HTTPStatusCode: 500}, true, 2 * time.Second},
+		{"502 retries", &openai.APIError{HTTPStatusCode: 502}, true, 2 * time.Second},
+		{"503 retries", &openai.APIError{HTTPStatusCode: 503}, true, 2 * time.Second},
+		{"400 does not retry", &openai.APIError{HTTPStatusCode: 400}, false, 0},
+		{"401 does not retry", &openai.APIError{HTTPStatusCode: 401}, false, 0},
+		{"plain error does not retry", errors.New("dial tcp: timeout"), false, 0},
+		{"wrapped API error still classified", fmt.Errorf("outer: %w", &openai.APIError{HTTPStatusCode: 429}), true, 2 * time.Second},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			gotRetry, gotWait := classifyOpenAIError(tc.err)
+			if gotRetry != tc.wantRetry {
+				t.Errorf("shouldRetry = %v, want %v", gotRetry, tc.wantRetry)
+			}
+			if gotWait != tc.wantWait {
+				t.Errorf("waitTime = %v, want %v", gotWait, tc.wantWait)
+			}
+		})
+	}
+}

--- a/internal/ai/middleware.go
+++ b/internal/ai/middleware.go
@@ -10,9 +10,9 @@ import (
 
 // AIOperation describes an in-flight AI call for middleware inspection.
 type AIOperation struct {
-	Name      string    // e.g. "GenerateRecipe", "AnalyzeAllergens"
-	Provider  string    // e.g. "anthropic"
-	Model     string    // e.g. "claude-3-5-sonnet-20241022"
+	Name      string // e.g. "GenerateRecipe", "AnalyzeAllergens"
+	Provider  string // e.g. "anthropic"
+	Model     string // e.g. "claude-3-5-sonnet-20241022"
 	StartTime time.Time
 }
 

--- a/internal/ai/middleware_test.go
+++ b/internal/ai/middleware_test.go
@@ -1,0 +1,148 @@
+package ai
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+)
+
+type mwCtxKey string
+
+// recordingMiddleware appends to a shared call log and stamps the context in
+// Before so call ordering and context threading can be asserted.
+type recordingMiddleware struct {
+	name  string
+	calls *[]string
+
+	gotResult *AIOperationResult
+}
+
+func (m *recordingMiddleware) Before(ctx context.Context, op AIOperation) context.Context {
+	*m.calls = append(*m.calls, m.name+":before")
+	return context.WithValue(ctx, mwCtxKey(m.name), op.Name)
+}
+
+func (m *recordingMiddleware) After(ctx context.Context, result AIOperationResult) {
+	*m.calls = append(*m.calls, m.name+":after")
+	r := result
+	m.gotResult = &r
+}
+
+func TestMiddlewareChain_BeforeInOrderAfterReversed(t *testing.T) {
+	var calls []string
+	first := &recordingMiddleware{name: "first", calls: &calls}
+	second := &recordingMiddleware{name: "second", calls: &calls}
+	chain := NewMiddlewareChain(first, second)
+
+	ctx := chain.Before(context.Background(), AIOperation{Name: "Op"})
+	chain.After(ctx, AIOperationResult{Operation: AIOperation{Name: "Op"}})
+
+	want := []string{"first:before", "second:before", "second:after", "first:after"}
+	if len(calls) != len(want) {
+		t.Fatalf("calls = %v, want %v", calls, want)
+	}
+	for i := range want {
+		if calls[i] != want[i] {
+			t.Errorf("calls[%d] = %q, want %q", i, calls[i], want[i])
+		}
+	}
+}
+
+func TestMiddlewareChain_BeforeThreadsContext(t *testing.T) {
+	var calls []string
+	first := &recordingMiddleware{name: "first", calls: &calls}
+	second := &recordingMiddleware{name: "second", calls: &calls}
+	chain := NewMiddlewareChain(first, second)
+
+	ctx := chain.Before(context.Background(), AIOperation{Name: "GenerateRecipe"})
+
+	// Both middlewares must have contributed to the final context.
+	if got := ctx.Value(mwCtxKey("first")); got != "GenerateRecipe" {
+		t.Errorf("first middleware context value = %v, want 'GenerateRecipe'", got)
+	}
+	if got := ctx.Value(mwCtxKey("second")); got != "GenerateRecipe" {
+		t.Errorf("second middleware context value = %v, want 'GenerateRecipe'", got)
+	}
+}
+
+func TestRunWithMiddleware_NilMiddlewareRunsOperation(t *testing.T) {
+	got, err := runWithMiddleware(context.Background(), nil, AIOperation{Name: "Op"}, func(ctx context.Context) (string, error) {
+		return "result", nil
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if got != "result" {
+		t.Errorf("result = %q, want 'result'", got)
+	}
+}
+
+func TestRunWithMiddleware_PassesBeforeContextToOperation(t *testing.T) {
+	var calls []string
+	mw := &recordingMiddleware{name: "obs", calls: &calls}
+	op := AIOperation{Name: "ClassifyVoiceIntent", StartTime: time.Now()}
+
+	var seen interface{}
+	_, err := runWithMiddleware(context.Background(), mw, op, func(ctx context.Context) (int, error) {
+		seen = ctx.Value(mwCtxKey("obs"))
+		return 1, nil
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if seen != "ClassifyVoiceIntent" {
+		t.Errorf("operation saw context value %v, want 'ClassifyVoiceIntent'", seen)
+	}
+
+	want := []string{"obs:before", "obs:after"}
+	if len(calls) != 2 || calls[0] != want[0] || calls[1] != want[1] {
+		t.Errorf("calls = %v, want %v", calls, want)
+	}
+}
+
+func TestRunWithMiddleware_ReportsErrorAndOperationInAfter(t *testing.T) {
+	var calls []string
+	mw := &recordingMiddleware{name: "obs", calls: &calls}
+	op := AIOperation{Name: "GenerateRecipe", Provider: "anthropic", Model: "test-model", StartTime: time.Now()}
+	opErr := errors.New("generation failed")
+
+	got, err := runWithMiddleware(context.Background(), mw, op, func(ctx context.Context) (*RecipeResult, error) {
+		return nil, opErr
+	})
+	if !errors.Is(err, opErr) {
+		t.Fatalf("error = %v, want the operation error", err)
+	}
+	if got != nil {
+		t.Errorf("result = %v, want nil on error", got)
+	}
+
+	if mw.gotResult == nil {
+		t.Fatal("After was not called")
+	}
+	if !errors.Is(mw.gotResult.Err, opErr) {
+		t.Errorf("After received Err = %v, want the operation error", mw.gotResult.Err)
+	}
+	if mw.gotResult.Operation.Name != "GenerateRecipe" {
+		t.Errorf("After received operation %q, want 'GenerateRecipe'", mw.gotResult.Operation.Name)
+	}
+	if mw.gotResult.Operation.Provider != "anthropic" {
+		t.Errorf("After received provider %q, want 'anthropic'", mw.gotResult.Operation.Provider)
+	}
+	if mw.gotResult.Duration < 0 {
+		t.Errorf("After received negative duration %v", mw.gotResult.Duration)
+	}
+}
+
+func TestLoggingMiddleware_BeforeAndAfterDoNotPanic(t *testing.T) {
+	mw := &LoggingMiddleware{}
+	op := AIOperation{Name: "Op", Provider: "anthropic", Model: "m", StartTime: time.Now()}
+
+	ctx := mw.Before(context.Background(), op)
+	if ctx == nil {
+		t.Fatal("Before returned a nil context")
+	}
+
+	mw.After(ctx, AIOperationResult{Operation: op, Duration: time.Millisecond})
+	mw.After(ctx, AIOperationResult{Operation: op, Duration: time.Millisecond, Err: errors.New("boom")})
+}

--- a/internal/ai/openai_whisper.go
+++ b/internal/ai/openai_whisper.go
@@ -5,6 +5,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"strings"
 	"time"
 
 	openai "github.com/sashabaranov/go-openai"
@@ -22,8 +23,34 @@ func NewWhisperProvider(apiKey string) *WhisperProvider {
 	return &WhisperProvider{apiKey: apiKey}
 }
 
-// TranscribeAudio transcribes audio data to text using Whisper.
-func (p *WhisperProvider) TranscribeAudio(ctx context.Context, audioData []byte) (string, error) {
+// whisperFormats lists the audio container formats the Whisper API accepts
+// as upload file extensions.
+var whisperFormats = map[string]bool{
+	"flac": true,
+	"m4a":  true,
+	"mp3":  true,
+	"mp4":  true,
+	"mpeg": true,
+	"mpga": true,
+	"oga":  true,
+	"ogg":  true,
+	"wav":  true,
+	"webm": true,
+}
+
+// audioFilePath derives the synthetic upload filename Whisper uses to detect
+// the audio container format. Empty or unrecognized formats default to webm.
+func audioFilePath(format string) string {
+	ext := strings.ToLower(strings.TrimPrefix(strings.TrimSpace(format), "."))
+	if !whisperFormats[ext] {
+		ext = "webm"
+	}
+	return "audio." + ext
+}
+
+// TranscribeAudio transcribes audio data to text using Whisper. format is the
+// audio container format (e.g. "webm", "m4a"); empty defaults to webm.
+func (p *WhisperProvider) TranscribeAudio(ctx context.Context, audioData []byte, format string) (string, error) {
 	if len(audioData) == 0 {
 		return "", errors.New("audio data is empty")
 	}
@@ -36,7 +63,7 @@ func (p *WhisperProvider) TranscribeAudio(ctx context.Context, audioData []byte)
 		resp, err := client.CreateTranscription(ctx, openai.AudioRequest{
 			Model:    openai.Whisper1,
 			Reader:   bytes.NewReader(audioData),
-			FilePath: "audio.webm",
+			FilePath: audioFilePath(format),
 		})
 		if err == nil {
 			if resp.Text == "" {

--- a/internal/ai/openai_whisper_test.go
+++ b/internal/ai/openai_whisper_test.go
@@ -1,0 +1,27 @@
+package ai
+
+import "testing"
+
+func TestAudioFilePath(t *testing.T) {
+	cases := []struct {
+		format string
+		want   string
+	}{
+		{"", "audio.webm"},     // empty defaults to webm
+		{"webm", "audio.webm"}, // passthrough
+		{"m4a", "audio.m4a"},   // common iOS format
+		{"M4A", "audio.m4a"},   // case-insensitive
+		{".mp3", "audio.mp3"},  // leading dot stripped
+		{" wav ", "audio.wav"}, // whitespace trimmed
+		{"exe", "audio.webm"},  // unsupported falls back to webm
+		{"../x", "audio.webm"}, // path-ish input falls back to webm
+		{"flac", "audio.flac"}, // remaining supported formats
+		{"ogg", "audio.ogg"},
+	}
+
+	for _, tc := range cases {
+		if got := audioFilePath(tc.format); got != tc.want {
+			t.Errorf("audioFilePath(%q) = %q, want %q", tc.format, got, tc.want)
+		}
+	}
+}

--- a/internal/ai/provider.go
+++ b/internal/ai/provider.go
@@ -17,7 +17,7 @@ type TextProvider interface {
 	EstimatePortions(ctx context.Context, recipeDef interface{}) (*PortionEstimate, error)
 	ExtractRecipeFromText(ctx context.Context, text string, unitSystem string) (*RecipeResult, error)
 	CookingQA(ctx context.Context, question string, recipeContext string) (string, error)
-	DietaryInterview(ctx context.Context, messages []Message, memberName string) (string, error)
+	DietaryInterview(ctx context.Context, messages []Message, memberName string) (*DietaryInterviewResult, error)
 }
 
 // VisionProvider handles image-based recipe extraction (Claude).
@@ -137,6 +137,35 @@ type PortionEstimate struct {
 	Portions    int
 	PortionSize string
 	Confidence  float64
+}
+
+// DietaryInterviewResult is the structured output of one dietary interview
+// turn. When the model has gathered enough information it calls the
+// save_dietary_profile tool: Complete is true and Profile is non-nil, with
+// Response carrying a short wrap-up message. Otherwise Complete is false,
+// Profile is nil and Response carries the next interview question.
+type DietaryInterviewResult struct {
+	Response string
+	Complete bool
+	Profile  *DietaryProfileResult
+}
+
+// DietaryProfileResult is the structured dietary profile produced by a
+// completed dietary interview.
+type DietaryProfileResult struct {
+	Allergies    []DietaryAllergyResult
+	Intolerances []string
+	Restrictions []string
+	Preferences  []string
+	MedicalNotes string
+}
+
+// DietaryAllergyResult is a single allergy entry in a dietary profile.
+type DietaryAllergyResult struct {
+	Name     string
+	Severity string
+	SubForms []string
+	Notes    string
 }
 
 // SearchResult is a single web search result.

--- a/internal/ai/provider.go
+++ b/internal/ai/provider.go
@@ -2,6 +2,11 @@ package ai
 
 import "context"
 
+// UnitSystemPreserveSource is a sentinel unit-system value that instructs
+// extraction to keep the source's original measurements instead of converting,
+// reporting the detected system via the unit_system tool field.
+const UnitSystemPreserveSource = "preserve source"
+
 // TextProvider handles all text/reasoning tasks (Claude).
 type TextProvider interface {
 	GenerateRecipe(ctx context.Context, req RecipeRequest) (*RecipeResult, error)

--- a/internal/ai/provider.go
+++ b/internal/ai/provider.go
@@ -30,9 +30,10 @@ type ImageProvider interface {
 	GenerateImage(ctx context.Context, prompt string) ([]byte, error)
 }
 
-// SpeechProvider handles speech-to-text (Whisper).
+// SpeechProvider handles speech-to-text (Whisper). format is the audio
+// container format (e.g. "webm", "m4a"); empty defaults to webm.
 type SpeechProvider interface {
-	TranscribeAudio(ctx context.Context, audioData []byte) (string, error)
+	TranscribeAudio(ctx context.Context, audioData []byte, format string) (string, error)
 }
 
 // EmbeddingProvider handles vector embeddings.

--- a/internal/ai/stream.go
+++ b/internal/ai/stream.go
@@ -28,6 +28,17 @@ type StreamEvent struct {
 	ErrorKind   string          `json:"error_kind,omitempty"`
 }
 
+// StreamingTextProvider is implemented by text providers that support
+// streaming recipe generation with incremental progress events. Providers
+// that do not implement it fall back to synchronous generation.
+type StreamingTextProvider interface {
+	TextProvider
+	StreamGenerateRecipe(ctx context.Context, req RecipeRequest, events chan<- StreamEvent) (*RecipeResult, error)
+}
+
+// Compile-time check that the Anthropic provider supports streaming.
+var _ StreamingTextProvider = (*AnthropicProvider)(nil)
+
 // TrySendEvent sends an event to the channel, returning false if the context
 // is cancelled (e.g. client disconnected). This prevents the producer goroutine
 // from blocking forever on a full or unconsumed channel.

--- a/internal/ai/stream_test.go
+++ b/internal/ai/stream_test.go
@@ -1,0 +1,108 @@
+package ai
+
+import (
+	"context"
+	"encoding/json"
+	"strings"
+	"testing"
+)
+
+// stubStreamingProvider compile-checks that any TextProvider plus a
+// StreamGenerateRecipe method satisfies StreamingTextProvider.
+type stubStreamingProvider struct {
+	TextProvider
+}
+
+func (s *stubStreamingProvider) StreamGenerateRecipe(ctx context.Context, req RecipeRequest, events chan<- StreamEvent) (*RecipeResult, error) {
+	return nil, nil
+}
+
+var _ StreamingTextProvider = (*stubStreamingProvider)(nil)
+
+func TestStreamEventTypes_WireValues(t *testing.T) {
+	// These string values are the SSE wire contract with the Flutter client;
+	// changing them silently breaks streaming on deployed apps.
+	tests := []struct {
+		event StreamEventType
+		want  string
+	}{
+		{StreamEventStarted, "recipe.started"},
+		{StreamEventGenerating, "recipe.generating"},
+		{StreamEventProgress, "recipe.progress"},
+		{StreamEventComplete, "recipe.complete"},
+		{StreamEventError, "recipe.error"},
+	}
+	for _, tc := range tests {
+		if string(tc.event) != tc.want {
+			t.Errorf("event type = %q, want %q", tc.event, tc.want)
+		}
+	}
+}
+
+func TestStreamEvent_JSONOmitsEmptyFields(t *testing.T) {
+	raw, err := json.Marshal(StreamEvent{Type: StreamEventGenerating})
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	got := string(raw)
+	if got != `{"type":"recipe.generating"}` {
+		t.Errorf("minimal event JSON = %s, want only the type field", got)
+	}
+
+	raw, err = json.Marshal(StreamEvent{Type: StreamEventError, Error: "boom", ErrorKind: "transient"})
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	got = string(raw)
+	for _, want := range []string{`"error":"boom"`, `"error_kind":"transient"`} {
+		if !strings.Contains(got, want) {
+			t.Errorf("error event JSON = %s, want %s", got, want)
+		}
+	}
+}
+
+func TestTrySendEvent_DeliversWhenChannelHasCapacity(t *testing.T) {
+	events := make(chan StreamEvent, 1)
+	ok := TrySendEvent(context.Background(), events, StreamEvent{Type: StreamEventProgress, TokensSoFar: 128})
+	if !ok {
+		t.Fatal("TrySendEvent returned false with channel capacity available")
+	}
+
+	got := <-events
+	if got.Type != StreamEventProgress {
+		t.Errorf("received type %q, want %q", got.Type, StreamEventProgress)
+	}
+	if got.TokensSoFar != 128 {
+		t.Errorf("received TokensSoFar = %d, want 128", got.TokensSoFar)
+	}
+}
+
+func TestTrySendEvent_ReturnsFalseWhenContextCancelled(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	// Unbuffered channel with no reader: without the ctx.Done() branch this
+	// would block forever.
+	events := make(chan StreamEvent)
+	ok := TrySendEvent(ctx, events, StreamEvent{Type: StreamEventProgress})
+	if ok {
+		t.Error("TrySendEvent returned true despite a cancelled context and no consumer")
+	}
+}
+
+func TestTrySendEvent_DeliversToWaitingConsumer(t *testing.T) {
+	events := make(chan StreamEvent)
+	received := make(chan StreamEvent, 1)
+	go func() {
+		received <- <-events
+	}()
+
+	ok := TrySendEvent(context.Background(), events, StreamEvent{Type: StreamEventComplete, RecipeID: 7})
+	if !ok {
+		t.Fatal("TrySendEvent returned false with an active consumer")
+	}
+	got := <-received
+	if got.Type != StreamEventComplete || got.RecipeID != 7 {
+		t.Errorf("consumer received %+v, want complete event for recipe 7", got)
+	}
+}

--- a/internal/ai/web_search.go
+++ b/internal/ai/web_search.go
@@ -99,15 +99,15 @@ type googleSearchResponse struct {
 }
 
 type googleSearchItem struct {
-	Title   string             `json:"title"`
-	Link    string             `json:"link"`
-	Snippet string             `json:"snippet"`
-	Pagemap *googlePagemap     `json:"pagemap"`
+	Title   string         `json:"title"`
+	Link    string         `json:"link"`
+	Snippet string         `json:"snippet"`
+	Pagemap *googlePagemap `json:"pagemap"`
 }
 
 type googlePagemap struct {
-	CSEThumbnail []googleThumbnail  `json:"cse_thumbnail"`
-	AggregateRating []googleRating  `json:"aggregaterating"`
+	CSEThumbnail    []googleThumbnail `json:"cse_thumbnail"`
+	AggregateRating []googleRating    `json:"aggregaterating"`
 }
 
 type googleThumbnail struct {

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -25,11 +25,18 @@ type EnvVars struct {
 	S3Bucket           string `env:"S3_BUCKET"`
 	IDHeader           string `env:"ID_HEADER"`
 	AnthropicAPIKey    string `env:"ANTHROPIC_API_KEY"`
-	OpenAIAPIKey       string `env:"OPENAI_API_KEY"`
-	GoogleSearchKey    string `env:"GOOGLE_SEARCH_KEY" optional:"true"`
-	GoogleSearchCX     string `env:"GOOGLE_SEARCH_CX" optional:"true"`
-	BraveSearchKey     string `env:"BRAVE_SEARCH_KEY" optional:"true"`
-	FirecrawlAPIKey    string `env:"FIRECRAWL_API_KEY" optional:"true"`
+	// AnthropicModel and AnthropicLightModel override the Claude model IDs
+	// used for full-quality and cheap preview/extraction tasks respectively.
+	AnthropicModel      string `env:"ANTHROPIC_MODEL" envDefault:"claude-sonnet-4-6" optional:"true"`
+	AnthropicLightModel string `env:"ANTHROPIC_LIGHT_MODEL" envDefault:"claude-haiku-4-5-20251001" optional:"true"`
+	OpenAIAPIKey        string `env:"OPENAI_API_KEY"`
+	// PromptsPath overrides the location of the prompts YAML file, which is
+	// cwd-relative by default and only resolves from the Docker workdir.
+	PromptsPath     string `env:"PROMPTS_PATH" envDefault:"configs/prompts.yaml" optional:"true"`
+	GoogleSearchKey string `env:"GOOGLE_SEARCH_KEY" optional:"true"`
+	GoogleSearchCX  string `env:"GOOGLE_SEARCH_CX" optional:"true"`
+	BraveSearchKey  string `env:"BRAVE_SEARCH_KEY" optional:"true"`
+	FirecrawlAPIKey string `env:"FIRECRAWL_API_KEY" optional:"true"`
 }
 
 // LoadConfig parses environment variables into the Config struct.

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -1,0 +1,89 @@
+package config
+
+import (
+	"os"
+	"testing"
+)
+
+// unsetenv removes an env var for the duration of the test, restoring it after.
+func unsetenv(t *testing.T, key string) {
+	t.Helper()
+	// t.Setenv registers the restore of the original value; Unsetenv then
+	// clears it so envDefault applies during the test.
+	t.Setenv(key, "")
+	os.Unsetenv(key)
+}
+
+func TestLoadConfig_AnthropicModelDefaults(t *testing.T) {
+	unsetenv(t, "ANTHROPIC_MODEL")
+	unsetenv(t, "ANTHROPIC_LIGHT_MODEL")
+
+	cfg, err := LoadConfig()
+	if err != nil {
+		t.Fatalf("LoadConfig() error = %v", err)
+	}
+
+	if got, want := cfg.EnvVars.AnthropicModel, "claude-sonnet-4-6"; got != want {
+		t.Errorf("AnthropicModel = %q, want %q", got, want)
+	}
+	if got, want := cfg.EnvVars.AnthropicLightModel, "claude-haiku-4-5-20251001"; got != want {
+		t.Errorf("AnthropicLightModel = %q, want %q", got, want)
+	}
+}
+
+func TestLoadConfig_AnthropicModelOverrides(t *testing.T) {
+	t.Setenv("ANTHROPIC_MODEL", "claude-opus-4-8")
+	t.Setenv("ANTHROPIC_LIGHT_MODEL", "claude-haiku-4-5")
+
+	cfg, err := LoadConfig()
+	if err != nil {
+		t.Fatalf("LoadConfig() error = %v", err)
+	}
+
+	if got, want := cfg.EnvVars.AnthropicModel, "claude-opus-4-8"; got != want {
+		t.Errorf("AnthropicModel = %q, want %q", got, want)
+	}
+	if got, want := cfg.EnvVars.AnthropicLightModel, "claude-haiku-4-5"; got != want {
+		t.Errorf("AnthropicLightModel = %q, want %q", got, want)
+	}
+}
+
+func TestLoadConfig_PromptsPathDefaultAndOverride(t *testing.T) {
+	unsetenv(t, "PROMPTS_PATH")
+
+	cfg, err := LoadConfig()
+	if err != nil {
+		t.Fatalf("LoadConfig() error = %v", err)
+	}
+	if got, want := cfg.EnvVars.PromptsPath, "configs/prompts.yaml"; got != want {
+		t.Errorf("PromptsPath default = %q, want %q", got, want)
+	}
+
+	t.Setenv("PROMPTS_PATH", "/etc/saltybytes/prompts.yaml")
+	cfg, err = LoadConfig()
+	if err != nil {
+		t.Fatalf("LoadConfig() error = %v", err)
+	}
+	if got, want := cfg.EnvVars.PromptsPath, "/etc/saltybytes/prompts.yaml"; got != want {
+		t.Errorf("PromptsPath override = %q, want %q", got, want)
+	}
+}
+
+func TestCheckConfigEnvFields_OptionalModelFieldsSkipped(t *testing.T) {
+	// A config with all required fields set must validate even when the
+	// optional model/prompt fields are zero.
+	cfg := &Config{EnvVars: EnvVars{
+		Port:            "8080",
+		DatabaseUrl:     "postgres://x",
+		JwtSecretKey:    "secret",
+		AWSRegion:       "us-east-2",
+		S3Bucket:        "bucket",
+		IDHeader:        "X-Id",
+		AnthropicAPIKey: "key",
+		OpenAIAPIKey:    "key",
+	}}
+
+	if err := cfg.CheckConfigEnvFields(); err != nil {
+		t.Errorf("CheckConfigEnvFields() error = %v, want nil", err)
+	}
+}

--- a/internal/db/db.go
+++ b/internal/db/db.go
@@ -38,11 +38,13 @@ func connectToDatabaseWithRetry(databaseURL string) (*gorm.DB, error) {
 	}
 
 	// Enable pgvector extension for embedding similarity search
-	database.Exec("CREATE EXTENSION IF NOT EXISTS vector")
+	if execErr := database.Exec("CREATE EXTENSION IF NOT EXISTS vector").Error; execErr != nil {
+		logger.Get().Warn("failed to create pgvector extension", zap.Error(execErr))
+	}
 
 	// AutoMigrate all models. RecipeTree.Nodes and RecipeNode.Children use gorm:"-"
 	// to avoid circular FK issues during migration.
-	database.AutoMigrate(
+	if migrateErr := database.AutoMigrate(
 		&models.User{},
 		&models.UserAuth{},
 		&models.Subscription{},
@@ -58,23 +60,47 @@ func connectToDatabaseWithRetry(databaseURL string) (*gorm.DB, error) {
 		&models.AllergenAnalysis{},
 		&models.SearchCache{},
 		&models.CanonicalRecipe{},
-	)
+	); migrateErr != nil {
+		return nil, fmt.Errorf("database auto-migration failed: %w", migrateErr)
+	}
 
 	// HNSW index for vector similarity on search cache embeddings
-	database.Exec(`CREATE INDEX IF NOT EXISTS idx_search_caches_embedding ON search_caches USING hnsw (embedding vector_cosine_ops)`)
+	if execErr := database.Exec(`CREATE INDEX IF NOT EXISTS idx_search_caches_embedding ON search_caches USING hnsw (embedding vector_cosine_ops)`).Error; execErr != nil {
+		logger.Get().Warn("failed to create idx_search_caches_embedding index", zap.Error(execErr))
+	}
 
 	// HNSW index for vector similarity on canonical recipe embeddings
-	database.Exec(`CREATE INDEX IF NOT EXISTS idx_canonical_recipes_embedding ON canonical_recipes USING hnsw (embedding vector_cosine_ops)`)
+	if execErr := database.Exec(`CREATE INDEX IF NOT EXISTS idx_canonical_recipes_embedding ON canonical_recipes USING hnsw (embedding vector_cosine_ops)`).Error; execErr != nil {
+		logger.Get().Warn("failed to create idx_canonical_recipes_embedding index", zap.Error(execErr))
+	}
+
+	// HNSW index for vector similarity on user recipe embeddings
+	if execErr := database.Exec(`CREATE INDEX IF NOT EXISTS idx_recipes_embedding ON recipes USING hnsw (embedding vector_cosine_ops)`).Error; execErr != nil {
+		logger.Get().Warn("failed to create idx_recipes_embedding index", zap.Error(execErr))
+	}
 
 	// Composite index for GetUserRecipes query (created_by_id, created_at DESC)
-	database.Exec(`CREATE INDEX IF NOT EXISTS idx_recipes_user_created ON recipes (created_by_id, created_at DESC)`)
+	if execErr := database.Exec(`CREATE INDEX IF NOT EXISTS idx_recipes_user_created ON recipes (created_by_id, created_at DESC)`).Error; execErr != nil {
+		logger.Get().Warn("failed to create idx_recipes_user_created index", zap.Error(execErr))
+	}
 
 	// Add the FK from recipe_nodes.tree_id → recipe_trees.id that gorm:"-" skipped.
-	database.Exec(`ALTER TABLE recipe_nodes ADD CONSTRAINT IF NOT EXISTS fk_recipe_nodes_tree
-		FOREIGN KEY (tree_id) REFERENCES recipe_trees(id)
-		ON UPDATE CASCADE ON DELETE CASCADE`)
+	// Postgres does not support ADD CONSTRAINT IF NOT EXISTS, so guard with a
+	// pg_constraint existence check.
+	if execErr := database.Exec(`DO $$
+	BEGIN
+		IF NOT EXISTS (
+			SELECT 1 FROM pg_constraint WHERE conname = 'fk_recipe_nodes_tree'
+		) THEN
+			ALTER TABLE recipe_nodes ADD CONSTRAINT fk_recipe_nodes_tree
+				FOREIGN KEY (tree_id) REFERENCES recipe_trees(id)
+				ON UPDATE CASCADE ON DELETE CASCADE;
+		END IF;
+	END $$`).Error; execErr != nil {
+		logger.Get().Warn("failed to add fk_recipe_nodes_tree constraint", zap.Error(execErr))
+	}
 
-	return database, err
+	return database, nil
 }
 
 // redactDSN parses a database connection string and masks the password.

--- a/internal/handlers/allergen.go
+++ b/internal/handlers/allergen.go
@@ -38,16 +38,29 @@ func (h *AllergenHandler) AnalyzeRecipe(c *gin.Context) {
 		return
 	}
 
-	// Check subscription tier for premium gating
+	// Check tier and usage limits through the subscription service so stale
+	// monthly counters get reset and nil-subscription users are gated with
+	// free-tier defaults.
 	isPremium := false
-	if user.Subscription != nil && user.Subscription.Tier == models.TierPremium {
-		isPremium = true
-	}
+	if h.Service.SubService != nil {
+		sub, err := h.Service.SubService.GetSubscription(user.ID)
+		if err != nil {
+			logger.Get().Error("failed to get subscription for allergen analysis", zap.Uint("user_id", user.ID), zap.Error(err))
+			c.JSON(http.StatusInternalServerError, gin.H{"error": "Failed to check subscription limits"})
+			return
+		}
+		isPremium = sub.Tier == models.TierPremium
 
-	// Check usage limits
-	if user.Subscription != nil && !user.Subscription.CanUseAllergenAnalysis() {
-		c.JSON(http.StatusForbidden, gin.H{"error": "allergen analysis limit reached; upgrade to premium for unlimited analyses"})
-		return
+		allowed, err := h.Service.SubService.CheckLimit(user.ID, "allergen")
+		if err != nil {
+			logger.Get().Error("failed to check allergen limit", zap.Uint("user_id", user.ID), zap.Error(err))
+			c.JSON(http.StatusInternalServerError, gin.H{"error": "Failed to check subscription limits"})
+			return
+		}
+		if !allowed {
+			c.JSON(http.StatusForbidden, gin.H{"error": "allergen analysis limit reached; upgrade to premium for unlimited analyses"})
+			return
+		}
 	}
 
 	// Verify recipe ownership
@@ -74,8 +87,10 @@ func (h *AllergenHandler) AnalyzeRecipe(c *gin.Context) {
 	}
 
 	// Increment usage counter after successful analysis
-	if err := h.Service.SubService.IncrementUsage(user.ID, "allergen"); err != nil {
-		logger.Get().Error("failed to increment allergen usage", zap.Uint("user_id", user.ID), zap.Error(err))
+	if h.Service.SubService != nil {
+		if err := h.Service.SubService.IncrementUsage(user.ID, "allergen"); err != nil {
+			logger.Get().Error("failed to increment allergen usage", zap.Uint("user_id", user.ID), zap.Error(err))
+		}
 	}
 
 	c.JSON(http.StatusOK, gin.H{"analysis": result})

--- a/internal/handlers/allergen.go
+++ b/internal/handlers/allergen.go
@@ -1,6 +1,7 @@
 package handlers
 
 import (
+	"errors"
 	"net/http"
 
 	"github.com/gin-gonic/gin"
@@ -77,10 +78,10 @@ func (h *AllergenHandler) AnalyzeRecipe(c *gin.Context) {
 	result, err := h.Service.AnalyzeRecipe(c.Request.Context(), recipeID, isPremium)
 	if err != nil {
 		logger.Get().Error("allergen analysis failed", zap.String("recipe_id", recipeIDStr), zap.Error(err))
-		switch err.(type) {
-		case repository.NotFoundError:
+		var notFound repository.NotFoundError
+		if errors.As(err, &notFound) {
 			c.JSON(http.StatusNotFound, gin.H{"error": err.Error()})
-		default:
+		} else {
 			c.JSON(http.StatusInternalServerError, gin.H{"error": "allergen analysis failed"})
 		}
 		return
@@ -126,10 +127,10 @@ func (h *AllergenHandler) GetAnalysis(c *gin.Context) {
 	result, err := h.Service.GetAnalysis(c.Request.Context(), recipeID)
 	if err != nil {
 		logger.Get().Error("failed to get allergen analysis", zap.String("recipe_id", recipeIDStr), zap.Error(err))
-		switch err.(type) {
-		case repository.NotFoundError:
+		var notFound repository.NotFoundError
+		if errors.As(err, &notFound) {
 			c.JSON(http.StatusNotFound, gin.H{"error": err.Error()})
-		default:
+		} else {
 			c.JSON(http.StatusInternalServerError, gin.H{"error": "failed to get allergen analysis"})
 		}
 		return
@@ -168,10 +169,10 @@ func (h *AllergenHandler) CheckFamily(c *gin.Context) {
 	result, err := h.Service.CheckFamily(c.Request.Context(), recipeID, user.ID)
 	if err != nil {
 		logger.Get().Error("family allergen check failed", zap.String("recipe_id", recipeIDStr), zap.Uint("user_id", user.ID), zap.Error(err))
-		switch err.(type) {
-		case repository.NotFoundError:
+		var notFound repository.NotFoundError
+		if errors.As(err, &notFound) {
 			c.JSON(http.StatusNotFound, gin.H{"error": err.Error()})
-		default:
+		} else {
 			c.JSON(http.StatusInternalServerError, gin.H{"error": "family allergen check failed"})
 		}
 		return

--- a/internal/handlers/allergen_handler_test.go
+++ b/internal/handlers/allergen_handler_test.go
@@ -1,0 +1,419 @@
+package handlers
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/gin-gonic/gin"
+	"github.com/windoze95/saltybytes-api/internal/ai"
+	"github.com/windoze95/saltybytes-api/internal/config"
+	"github.com/windoze95/saltybytes-api/internal/models"
+	"github.com/windoze95/saltybytes-api/internal/service"
+	"github.com/windoze95/saltybytes-api/internal/testutil"
+	"gorm.io/gorm"
+)
+
+// freeSubscription returns a fresh free-tier subscription with the given
+// allergen usage and a reset date in the future.
+func freeSubscription(userID uint, allergenUsed int) *models.Subscription {
+	return &models.Subscription{
+		Model:                gorm.Model{ID: 1},
+		UserID:               userID,
+		Tier:                 models.TierFree,
+		AllergenAnalysesUsed: allergenUsed,
+		MonthlyResetAt:       time.Now().Add(time.Hour),
+	}
+}
+
+// newAllergenHandlerFixture wires an AllergenHandler whose recipe repo holds
+// the standard test recipe (owned by user 1) and whose subscription service is
+// backed by the given user repo.
+func newAllergenHandlerFixture(allergenRepo *testutil.MockAllergenRepo, provider ai.TextProvider, userRepo *testutil.MockUserRepo) (*AllergenHandler, *testutil.MockRecipeRepo) {
+	recipeRepo := testutil.NewMockRecipeRepo()
+	recipe := testutil.TestRecipe()
+	recipeRepo.Recipes[recipe.ID] = recipe
+
+	subService := service.NewSubscriptionService(&config.Config{}, userRepo)
+	svc := service.NewAllergenService(&config.Config{}, allergenRepo, &testutil.MockFamilyRepo{}, recipeRepo, provider, subService)
+	return NewAllergenHandler(svc), recipeRepo
+}
+
+func allergenAIProvider() *testutil.MockTextProvider {
+	return &testutil.MockTextProvider{
+		AnalyzeAllergensFunc: func(ctx context.Context, req ai.AllergenRequest) (*ai.AllergenResult, error) {
+			return &ai.AllergenResult{
+				IngredientAnalyses: []ai.IngredientAnalysisResult{
+					{IngredientName: "Milk", CommonAllergens: []string{"dairy"}, Confidence: 0.99},
+				},
+				Confidence: 0.95,
+			}, nil
+		},
+	}
+}
+
+func TestAnalyzeRecipe_Handler_EnvelopeSnakeCase(t *testing.T) {
+	user := testutil.TestUser()
+	user.Subscription = freeSubscription(user.ID, 0)
+	userRepo := testutil.NewMockUserRepo()
+	userRepo.Users[user.ID] = user
+
+	handler, _ := newAllergenHandlerFixture(&testutil.MockAllergenRepo{}, allergenAIProvider(), userRepo)
+
+	r := gin.New()
+	r.POST("/recipes/:recipe_id/allergens/analyze", setUser(user), handler.AnalyzeRecipe)
+
+	req := httptest.NewRequest("POST", "/recipes/1/allergens/analyze", nil)
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("status = %d, want %d. body: %s", w.Code, http.StatusOK, w.Body.String())
+	}
+
+	var resp map[string]json.RawMessage
+	if err := json.Unmarshal(w.Body.Bytes(), &resp); err != nil {
+		t.Fatalf("failed to parse response: %v", err)
+	}
+	analysisRaw, ok := resp["analysis"]
+	if !ok {
+		t.Fatalf("response missing 'analysis' envelope key. body: %s", w.Body.String())
+	}
+
+	var analysis map[string]interface{}
+	if err := json.Unmarshal(analysisRaw, &analysis); err != nil {
+		t.Fatalf("failed to parse analysis: %v", err)
+	}
+	// snake_case contract keys.
+	if analysis["contains_dairy"] != true {
+		t.Errorf("analysis.contains_dairy = %v, want true", analysis["contains_dairy"])
+	}
+	if analysis["prompt_version"] != "v1" {
+		t.Errorf("analysis.prompt_version = %v, want 'v1'", analysis["prompt_version"])
+	}
+	if analysis["is_premium"] != false {
+		t.Errorf("analysis.is_premium = %v, want false", analysis["is_premium"])
+	}
+	if _, ok := analysis["ingredient_analyses"]; !ok {
+		t.Error("analysis missing 'ingredient_analyses' key")
+	}
+	disclaimer, _ := analysis["disclaimer"].(string)
+	if disclaimer == "" {
+		t.Error("analysis.disclaimer should be a non-empty string")
+	}
+
+	// Successful analysis increments the allergen usage counter.
+	if got := userRepo.Users[user.ID].Subscription.AllergenAnalysesUsed; got != 1 {
+		t.Errorf("AllergenAnalysesUsed = %d, want 1 after successful analysis", got)
+	}
+}
+
+func TestAnalyzeRecipe_Handler_NotOwner_403(t *testing.T) {
+	user := testutil.TestUser()
+	user.ID = 2 // test recipe is owned by user 1
+	user.Subscription = freeSubscription(user.ID, 0)
+	userRepo := testutil.NewMockUserRepo()
+	userRepo.Users[user.ID] = user
+
+	handler, _ := newAllergenHandlerFixture(&testutil.MockAllergenRepo{}, allergenAIProvider(), userRepo)
+
+	r := gin.New()
+	r.POST("/recipes/:recipe_id/allergens/analyze", setUser(user), handler.AnalyzeRecipe)
+
+	req := httptest.NewRequest("POST", "/recipes/1/allergens/analyze", nil)
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, req)
+
+	if w.Code != http.StatusForbidden {
+		t.Errorf("status = %d, want %d. body: %s", w.Code, http.StatusForbidden, w.Body.String())
+	}
+}
+
+func TestAnalyzeRecipe_Handler_FreeUserAtLimit_403(t *testing.T) {
+	user := testutil.TestUser()
+	user.Subscription = freeSubscription(user.ID, 5) // free-tier allergen limit
+	userRepo := testutil.NewMockUserRepo()
+	userRepo.Users[user.ID] = user
+
+	aiCalled := false
+	provider := &testutil.MockTextProvider{
+		AnalyzeAllergensFunc: func(ctx context.Context, req ai.AllergenRequest) (*ai.AllergenResult, error) {
+			aiCalled = true
+			return &ai.AllergenResult{}, nil
+		},
+	}
+	handler, _ := newAllergenHandlerFixture(&testutil.MockAllergenRepo{}, provider, userRepo)
+
+	r := gin.New()
+	r.POST("/recipes/:recipe_id/allergens/analyze", setUser(user), handler.AnalyzeRecipe)
+
+	req := httptest.NewRequest("POST", "/recipes/1/allergens/analyze", nil)
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, req)
+
+	if w.Code != http.StatusForbidden {
+		t.Errorf("status = %d, want %d. body: %s", w.Code, http.StatusForbidden, w.Body.String())
+	}
+	if aiCalled {
+		t.Error("AI provider must not be called when the user is over their allergen limit")
+	}
+	if got := userRepo.Users[user.ID].Subscription.AllergenAnalysesUsed; got != 5 {
+		t.Errorf("AllergenAnalysesUsed = %d, want unchanged 5", got)
+	}
+}
+
+func TestAnalyzeRecipe_Handler_PremiumBypassesLimit(t *testing.T) {
+	user := testutil.TestUser()
+	user.Subscription = &models.Subscription{
+		Model:                gorm.Model{ID: 1},
+		UserID:               user.ID,
+		Tier:                 models.TierPremium,
+		AllergenAnalysesUsed: 100,
+		MonthlyResetAt:       time.Now().Add(time.Hour),
+	}
+	userRepo := testutil.NewMockUserRepo()
+	userRepo.Users[user.ID] = user
+
+	var gotPremium bool
+	provider := &testutil.MockTextProvider{
+		AnalyzeAllergensFunc: func(ctx context.Context, req ai.AllergenRequest) (*ai.AllergenResult, error) {
+			gotPremium = req.IsPremium
+			return &ai.AllergenResult{Confidence: 0.9}, nil
+		},
+	}
+	handler, _ := newAllergenHandlerFixture(&testutil.MockAllergenRepo{}, provider, userRepo)
+
+	r := gin.New()
+	r.POST("/recipes/:recipe_id/allergens/analyze", setUser(user), handler.AnalyzeRecipe)
+
+	req := httptest.NewRequest("POST", "/recipes/1/allergens/analyze", nil)
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("status = %d, want %d. body: %s", w.Code, http.StatusOK, w.Body.String())
+	}
+	if !gotPremium {
+		t.Error("premium tier must be forwarded as IsPremium=true to the AI request")
+	}
+}
+
+func TestAnalyzeRecipe_Handler_InvalidRecipeID_400(t *testing.T) {
+	user := testutil.TestUser()
+	user.Subscription = freeSubscription(user.ID, 0)
+	userRepo := testutil.NewMockUserRepo()
+	userRepo.Users[user.ID] = user
+
+	handler, _ := newAllergenHandlerFixture(&testutil.MockAllergenRepo{}, allergenAIProvider(), userRepo)
+
+	r := gin.New()
+	r.POST("/recipes/:recipe_id/allergens/analyze", setUser(user), handler.AnalyzeRecipe)
+
+	req := httptest.NewRequest("POST", "/recipes/abc/allergens/analyze", nil)
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, req)
+
+	if w.Code != http.StatusBadRequest {
+		t.Errorf("status = %d, want %d", w.Code, http.StatusBadRequest)
+	}
+}
+
+func TestAnalyzeRecipe_Handler_RecipeNotFound_404(t *testing.T) {
+	user := testutil.TestUser()
+	user.Subscription = freeSubscription(user.ID, 0)
+	userRepo := testutil.NewMockUserRepo()
+	userRepo.Users[user.ID] = user
+
+	handler, _ := newAllergenHandlerFixture(&testutil.MockAllergenRepo{}, allergenAIProvider(), userRepo)
+
+	r := gin.New()
+	r.POST("/recipes/:recipe_id/allergens/analyze", setUser(user), handler.AnalyzeRecipe)
+
+	req := httptest.NewRequest("POST", "/recipes/999/allergens/analyze", nil)
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, req)
+
+	if w.Code != http.StatusNotFound {
+		t.Errorf("status = %d, want %d. body: %s", w.Code, http.StatusNotFound, w.Body.String())
+	}
+}
+
+// --- GetAnalysis handler ---
+
+func TestGetAnalysis_Handler_Envelope(t *testing.T) {
+	user := testutil.TestUser()
+	userRepo := testutil.NewMockUserRepo()
+	userRepo.Users[user.ID] = user
+
+	allergenRepo := &testutil.MockAllergenRepo{
+		GetAnalysisByRecipeIDFunc: func(recipeID uint) (*models.AllergenAnalysis, error) {
+			return &models.AllergenAnalysis{ID: 3, RecipeID: recipeID, ContainsNuts: true, PromptVersion: "v1"}, nil
+		},
+	}
+	handler, _ := newAllergenHandlerFixture(allergenRepo, &testutil.MockTextProvider{}, userRepo)
+
+	r := gin.New()
+	r.GET("/recipes/:recipe_id/allergens", setUser(user), handler.GetAnalysis)
+
+	req := httptest.NewRequest("GET", "/recipes/1/allergens", nil)
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("status = %d, want %d. body: %s", w.Code, http.StatusOK, w.Body.String())
+	}
+	var resp map[string]map[string]interface{}
+	if err := json.Unmarshal(w.Body.Bytes(), &resp); err != nil {
+		t.Fatalf("failed to parse response: %v", err)
+	}
+	analysis, ok := resp["analysis"]
+	if !ok {
+		t.Fatalf("response missing 'analysis' envelope key. body: %s", w.Body.String())
+	}
+	if analysis["contains_nuts"] != true {
+		t.Errorf("analysis.contains_nuts = %v, want true", analysis["contains_nuts"])
+	}
+}
+
+func TestGetAnalysis_Handler_NotFound_404(t *testing.T) {
+	user := testutil.TestUser()
+	userRepo := testutil.NewMockUserRepo()
+	userRepo.Users[user.ID] = user
+
+	handler, _ := newAllergenHandlerFixture(&testutil.MockAllergenRepo{}, &testutil.MockTextProvider{}, userRepo)
+
+	r := gin.New()
+	r.GET("/recipes/:recipe_id/allergens", setUser(user), handler.GetAnalysis)
+
+	req := httptest.NewRequest("GET", "/recipes/1/allergens", nil)
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, req)
+
+	if w.Code != http.StatusNotFound {
+		t.Errorf("status = %d, want %d. body: %s", w.Code, http.StatusNotFound, w.Body.String())
+	}
+}
+
+func TestGetAnalysis_Handler_NotOwner_403(t *testing.T) {
+	user := testutil.TestUser()
+	user.ID = 2
+	userRepo := testutil.NewMockUserRepo()
+	userRepo.Users[user.ID] = user
+
+	handler, _ := newAllergenHandlerFixture(&testutil.MockAllergenRepo{}, &testutil.MockTextProvider{}, userRepo)
+
+	r := gin.New()
+	r.GET("/recipes/:recipe_id/allergens", setUser(user), handler.GetAnalysis)
+
+	req := httptest.NewRequest("GET", "/recipes/1/allergens", nil)
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, req)
+
+	if w.Code != http.StatusForbidden {
+		t.Errorf("status = %d, want %d", w.Code, http.StatusForbidden)
+	}
+}
+
+// --- CheckFamily handler ---
+
+func TestCheckFamily_Handler_Envelope(t *testing.T) {
+	user := testutil.TestUser()
+	userRepo := testutil.NewMockUserRepo()
+	userRepo.Users[user.ID] = user
+
+	recipeRepo := testutil.NewMockRecipeRepo()
+	recipe := testutil.TestRecipe()
+	recipeRepo.Recipes[recipe.ID] = recipe
+
+	allergenRepo := &testutil.MockAllergenRepo{
+		GetAnalysisByRecipeIDFunc: func(recipeID uint) (*models.AllergenAnalysis, error) {
+			return &models.AllergenAnalysis{
+				ID:       1,
+				RecipeID: recipeID,
+				IngredientAnalyses: models.IngredientAnalysisList{
+					{IngredientName: "Peanut butter", CommonAllergens: []string{"peanuts"}},
+				},
+			}, nil
+		},
+	}
+	familyRepo := &testutil.MockFamilyRepo{
+		GetFamilyByOwnerIDFunc: func(ownerID uint) (*models.Family, error) {
+			return &models.Family{ID: 7, OwnerID: ownerID, Members: []models.FamilyMember{
+				{ID: 5, FamilyID: 7, Name: "Joey", DietaryProfile: &models.DietaryProfile{
+					Allergies: models.AllergyList{{Name: "peanuts"}},
+				}},
+			}}, nil
+		},
+	}
+	subService := service.NewSubscriptionService(&config.Config{}, userRepo)
+	svc := service.NewAllergenService(&config.Config{}, allergenRepo, familyRepo, recipeRepo, &testutil.MockTextProvider{}, subService)
+	handler := NewAllergenHandler(svc)
+
+	r := gin.New()
+	r.POST("/recipes/:recipe_id/allergens/check-family", setUser(user), handler.CheckFamily)
+
+	req := httptest.NewRequest("POST", "/recipes/1/allergens/check-family", nil)
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("status = %d, want %d. body: %s", w.Code, http.StatusOK, w.Body.String())
+	}
+
+	var resp map[string]json.RawMessage
+	if err := json.Unmarshal(w.Body.Bytes(), &resp); err != nil {
+		t.Fatalf("failed to parse response: %v", err)
+	}
+	checkRaw, ok := resp["family_check"]
+	if !ok {
+		t.Fatalf("response missing 'family_check' envelope key. body: %s", w.Body.String())
+	}
+
+	var check map[string]interface{}
+	if err := json.Unmarshal(checkRaw, &check); err != nil {
+		t.Fatalf("failed to parse family_check: %v", err)
+	}
+	if check["recipe_id"] != float64(1) {
+		t.Errorf("family_check.recipe_id = %v, want 1", check["recipe_id"])
+	}
+	results, ok := check["member_results"].([]interface{})
+	if !ok || len(results) != 1 {
+		t.Fatalf("family_check.member_results = %v, want array of 1", check["member_results"])
+	}
+	mr, _ := results[0].(map[string]interface{})
+	if mr["member_id"] != float64(5) || mr["member_name"] != "Joey" {
+		t.Errorf("member_results[0] identity = %v/%v, want 5/Joey", mr["member_id"], mr["member_name"])
+	}
+	if mr["status"] != "unsafe" {
+		t.Errorf("member_results[0].status = %v, want 'unsafe'", mr["status"])
+	}
+	if _, ok := mr["warnings"]; !ok {
+		t.Error("member_results[0] missing 'warnings' key")
+	}
+	if disclaimer, _ := check["disclaimer"].(string); disclaimer == "" {
+		t.Error("family_check.disclaimer should be a non-empty string")
+	}
+}
+
+func TestCheckFamily_Handler_NotOwner_403(t *testing.T) {
+	user := testutil.TestUser()
+	user.ID = 2
+	userRepo := testutil.NewMockUserRepo()
+	userRepo.Users[user.ID] = user
+
+	handler, _ := newAllergenHandlerFixture(&testutil.MockAllergenRepo{}, &testutil.MockTextProvider{}, userRepo)
+
+	r := gin.New()
+	r.POST("/recipes/:recipe_id/allergens/check-family", setUser(user), handler.CheckFamily)
+
+	req := httptest.NewRequest("POST", "/recipes/1/allergens/check-family", nil)
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, req)
+
+	if w.Code != http.StatusForbidden {
+		t.Errorf("status = %d, want %d", w.Code, http.StatusForbidden)
+	}
+}

--- a/internal/handlers/family.go
+++ b/internal/handlers/family.go
@@ -234,12 +234,17 @@ func (h *FamilyHandler) DietaryInterview(c *gin.Context) {
 		return
 	}
 
-	response, err := h.Service.DietaryInterview(c.Request.Context(), uint(memberID), req.Messages)
+	response, complete, profile, err := h.Service.DietaryInterview(c.Request.Context(), uint(memberID), req.Messages)
 	if err != nil {
 		logger.Get().Error("dietary interview failed", zap.Uint("member_id", uint(memberID)), zap.Error(err))
 		c.JSON(http.StatusInternalServerError, gin.H{"error": "dietary interview failed"})
 		return
 	}
 
-	c.JSON(http.StatusOK, gin.H{"response": response})
+	// profile is nil (serialized as JSON null) unless complete is true.
+	c.JSON(http.StatusOK, gin.H{
+		"response": response,
+		"complete": complete,
+		"profile":  profile,
+	})
 }

--- a/internal/handlers/family_crud_handler_test.go
+++ b/internal/handlers/family_crud_handler_test.go
@@ -1,0 +1,347 @@
+package handlers
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/gin-gonic/gin"
+	"github.com/windoze95/saltybytes-api/internal/config"
+	"github.com/windoze95/saltybytes-api/internal/models"
+	"github.com/windoze95/saltybytes-api/internal/service"
+	"github.com/windoze95/saltybytes-api/internal/testutil"
+	"gorm.io/gorm"
+)
+
+// newFamilyCrudRouter wires the full family route set against the given repo
+// with an authenticated test user.
+func newFamilyCrudRouter(repo *testutil.MockFamilyRepo) (*gin.Engine, *models.User) {
+	user := testutil.TestUser()
+	svc := service.NewFamilyService(&config.Config{}, repo, &testutil.MockTextProvider{})
+	handler := NewFamilyHandler(svc)
+
+	r := gin.New()
+	r.POST("/family", setUser(user), handler.CreateFamily)
+	r.GET("/family", setUser(user), handler.GetFamily)
+	r.POST("/family/members", setUser(user), handler.AddMember)
+	r.PUT("/family/members/:member_id", setUser(user), handler.UpdateMember)
+	r.PUT("/family/members/:member_id/dietary", setUser(user), handler.UpdateDietaryProfile)
+	return r, user
+}
+
+func doJSON(r *gin.Engine, method, path, body string) *httptest.ResponseRecorder {
+	var req *http.Request
+	if body == "" {
+		req = httptest.NewRequest(method, path, nil)
+	} else {
+		req = httptest.NewRequest(method, path, strings.NewReader(body))
+		req.Header.Set("Content-Type", "application/json")
+	}
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, req)
+	return w
+}
+
+// --- CreateFamily ---
+
+func TestCreateFamily_Handler_Envelope(t *testing.T) {
+	repo := &testutil.MockFamilyRepo{
+		CreateFamilyFunc: func(family *models.Family) error {
+			family.ID = 7
+			return nil
+		},
+	}
+	r, user := newFamilyCrudRouter(repo)
+
+	w := doJSON(r, "POST", "/family", `{"name": "The Does"}`)
+	if w.Code != http.StatusCreated {
+		t.Fatalf("status = %d, want %d. body: %s", w.Code, http.StatusCreated, w.Body.String())
+	}
+
+	var resp map[string]map[string]interface{}
+	if err := json.Unmarshal(w.Body.Bytes(), &resp); err != nil {
+		t.Fatalf("failed to parse response: %v", err)
+	}
+	family, ok := resp["family"]
+	if !ok {
+		t.Fatalf("response missing 'family' envelope key. body: %s", w.Body.String())
+	}
+	if family["name"] != "The Does" {
+		t.Errorf("family.name = %v, want 'The Does'", family["name"])
+	}
+	// snake_case contract key for the owner.
+	if family["owner_id"] != float64(user.ID) {
+		t.Errorf("family.owner_id = %v, want %d", family["owner_id"], user.ID)
+	}
+}
+
+func TestCreateFamily_Handler_MissingName_400(t *testing.T) {
+	r, _ := newFamilyCrudRouter(&testutil.MockFamilyRepo{})
+
+	w := doJSON(r, "POST", "/family", `{}`)
+	if w.Code != http.StatusBadRequest {
+		t.Errorf("status = %d, want %d", w.Code, http.StatusBadRequest)
+	}
+}
+
+// --- GetFamily ---
+
+func TestGetFamily_Handler_NullWhenNotFound(t *testing.T) {
+	repo := &testutil.MockFamilyRepo{
+		GetFamilyByOwnerIDFunc: func(ownerID uint) (*models.Family, error) {
+			return nil, gorm.ErrRecordNotFound
+		},
+	}
+	r, _ := newFamilyCrudRouter(repo)
+
+	w := doJSON(r, "GET", "/family", "")
+	if w.Code != http.StatusOK {
+		t.Fatalf("status = %d, want %d (no family is not an error). body: %s", w.Code, http.StatusOK, w.Body.String())
+	}
+
+	var resp map[string]json.RawMessage
+	if err := json.Unmarshal(w.Body.Bytes(), &resp); err != nil {
+		t.Fatalf("failed to parse response: %v", err)
+	}
+	if familyRaw, ok := resp["family"]; !ok || string(familyRaw) != "null" {
+		t.Errorf("family = %s, want JSON null", string(familyRaw))
+	}
+}
+
+func TestGetFamily_Handler_Envelope(t *testing.T) {
+	repo := &testutil.MockFamilyRepo{
+		GetFamilyByOwnerIDFunc: func(ownerID uint) (*models.Family, error) {
+			return &models.Family{ID: 7, OwnerID: ownerID, Name: "The Does", Members: []models.FamilyMember{
+				{ID: 5, FamilyID: 7, Name: "Joey"},
+			}}, nil
+		},
+	}
+	r, _ := newFamilyCrudRouter(repo)
+
+	w := doJSON(r, "GET", "/family", "")
+	if w.Code != http.StatusOK {
+		t.Fatalf("status = %d, want %d. body: %s", w.Code, http.StatusOK, w.Body.String())
+	}
+
+	var resp map[string]map[string]interface{}
+	if err := json.Unmarshal(w.Body.Bytes(), &resp); err != nil {
+		t.Fatalf("failed to parse response: %v", err)
+	}
+	family := resp["family"]
+	members, ok := family["members"].([]interface{})
+	if !ok || len(members) != 1 {
+		t.Fatalf("family.members = %v, want array of 1", family["members"])
+	}
+	member, _ := members[0].(map[string]interface{})
+	if member["family_id"] != float64(7) {
+		t.Errorf("member.family_id = %v, want 7 (snake_case)", member["family_id"])
+	}
+}
+
+// --- AddMember ---
+
+func TestAddMember_Handler_Envelope(t *testing.T) {
+	var created *models.FamilyMember
+	repo := &testutil.MockFamilyRepo{
+		GetFamilyByOwnerIDFunc: func(ownerID uint) (*models.Family, error) {
+			return &models.Family{ID: 7, OwnerID: ownerID}, nil
+		},
+		CreateFamilyMemberFunc: func(member *models.FamilyMember) error {
+			member.ID = 5
+			created = member
+			return nil
+		},
+	}
+	r, _ := newFamilyCrudRouter(repo)
+
+	w := doJSON(r, "POST", "/family/members", `{"name": "Joey", "relationship": "son", "user_id": 33}`)
+	if w.Code != http.StatusCreated {
+		t.Fatalf("status = %d, want %d. body: %s", w.Code, http.StatusCreated, w.Body.String())
+	}
+	if created == nil {
+		t.Fatal("member was not created")
+	}
+	if created.FamilyID != 7 {
+		t.Errorf("created.FamilyID = %d, want owner's family 7", created.FamilyID)
+	}
+	if created.UserID == nil || *created.UserID != 33 {
+		t.Errorf("created.UserID = %v, want 33 (snake_case user_id binding)", created.UserID)
+	}
+
+	var resp map[string]map[string]interface{}
+	if err := json.Unmarshal(w.Body.Bytes(), &resp); err != nil {
+		t.Fatalf("failed to parse response: %v", err)
+	}
+	member, ok := resp["member"]
+	if !ok {
+		t.Fatalf("response missing 'member' envelope key. body: %s", w.Body.String())
+	}
+	if member["name"] != "Joey" || member["relationship"] != "son" {
+		t.Errorf("member = %v, want Joey/son", member)
+	}
+}
+
+func TestAddMember_Handler_MissingName_400(t *testing.T) {
+	r, _ := newFamilyCrudRouter(&testutil.MockFamilyRepo{})
+
+	w := doJSON(r, "POST", "/family/members", `{"relationship": "son"}`)
+	if w.Code != http.StatusBadRequest {
+		t.Errorf("status = %d, want %d", w.Code, http.StatusBadRequest)
+	}
+}
+
+func TestAddMember_Handler_NoFamily_404(t *testing.T) {
+	repo := &testutil.MockFamilyRepo{
+		GetFamilyByOwnerIDFunc: func(ownerID uint) (*models.Family, error) {
+			return nil, gorm.ErrRecordNotFound
+		},
+	}
+	r, _ := newFamilyCrudRouter(repo)
+
+	w := doJSON(r, "POST", "/family/members", `{"name": "Joey"}`)
+	if w.Code != http.StatusNotFound {
+		t.Errorf("status = %d, want %d", w.Code, http.StatusNotFound)
+	}
+}
+
+// --- UpdateMember ---
+
+func TestUpdateMember_Handler_Envelope(t *testing.T) {
+	repo := &testutil.MockFamilyRepo{
+		GetFamilyMemberByIDFunc: func(id uint) (*models.FamilyMember, error) {
+			return &models.FamilyMember{ID: id, FamilyID: 7, Name: "Old"}, nil
+		},
+		GetFamilyByOwnerIDFunc: func(ownerID uint) (*models.Family, error) {
+			return &models.Family{ID: 7, OwnerID: ownerID}, nil
+		},
+	}
+	r, _ := newFamilyCrudRouter(repo)
+
+	w := doJSON(r, "PUT", "/family/members/5", `{"name": "New", "relationship": "daughter"}`)
+	if w.Code != http.StatusOK {
+		t.Fatalf("status = %d, want %d. body: %s", w.Code, http.StatusOK, w.Body.String())
+	}
+
+	var resp map[string]map[string]interface{}
+	if err := json.Unmarshal(w.Body.Bytes(), &resp); err != nil {
+		t.Fatalf("failed to parse response: %v", err)
+	}
+	member, ok := resp["member"]
+	if !ok {
+		t.Fatalf("response missing 'member' envelope key. body: %s", w.Body.String())
+	}
+	if member["name"] != "New" || member["relationship"] != "daughter" {
+		t.Errorf("member = %v, want New/daughter", member)
+	}
+}
+
+func TestUpdateMember_Handler_NotOwner_403(t *testing.T) {
+	repo := &testutil.MockFamilyRepo{
+		GetFamilyMemberByIDFunc: func(id uint) (*models.FamilyMember, error) {
+			return &models.FamilyMember{ID: id, FamilyID: 99}, nil
+		},
+		GetFamilyByOwnerIDFunc: func(ownerID uint) (*models.Family, error) {
+			return &models.Family{ID: 7, OwnerID: ownerID}, nil
+		},
+	}
+	r, _ := newFamilyCrudRouter(repo)
+
+	w := doJSON(r, "PUT", "/family/members/5", `{"name": "New"}`)
+	if w.Code != http.StatusForbidden {
+		t.Errorf("status = %d, want %d", w.Code, http.StatusForbidden)
+	}
+}
+
+// --- UpdateDietaryProfile ---
+
+func TestUpdateDietaryProfile_Handler_SnakeCaseBinding(t *testing.T) {
+	var saved *models.DietaryProfile
+	repo := &testutil.MockFamilyRepo{
+		GetFamilyMemberByIDFunc: func(id uint) (*models.FamilyMember, error) {
+			return &models.FamilyMember{ID: id, FamilyID: 7}, nil
+		},
+		GetFamilyByOwnerIDFunc: func(ownerID uint) (*models.Family, error) {
+			return &models.Family{ID: 7, OwnerID: ownerID}, nil
+		},
+		GetOrCreateDietaryProfileFunc: func(memberID uint) (*models.DietaryProfile, error) {
+			return &models.DietaryProfile{ID: 3, MemberID: memberID}, nil
+		},
+		UpdateDietaryProfileFunc: func(profile *models.DietaryProfile) error {
+			saved = profile
+			return nil
+		},
+	}
+	r, _ := newFamilyCrudRouter(repo)
+
+	body := `{
+		"allergies": [{"name": "peanuts", "severity": "severe", "sub_forms": ["peanut butter", "peanut oil"], "notes": "EpiPen"}],
+		"intolerances": ["lactose"],
+		"restrictions": ["halal"],
+		"preferences": ["spicy"],
+		"medical_notes": "type 1 diabetes"
+	}`
+	w := doJSON(r, "PUT", "/family/members/5/dietary", body)
+	if w.Code != http.StatusOK {
+		t.Fatalf("status = %d, want %d. body: %s", w.Code, http.StatusOK, w.Body.String())
+	}
+
+	var resp map[string]interface{}
+	if err := json.Unmarshal(w.Body.Bytes(), &resp); err != nil {
+		t.Fatalf("failed to parse response: %v", err)
+	}
+	if resp["message"] == nil {
+		t.Error("response should contain 'message'")
+	}
+
+	if saved == nil {
+		t.Fatal("dietary profile was not persisted")
+	}
+	// snake_case body keys must bind into the model.
+	if saved.MedicalNotes != "type 1 diabetes" {
+		t.Errorf("MedicalNotes = %q, want 'type 1 diabetes' (medical_notes binding)", saved.MedicalNotes)
+	}
+	if len(saved.Allergies) != 1 {
+		t.Fatalf("len(Allergies) = %d, want 1", len(saved.Allergies))
+	}
+	a := saved.Allergies[0]
+	if a.Name != "peanuts" || a.Severity != "severe" || a.Notes != "EpiPen" {
+		t.Errorf("Allergies[0] = %+v, want peanuts/severe/EpiPen", a)
+	}
+	if len(a.SubForms) != 2 || a.SubForms[0] != "peanut butter" || a.SubForms[1] != "peanut oil" {
+		t.Errorf("Allergies[0].SubForms = %v, want sub_forms binding", a.SubForms)
+	}
+	if len(saved.Intolerances) != 1 || saved.Intolerances[0] != "lactose" {
+		t.Errorf("Intolerances = %v, want [lactose]", saved.Intolerances)
+	}
+	if len(saved.Restrictions) != 1 || len(saved.Preferences) != 1 {
+		t.Errorf("Restrictions/Preferences = %v/%v, want both bound", saved.Restrictions, saved.Preferences)
+	}
+}
+
+func TestUpdateDietaryProfile_Handler_NotOwner_403(t *testing.T) {
+	repo := &testutil.MockFamilyRepo{
+		GetFamilyMemberByIDFunc: func(id uint) (*models.FamilyMember, error) {
+			return &models.FamilyMember{ID: id, FamilyID: 99}, nil
+		},
+		GetFamilyByOwnerIDFunc: func(ownerID uint) (*models.Family, error) {
+			return &models.Family{ID: 7, OwnerID: ownerID}, nil
+		},
+	}
+	r, _ := newFamilyCrudRouter(repo)
+
+	w := doJSON(r, "PUT", "/family/members/5/dietary", `{"medical_notes": "x"}`)
+	if w.Code != http.StatusForbidden {
+		t.Errorf("status = %d, want %d", w.Code, http.StatusForbidden)
+	}
+}
+
+func TestUpdateDietaryProfile_Handler_InvalidMemberID_400(t *testing.T) {
+	r, _ := newFamilyCrudRouter(&testutil.MockFamilyRepo{})
+
+	w := doJSON(r, "PUT", "/family/members/abc/dietary", `{}`)
+	if w.Code != http.StatusBadRequest {
+		t.Errorf("status = %d, want %d", w.Code, http.StatusBadRequest)
+	}
+}

--- a/internal/handlers/family_handler_test.go
+++ b/internal/handlers/family_handler_test.go
@@ -1,0 +1,193 @@
+package handlers
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/gin-gonic/gin"
+	"github.com/windoze95/saltybytes-api/internal/ai"
+	"github.com/windoze95/saltybytes-api/internal/config"
+	"github.com/windoze95/saltybytes-api/internal/models"
+	"github.com/windoze95/saltybytes-api/internal/service"
+	"github.com/windoze95/saltybytes-api/internal/testutil"
+)
+
+// newDietaryInterviewRouter builds a router for the dietary interview
+// endpoint with an authenticated user that owns family 7, which member 5
+// belongs to.
+func newDietaryInterviewRouter(provider *testutil.MockTextProvider) *gin.Engine {
+	user := testutil.TestUser()
+	repo := &testutil.MockFamilyRepo{
+		GetFamilyMemberByIDFunc: func(id uint) (*models.FamilyMember, error) {
+			return &models.FamilyMember{ID: id, FamilyID: 7, Name: "Joey"}, nil
+		},
+		GetFamilyByOwnerIDFunc: func(ownerID uint) (*models.Family, error) {
+			return &models.Family{ID: 7, OwnerID: ownerID}, nil
+		},
+	}
+	svc := service.NewFamilyService(&config.Config{}, repo, provider)
+	handler := NewFamilyHandler(svc)
+
+	r := gin.New()
+	r.POST("/family/members/:member_id/dietary/interview", setUser(user), handler.DietaryInterview)
+	return r
+}
+
+func postDietaryInterview(r *gin.Engine, body string) *httptest.ResponseRecorder {
+	req := httptest.NewRequest("POST", "/family/members/5/dietary/interview", strings.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, req)
+	return w
+}
+
+func TestDietaryInterview_Handler_IncompleteEnvelope(t *testing.T) {
+	provider := &testutil.MockTextProvider{
+		DietaryInterviewFunc: func(ctx context.Context, messages []ai.Message, memberName string) (*ai.DietaryInterviewResult, error) {
+			return &ai.DietaryInterviewResult{Response: "Do you have any food allergies?"}, nil
+		},
+	}
+	r := newDietaryInterviewRouter(provider)
+
+	w := postDietaryInterview(r, `{"messages": [{"role": "user", "content": "hi"}]}`)
+	if w.Code != http.StatusOK {
+		t.Fatalf("status = %d, want %d. body: %s", w.Code, http.StatusOK, w.Body.String())
+	}
+
+	// Assert the exact 3-key envelope.
+	var resp map[string]json.RawMessage
+	if err := json.Unmarshal(w.Body.Bytes(), &resp); err != nil {
+		t.Fatalf("failed to parse response: %v", err)
+	}
+	if len(resp) != 3 {
+		t.Errorf("response has %d keys, want exactly 3 (response, complete, profile). body: %s", len(resp), w.Body.String())
+	}
+
+	var response string
+	if err := json.Unmarshal(resp["response"], &response); err != nil || response != "Do you have any food allergies?" {
+		t.Errorf("response = %q (err %v), want question text", response, err)
+	}
+	var complete bool
+	if err := json.Unmarshal(resp["complete"], &complete); err != nil || complete {
+		t.Errorf("complete = %v (err %v), want false", complete, err)
+	}
+	if profileRaw, ok := resp["profile"]; !ok || string(profileRaw) != "null" {
+		t.Errorf("profile = %s, want JSON null", string(profileRaw))
+	}
+}
+
+func TestDietaryInterview_Handler_CompleteProfileSnakeCase(t *testing.T) {
+	provider := &testutil.MockTextProvider{
+		DietaryInterviewFunc: func(ctx context.Context, messages []ai.Message, memberName string) (*ai.DietaryInterviewResult, error) {
+			return &ai.DietaryInterviewResult{
+				Response: "All saved!",
+				Complete: true,
+				Profile: &ai.DietaryProfileResult{
+					Allergies: []ai.DietaryAllergyResult{
+						{Name: "peanuts", Severity: "severe", SubForms: []string{"raw peanuts"}, Notes: "carries an EpiPen"},
+					},
+					Intolerances: []string{"lactose"},
+					Restrictions: []string{"vegetarian"},
+					Preferences:  []string{"dislikes cilantro"},
+					MedicalNotes: "low sodium",
+				},
+			}, nil
+		},
+	}
+	r := newDietaryInterviewRouter(provider)
+
+	w := postDietaryInterview(r, `{"messages": [{"role": "user", "content": "that is everything"}]}`)
+	if w.Code != http.StatusOK {
+		t.Fatalf("status = %d, want %d. body: %s", w.Code, http.StatusOK, w.Body.String())
+	}
+
+	var resp map[string]interface{}
+	if err := json.Unmarshal(w.Body.Bytes(), &resp); err != nil {
+		t.Fatalf("failed to parse response: %v", err)
+	}
+	if resp["response"] != "All saved!" {
+		t.Errorf("response = %v, want 'All saved!'", resp["response"])
+	}
+	if resp["complete"] != true {
+		t.Errorf("complete = %v, want true", resp["complete"])
+	}
+
+	profile, ok := resp["profile"].(map[string]interface{})
+	if !ok {
+		t.Fatalf("profile is not an object: %v", resp["profile"])
+	}
+
+	// Assert snake_case keys per models.DietaryProfile json tags.
+	allergies, ok := profile["allergies"].([]interface{})
+	if !ok || len(allergies) != 1 {
+		t.Fatalf("profile.allergies = %v, want array with 1 entry", profile["allergies"])
+	}
+	allergy, ok := allergies[0].(map[string]interface{})
+	if !ok {
+		t.Fatalf("allergies[0] is not an object: %v", allergies[0])
+	}
+	if allergy["name"] != "peanuts" {
+		t.Errorf("allergy.name = %v, want 'peanuts'", allergy["name"])
+	}
+	if allergy["severity"] != "severe" {
+		t.Errorf("allergy.severity = %v, want 'severe'", allergy["severity"])
+	}
+	subForms, ok := allergy["sub_forms"].([]interface{})
+	if !ok || len(subForms) != 1 || subForms[0] != "raw peanuts" {
+		t.Errorf("allergy.sub_forms = %v, want ['raw peanuts']", allergy["sub_forms"])
+	}
+	if allergy["notes"] != "carries an EpiPen" {
+		t.Errorf("allergy.notes = %v, want EpiPen note", allergy["notes"])
+	}
+
+	intolerances, ok := profile["intolerances"].([]interface{})
+	if !ok || len(intolerances) != 1 || intolerances[0] != "lactose" {
+		t.Errorf("profile.intolerances = %v, want ['lactose']", profile["intolerances"])
+	}
+	restrictions, ok := profile["restrictions"].([]interface{})
+	if !ok || len(restrictions) != 1 || restrictions[0] != "vegetarian" {
+		t.Errorf("profile.restrictions = %v, want ['vegetarian']", profile["restrictions"])
+	}
+	preferences, ok := profile["preferences"].([]interface{})
+	if !ok || len(preferences) != 1 || preferences[0] != "dislikes cilantro" {
+		t.Errorf("profile.preferences = %v, want ['dislikes cilantro']", profile["preferences"])
+	}
+	if profile["medical_notes"] != "low sodium" {
+		t.Errorf("profile.medical_notes = %v, want 'low sodium'", profile["medical_notes"])
+	}
+}
+
+func TestDietaryInterview_Handler_MissingMessages(t *testing.T) {
+	r := newDietaryInterviewRouter(&testutil.MockTextProvider{})
+
+	w := postDietaryInterview(r, `{}`)
+	if w.Code != http.StatusBadRequest {
+		t.Errorf("status = %d, want %d", w.Code, http.StatusBadRequest)
+	}
+}
+
+func TestDietaryInterview_Handler_NotOwnedMember(t *testing.T) {
+	user := testutil.TestUser()
+	repo := &testutil.MockFamilyRepo{
+		GetFamilyMemberByIDFunc: func(id uint) (*models.FamilyMember, error) {
+			return &models.FamilyMember{ID: id, FamilyID: 99, Name: "Joey"}, nil
+		},
+		GetFamilyByOwnerIDFunc: func(ownerID uint) (*models.Family, error) {
+			return &models.Family{ID: 7, OwnerID: ownerID}, nil
+		},
+	}
+	svc := service.NewFamilyService(&config.Config{}, repo, &testutil.MockTextProvider{})
+	handler := NewFamilyHandler(svc)
+
+	r := gin.New()
+	r.POST("/family/members/:member_id/dietary/interview", setUser(user), handler.DietaryInterview)
+
+	w := postDietaryInterview(r, `{"messages": [{"role": "user", "content": "hi"}]}`)
+	if w.Code != http.StatusForbidden {
+		t.Errorf("status = %d, want %d", w.Code, http.StatusForbidden)
+	}
+}

--- a/internal/handlers/image.go
+++ b/internal/handlers/image.go
@@ -1,7 +1,6 @@
 package handlers
 
 import (
-	"fmt"
 	"io"
 	"net/http"
 	"path/filepath"
@@ -25,12 +24,12 @@ func NewImageHandler(cfg *config.Config) *ImageHandler {
 	return &ImageHandler{Cfg: cfg}
 }
 
-// allowedImageTypes is the set of accepted image file extensions.
-var allowedImageTypes = map[string]bool{
-	".jpg":  true,
-	".jpeg": true,
-	".png":  true,
-	".webp": true,
+// allowedImageTypes maps accepted image file extensions to their content type.
+var allowedImageTypes = map[string]string{
+	".jpg":  "image/jpeg",
+	".jpeg": "image/jpeg",
+	".png":  "image/png",
+	".webp": "image/webp",
 }
 
 // UploadImage handles POST /v1/images/upload
@@ -50,7 +49,8 @@ func (h *ImageHandler) UploadImage(c *gin.Context) {
 
 	// Validate file extension
 	ext := strings.ToLower(filepath.Ext(header.Filename))
-	if !allowedImageTypes[ext] {
+	contentType, ok := allowedImageTypes[ext]
+	if !ok {
 		c.JSON(http.StatusBadRequest, gin.H{"error": "Unsupported image type. Allowed: jpg, png, webp"})
 		return
 	}
@@ -69,9 +69,10 @@ func (h *ImageHandler) UploadImage(c *gin.Context) {
 		return
 	}
 
-	// Upload to S3
-	s3Key := fmt.Sprintf("uploads/%d/images/%s", user.ID, header.Filename)
-	imageURL, err := s3.UploadRecipeImageToS3(c.Request.Context(), h.Cfg, imgBytes, s3Key)
+	// Upload to S3 under a server-generated UUID key. The raw client filename
+	// is never used: it is unsanitized and identical names would overwrite.
+	s3Key := s3.GenerateUploadKey(user.ID, ext)
+	imageURL, err := s3.UploadRecipeImageToS3(c.Request.Context(), h.Cfg, imgBytes, s3Key, contentType)
 	if err != nil {
 		logger.Get().Error("failed to upload image to S3", zap.Uint("user_id", user.ID), zap.Error(err))
 		c.JSON(http.StatusInternalServerError, gin.H{"error": "Failed to upload image"})

--- a/internal/handlers/import.go
+++ b/internal/handlers/import.go
@@ -4,6 +4,7 @@ import (
 	"errors"
 	"io"
 	"net/http"
+	"net/url"
 	"strings"
 
 	"github.com/gin-gonic/gin"
@@ -181,6 +182,17 @@ func (h *ImportHandler) ImportManual(c *gin.Context) {
 	if request.UnitSystem != "" && request.UnitSystem != "us_customary" && request.UnitSystem != "metric" {
 		c.JSON(http.StatusBadRequest, gin.H{"error": "unit_system must be 'us_customary' or 'metric'"})
 		return
+	}
+
+	// image_url is stored verbatim and later served to any authenticated
+	// viewer of the recipe, so reject anything that isn't a plain http(s)
+	// URL (e.g. javascript:, data:, or garbage).
+	if request.ImageURL != "" {
+		u, err := url.Parse(request.ImageURL)
+		if err != nil || (u.Scheme != "http" && u.Scheme != "https") || u.Host == "" {
+			c.JSON(http.StatusBadRequest, gin.H{"error": "image_url must be a valid http(s) URL"})
+			return
+		}
 	}
 
 	// Convert request to RecipeDef

--- a/internal/handlers/import.go
+++ b/internal/handlers/import.go
@@ -150,6 +150,8 @@ type manualImportRequest struct {
 	PortionSize  string                  `json:"portion_size"`
 	Hashtags     []string                `json:"hashtags"`
 	SourceURL    string                  `json:"source_url"`
+	UnitSystem   string                  `json:"unit_system"`
+	ImageURL     string                  `json:"image_url"`
 }
 
 // manualIngredientInput represents an ingredient in the manual import request.
@@ -159,6 +161,7 @@ type manualIngredientInput struct {
 	Amount       float64 `json:"amount"`
 	MetricUnit   string  `json:"metric_unit"`
 	MetricAmount float64 `json:"metric_amount"`
+	OriginalText string  `json:"original_text"`
 }
 
 // ImportManual handles POST /v1/recipes/import/manual
@@ -175,6 +178,11 @@ func (h *ImportHandler) ImportManual(c *gin.Context) {
 		return
 	}
 
+	if request.UnitSystem != "" && request.UnitSystem != "us_customary" && request.UnitSystem != "metric" {
+		c.JSON(http.StatusBadRequest, gin.H{"error": "unit_system must be 'us_customary' or 'metric'"})
+		return
+	}
+
 	// Convert request to RecipeDef
 	ingredients := make(models.Ingredients, len(request.Ingredients))
 	for i, ing := range request.Ingredients {
@@ -184,7 +192,16 @@ func (h *ImportHandler) ImportManual(c *gin.Context) {
 			Amount:       ing.Amount,
 			MetricUnit:   ing.MetricUnit,
 			MetricAmount: ing.MetricAmount,
+			OriginalText: ing.OriginalText,
 		}
+	}
+
+	// Use the unit system supplied by the client when present (e.g. preserved
+	// from a preview extraction); only fall back to the user's personalization
+	// when the request does not specify one.
+	unitSystem := request.UnitSystem
+	if unitSystem == "" {
+		unitSystem = user.Personalization.UnitSystem
 	}
 
 	recipeDef := &models.RecipeDef{
@@ -196,7 +213,7 @@ func (h *ImportHandler) ImportManual(c *gin.Context) {
 		PortionSize:  request.PortionSize,
 		ImagePrompt:  "A photo of " + request.Title,
 		SourceURL:    request.SourceURL,
-		UnitSystem:   user.Personalization.UnitSystem,
+		UnitSystem:   unitSystem,
 	}
 
 	recipeType := models.RecipeTypeManualEntry
@@ -204,7 +221,7 @@ func (h *ImportHandler) ImportManual(c *gin.Context) {
 		recipeType = models.RecipeTypeImportLink
 	}
 
-	recipeResponse, err := h.Service.ImportManual(c.Request.Context(), recipeDef, user, recipeType, request.Hashtags)
+	recipeResponse, err := h.Service.ImportManual(c.Request.Context(), recipeDef, user, recipeType, request.Hashtags, request.ImageURL)
 	if err != nil {
 		logger.Get().Error("failed to import recipe manually", zap.Error(err))
 		c.JSON(http.StatusInternalServerError, gin.H{"error": "Failed to create recipe"})

--- a/internal/handlers/import_handler_test.go
+++ b/internal/handlers/import_handler_test.go
@@ -256,3 +256,116 @@ func TestPreviewFromURL_Handler_NotFound(t *testing.T) {
 		t.Errorf("code = %v, want 'not_found'", resp["code"])
 	}
 }
+
+func TestImportManual_Handler_RespectsProvidedUnitSystem(t *testing.T) {
+	repo := testutil.NewMockRecipeRepo()
+	importSvc := newImportService(repo, nil)
+	handler := NewImportHandler(importSvc)
+
+	user := testutil.TestUser()
+	user.Personalization.UnitSystem = "us_customary" // request should win
+	r := gin.New()
+	r.POST("/recipes/import/manual", setUser(user), handler.ImportManual)
+
+	body := `{
+		"title": "Metric Bread",
+		"unit_system": "metric",
+		"image_url": "https://example.com/bread.jpg",
+		"ingredients": [
+			{"name": "flour", "unit": "g", "amount": 500, "metric_unit": "g", "metric_amount": 500, "original_text": "500 g strong bread flour"}
+		],
+		"instructions": ["Knead", "Bake"]
+	}`
+	req := httptest.NewRequest("POST", "/recipes/import/manual", strings.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("status = %d, want %d. body: %s", w.Code, http.StatusOK, w.Body.String())
+	}
+
+	if len(repo.Recipes) != 1 {
+		t.Fatalf("recipes in repo = %d, want 1", len(repo.Recipes))
+	}
+	var recipe *models.Recipe
+	for _, rec := range repo.Recipes {
+		recipe = rec
+	}
+
+	if recipe.UnitSystem != "metric" {
+		t.Errorf("UnitSystem = %q, want 'metric' (from request, not personalization)", recipe.UnitSystem)
+	}
+	if recipe.ImageURL != "https://example.com/bread.jpg" {
+		t.Errorf("ImageURL = %q, want request image_url", recipe.ImageURL)
+	}
+	if len(recipe.Ingredients) != 1 {
+		t.Fatalf("ingredients count = %d, want 1", len(recipe.Ingredients))
+	}
+	ing := recipe.Ingredients[0]
+	if ing.OriginalText != "500 g strong bread flour" {
+		t.Errorf("OriginalText = %q, want '500 g strong bread flour'", ing.OriginalText)
+	}
+	if ing.MetricUnit != "g" || ing.MetricAmount != 500 {
+		t.Errorf("metric fields = %q/%v, want g/500", ing.MetricUnit, ing.MetricAmount)
+	}
+}
+
+func TestImportManual_Handler_FallsBackToPersonalizationUnitSystem(t *testing.T) {
+	repo := testutil.NewMockRecipeRepo()
+	importSvc := newImportService(repo, nil)
+	handler := NewImportHandler(importSvc)
+
+	user := testutil.TestUser()
+	user.Personalization.UnitSystem = "metric"
+	r := gin.New()
+	r.POST("/recipes/import/manual", setUser(user), handler.ImportManual)
+
+	body := `{
+		"title": "No Unit System",
+		"ingredients": [{"name": "flour", "unit": "g", "amount": 500}],
+		"instructions": ["Bake"]
+	}`
+	req := httptest.NewRequest("POST", "/recipes/import/manual", strings.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("status = %d, want %d. body: %s", w.Code, http.StatusOK, w.Body.String())
+	}
+
+	for _, rec := range repo.Recipes {
+		if rec.UnitSystem != "metric" {
+			t.Errorf("UnitSystem = %q, want 'metric' (from personalization fallback)", rec.UnitSystem)
+		}
+	}
+}
+
+func TestImportManual_Handler_InvalidUnitSystem(t *testing.T) {
+	repo := testutil.NewMockRecipeRepo()
+	importSvc := newImportService(repo, nil)
+	handler := NewImportHandler(importSvc)
+
+	user := testutil.TestUser()
+	r := gin.New()
+	r.POST("/recipes/import/manual", setUser(user), handler.ImportManual)
+
+	body := `{
+		"title": "Bad Units",
+		"unit_system": "imperial",
+		"ingredients": [{"name": "flour"}],
+		"instructions": ["Bake"]
+	}`
+	req := httptest.NewRequest("POST", "/recipes/import/manual", strings.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, req)
+
+	if w.Code != http.StatusBadRequest {
+		t.Errorf("status = %d, want %d", w.Code, http.StatusBadRequest)
+	}
+	if len(repo.Recipes) != 0 {
+		t.Errorf("no recipe should be created for invalid unit_system")
+	}
+}

--- a/internal/handlers/recipe.go
+++ b/internal/handlers/recipe.go
@@ -21,11 +21,45 @@ import (
 // RecipeHandler is the handler for recipe-related requests.
 type RecipeHandler struct {
 	Service *service.RecipeService
+	// SubService gates the AI-generation endpoints by subscription usage
+	// when set (nil skips gating, e.g. in isolated tests).
+	SubService *service.SubscriptionService
 }
 
 // NewRecipeHandler is the constructor function for initializing a new RecipeHandler.
 func NewRecipeHandler(recipeService *service.RecipeService) *RecipeHandler {
 	return &RecipeHandler{Service: recipeService}
+}
+
+// checkAIGenerationLimit verifies the user is within their AI-generation
+// usage limit. It writes the error response and returns false when the user
+// is over limit or the check fails.
+func (h *RecipeHandler) checkAIGenerationLimit(c *gin.Context, userID uint) bool {
+	if h.SubService == nil {
+		return true
+	}
+	allowed, err := h.SubService.CheckLimit(userID, "ai_generation")
+	if err != nil {
+		logger.Get().Error("failed to check AI generation limit", zap.Uint("user_id", userID), zap.Error(err))
+		c.JSON(http.StatusInternalServerError, gin.H{"error": "Failed to check subscription limits"})
+		return false
+	}
+	if !allowed {
+		c.JSON(http.StatusForbidden, gin.H{"error": "AI generation limit reached; upgrade to premium for unlimited generations"})
+		return false
+	}
+	return true
+}
+
+// incrementAIGenerationUsage records one AI generation against the user's
+// monthly quota. Failures are logged but never block the response.
+func (h *RecipeHandler) incrementAIGenerationUsage(userID uint) {
+	if h.SubService == nil {
+		return
+	}
+	if err := h.SubService.IncrementUsage(userID, "ai_generation"); err != nil {
+		logger.Get().Error("failed to increment AI generation usage", zap.Uint("user_id", userID), zap.Error(err))
+	}
 }
 
 // ListRecipes returns a paginated list of the authenticated user's recipes.
@@ -128,6 +162,10 @@ func (h *RecipeHandler) GenerateRecipe(c *gin.Context) {
 		genImage = *request.GenImage
 	}
 
+	if !h.checkAIGenerationLimit(c, user.ID) {
+		return
+	}
+
 	prompt := strings.TrimSpace(request.UserPrompt)
 	recipeResponse, err := h.Service.InitGenerateRecipe(user, prompt, genImage)
 	if err != nil {
@@ -135,6 +173,8 @@ func (h *RecipeHandler) GenerateRecipe(c *gin.Context) {
 		c.JSON(http.StatusInternalServerError, gin.H{"error": "An unexpected error occurred while initializing generation"})
 		return
 	}
+
+	h.incrementAIGenerationUsage(user.ID)
 
 	// go h.Service.FinishGenerateRecipe(recipe, user, request.UserPrompt)
 
@@ -179,6 +219,10 @@ func (h *RecipeHandler) RegenerateRecipe(c *gin.Context) {
 		genImage = *request.GenImage
 	}
 
+	if !h.checkAIGenerationLimit(c, user.ID) {
+		return
+	}
+
 	prompt := strings.TrimSpace(request.UserPrompt)
 	err = h.Service.InitRegenerateRecipe(user, recipeID, prompt, genImage)
 	if err != nil {
@@ -186,6 +230,8 @@ func (h *RecipeHandler) RegenerateRecipe(c *gin.Context) {
 		c.JSON(http.StatusInternalServerError, gin.H{"error": "An unexpected error occurred while initializing generation"})
 		return
 	}
+
+	h.incrementAIGenerationUsage(user.ID)
 
 	c.JSON(http.StatusOK, gin.H{"message": "Regenerating recipe"})
 }
@@ -227,6 +273,10 @@ func (h *RecipeHandler) GenerateRecipeWithFork(c *gin.Context) {
 		genImage = *request.GenImage
 	}
 
+	if !h.checkAIGenerationLimit(c, user.ID) {
+		return
+	}
+
 	prompt := strings.TrimSpace(request.UserPrompt)
 	recipeResponse, err := h.Service.InitGenerateRecipeWithFork(user, recipeID, prompt, genImage)
 	if err != nil {
@@ -234,6 +284,8 @@ func (h *RecipeHandler) GenerateRecipeWithFork(c *gin.Context) {
 		c.JSON(http.StatusInternalServerError, gin.H{"error": "An unexpected error occurred while initializing generation"})
 		return
 	}
+
+	h.incrementAIGenerationUsage(user.ID)
 
 	c.JSON(http.StatusOK, gin.H{"recipe": recipeResponse, "message": "Regenerating recipe"})
 }
@@ -265,6 +317,13 @@ func (h *RecipeHandler) StreamGenerateRecipe(c *gin.Context) {
 		c.JSON(http.StatusBadRequest, gin.H{"error": "user_prompt is required"})
 		return
 	}
+
+	if !h.checkAIGenerationLimit(c, user.ID) {
+		return
+	}
+	// The generation is launched below; count it now since SSE headers make
+	// it impossible to report a gating error once streaming starts.
+	h.incrementAIGenerationUsage(user.ID)
 
 	// Set SSE headers
 	c.Header("Content-Type", "text/event-stream")

--- a/internal/handlers/recipe.go
+++ b/internal/handlers/recipe.go
@@ -50,7 +50,17 @@ func (h *RecipeHandler) ListRecipes(c *gin.Context) {
 		}
 	}
 
-	recipes, total, err := h.Service.GetUserRecipes(user.ID, page, pageSize)
+	var recipes []service.RecipeListItem
+	var total int64
+
+	// When a search query is present (>= 2 chars), perform a semantic search
+	// over the user's own recipes instead of a plain listing.
+	q := strings.TrimSpace(c.Query("q"))
+	if len([]rune(q)) >= 2 {
+		recipes, total, err = h.Service.SearchUserRecipes(c.Request.Context(), user.ID, q, page, pageSize)
+	} else {
+		recipes, total, err = h.Service.GetUserRecipes(user.ID, page, pageSize)
+	}
 	if err != nil {
 		logger.Get().Error("failed to list recipes", zap.Uint("user_id", user.ID), zap.Error(err))
 		c.JSON(http.StatusInternalServerError, gin.H{"error": "failed to list recipes"})

--- a/internal/handlers/recipe.go
+++ b/internal/handlers/recipe.go
@@ -321,9 +321,6 @@ func (h *RecipeHandler) StreamGenerateRecipe(c *gin.Context) {
 	if !h.checkAIGenerationLimit(c, user.ID) {
 		return
 	}
-	// The generation is launched below; count it now since SSE headers make
-	// it impossible to report a gating error once streaming starts.
-	h.incrementAIGenerationUsage(user.ID)
 
 	// Set SSE headers
 	c.Header("Content-Type", "text/event-stream")
@@ -338,6 +335,7 @@ func (h *RecipeHandler) StreamGenerateRecipe(c *gin.Context) {
 
 	go func() {
 		defer close(events)
+		defer util.RecoverPanic("stream generate recipe")
 		h.Service.StreamGenerateRecipe(ctx, user, prompt, genImage, events)
 	}()
 
@@ -346,6 +344,14 @@ func (h *RecipeHandler) StreamGenerateRecipe(c *gin.Context) {
 		case event, ok := <-events:
 			if !ok {
 				return false
+			}
+			// Usage is counted only when generation actually completes, so
+			// failed generations (provider errors, content-quality
+			// rejections) don't burn the user's monthly quota — matching
+			// the non-streaming endpoints, which increment after a
+			// successful init.
+			if event.Type == ai.StreamEventComplete {
+				h.incrementAIGenerationUsage(user.ID)
 			}
 			data, _ := json.Marshal(event)
 			c.SSEvent(string(event.Type), string(data))

--- a/internal/handlers/recipe_gating_test.go
+++ b/internal/handlers/recipe_gating_test.go
@@ -1,0 +1,198 @@
+package handlers
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/gin-gonic/gin"
+	"github.com/windoze95/saltybytes-api/internal/config"
+	"github.com/windoze95/saltybytes-api/internal/models"
+	"github.com/windoze95/saltybytes-api/internal/service"
+	"github.com/windoze95/saltybytes-api/internal/testutil"
+	"gorm.io/gorm"
+)
+
+// newGatedRecipeHandler builds a RecipeHandler with a SubscriptionService
+// backed by the given user repo so AI-generation gating is exercised.
+func newGatedRecipeHandler(userRepo *testutil.MockUserRepo) (*RecipeHandler, *testutil.MockRecipeRepo) {
+	recipeRepo := testutil.NewMockRecipeRepo()
+	svc := service.NewRecipeService(&config.Config{}, recipeRepo, &testutil.MockTextProvider{}, &testutil.MockImageProvider{})
+	handler := NewRecipeHandler(svc)
+	handler.SubService = service.NewSubscriptionService(&config.Config{}, userRepo)
+	return handler, recipeRepo
+}
+
+func TestGenerateRecipe_FreeUserAtLimit_403(t *testing.T) {
+	user := testutil.TestUser()
+	user.Subscription = &models.Subscription{
+		Model:             gorm.Model{ID: 1},
+		UserID:            user.ID,
+		Tier:              models.TierFree,
+		AIGenerationsUsed: 50, // free-tier limit
+		MonthlyResetAt:    time.Now().Add(time.Hour),
+	}
+	userRepo := testutil.NewMockUserRepo()
+	userRepo.Users[user.ID] = user
+
+	handler, recipeRepo := newGatedRecipeHandler(userRepo)
+
+	r := gin.New()
+	r.POST("/recipes/chat", setUser(user), handler.GenerateRecipe)
+
+	req := httptest.NewRequest("POST", "/recipes/chat", strings.NewReader(`{"user_prompt": "pancakes", "gen_image": false}`))
+	req.Header.Set("Content-Type", "application/json")
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, req)
+
+	if w.Code != http.StatusForbidden {
+		t.Errorf("status = %d, want %d. body: %s", w.Code, http.StatusForbidden, w.Body.String())
+	}
+	if len(recipeRepo.Recipes) != 0 {
+		t.Error("no recipe should be created when the user is over their AI generation limit")
+	}
+}
+
+func TestGenerateRecipe_FreeUserUnderLimit_IncrementsUsage(t *testing.T) {
+	user := testutil.TestUser()
+	user.Subscription = &models.Subscription{
+		Model:             gorm.Model{ID: 1},
+		UserID:            user.ID,
+		Tier:              models.TierFree,
+		AIGenerationsUsed: 3,
+		MonthlyResetAt:    time.Now().Add(time.Hour),
+	}
+	userRepo := testutil.NewMockUserRepo()
+	userRepo.Users[user.ID] = user
+
+	handler, _ := newGatedRecipeHandler(userRepo)
+
+	r := gin.New()
+	r.POST("/recipes/chat", setUser(user), handler.GenerateRecipe)
+
+	req := httptest.NewRequest("POST", "/recipes/chat", strings.NewReader(`{"user_prompt": "pancakes", "gen_image": false}`))
+	req.Header.Set("Content-Type", "application/json")
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("status = %d, want %d. body: %s", w.Code, http.StatusOK, w.Body.String())
+	}
+	if got := userRepo.Users[user.ID].Subscription.AIGenerationsUsed; got != 4 {
+		t.Errorf("AIGenerationsUsed = %d, want 4 (incremented on success)", got)
+	}
+}
+
+func TestGenerateRecipe_PremiumUserOverFreeLimit_Allowed(t *testing.T) {
+	user := testutil.TestUser()
+	user.Subscription = &models.Subscription{
+		Model:             gorm.Model{ID: 1},
+		UserID:            user.ID,
+		Tier:              models.TierPremium,
+		AIGenerationsUsed: 999,
+		MonthlyResetAt:    time.Now().Add(time.Hour),
+	}
+	userRepo := testutil.NewMockUserRepo()
+	userRepo.Users[user.ID] = user
+
+	handler, _ := newGatedRecipeHandler(userRepo)
+
+	r := gin.New()
+	r.POST("/recipes/chat", setUser(user), handler.GenerateRecipe)
+
+	req := httptest.NewRequest("POST", "/recipes/chat", strings.NewReader(`{"user_prompt": "pancakes", "gen_image": false}`))
+	req.Header.Set("Content-Type", "application/json")
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Errorf("status = %d, want %d. body: %s", w.Code, http.StatusOK, w.Body.String())
+	}
+}
+
+func TestGenerateRecipe_NilSubscriptionUser_GatedWithFreeDefaults(t *testing.T) {
+	user := testutil.TestUser()
+	user.Subscription = nil
+	userRepo := testutil.NewMockUserRepo()
+	userRepo.Users[user.ID] = user
+
+	handler, _ := newGatedRecipeHandler(userRepo)
+
+	r := gin.New()
+	r.POST("/recipes/chat", setUser(user), handler.GenerateRecipe)
+
+	req := httptest.NewRequest("POST", "/recipes/chat", strings.NewReader(`{"user_prompt": "pancakes", "gen_image": false}`))
+	req.Header.Set("Content-Type", "application/json")
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("status = %d, want %d. body: %s", w.Code, http.StatusOK, w.Body.String())
+	}
+	sub := userRepo.Users[user.ID].Subscription
+	if sub == nil {
+		t.Fatal("a free-tier subscription row should have been created for gating")
+	}
+	if sub.Tier != models.TierFree {
+		t.Errorf("Tier = %q, want %q", sub.Tier, models.TierFree)
+	}
+	if sub.AIGenerationsUsed != 1 {
+		t.Errorf("AIGenerationsUsed = %d, want 1", sub.AIGenerationsUsed)
+	}
+}
+
+func TestRegenerateRecipe_FreeUserAtLimit_403(t *testing.T) {
+	user := testutil.TestUser()
+	user.Subscription = &models.Subscription{
+		Model:             gorm.Model{ID: 1},
+		UserID:            user.ID,
+		Tier:              models.TierFree,
+		AIGenerationsUsed: 50,
+		MonthlyResetAt:    time.Now().Add(time.Hour),
+	}
+	userRepo := testutil.NewMockUserRepo()
+	userRepo.Users[user.ID] = user
+
+	handler, _ := newGatedRecipeHandler(userRepo)
+
+	r := gin.New()
+	r.PUT("/recipes/:recipe_id/chat", setUser(user), handler.RegenerateRecipe)
+
+	req := httptest.NewRequest("PUT", "/recipes/1/chat", strings.NewReader(`{"user_prompt": "less sugar", "gen_image": false}`))
+	req.Header.Set("Content-Type", "application/json")
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, req)
+
+	if w.Code != http.StatusForbidden {
+		t.Errorf("status = %d, want %d. body: %s", w.Code, http.StatusForbidden, w.Body.String())
+	}
+}
+
+func TestForkRecipe_FreeUserAtLimit_403(t *testing.T) {
+	user := testutil.TestUser()
+	user.Subscription = &models.Subscription{
+		Model:             gorm.Model{ID: 1},
+		UserID:            user.ID,
+		Tier:              models.TierFree,
+		AIGenerationsUsed: 50,
+		MonthlyResetAt:    time.Now().Add(time.Hour),
+	}
+	userRepo := testutil.NewMockUserRepo()
+	userRepo.Users[user.ID] = user
+
+	handler, _ := newGatedRecipeHandler(userRepo)
+
+	r := gin.New()
+	r.POST("/recipes/:recipe_id/fork", setUser(user), handler.GenerateRecipeWithFork)
+
+	req := httptest.NewRequest("POST", "/recipes/1/fork", strings.NewReader(`{"user_prompt": "make it vegan", "gen_image": false}`))
+	req.Header.Set("Content-Type", "application/json")
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, req)
+
+	if w.Code != http.StatusForbidden {
+		t.Errorf("status = %d, want %d. body: %s", w.Code, http.StatusForbidden, w.Body.String())
+	}
+}

--- a/internal/handlers/recipe_gating_test.go
+++ b/internal/handlers/recipe_gating_test.go
@@ -1,6 +1,7 @@
 package handlers
 
 import (
+	"context"
 	"net/http"
 	"net/http/httptest"
 	"strings"
@@ -8,6 +9,7 @@ import (
 	"time"
 
 	"github.com/gin-gonic/gin"
+	"github.com/windoze95/saltybytes-api/internal/ai"
 	"github.com/windoze95/saltybytes-api/internal/config"
 	"github.com/windoze95/saltybytes-api/internal/models"
 	"github.com/windoze95/saltybytes-api/internal/service"
@@ -140,6 +142,83 @@ func TestGenerateRecipe_NilSubscriptionUser_GatedWithFreeDefaults(t *testing.T) 
 	}
 	if sub.AIGenerationsUsed != 1 {
 		t.Errorf("AIGenerationsUsed = %d, want 1", sub.AIGenerationsUsed)
+	}
+}
+
+// closeNotifyRecorder adds the http.CloseNotifier interface that gin's
+// c.Stream requires but httptest.ResponseRecorder does not implement.
+type closeNotifyRecorder struct {
+	*httptest.ResponseRecorder
+	closed chan bool
+}
+
+func newCloseNotifyRecorder() *closeNotifyRecorder {
+	return &closeNotifyRecorder{httptest.NewRecorder(), make(chan bool, 1)}
+}
+
+func (r *closeNotifyRecorder) CloseNotify() <-chan bool { return r.closed }
+
+func TestStreamGenerateRecipe_FailureDoesNotChargeQuota(t *testing.T) {
+	user := testutil.TestUser()
+	user.Subscription = &models.Subscription{
+		Model:             gorm.Model{ID: 1},
+		UserID:            user.ID,
+		Tier:              models.TierFree,
+		AIGenerationsUsed: 3,
+		MonthlyResetAt:    time.Now().Add(time.Hour),
+	}
+	userRepo := testutil.NewMockUserRepo()
+	userRepo.Users[user.ID] = user
+
+	// MockTextProvider does not implement streaming, so the handler falls
+	// back to sync generation — which is not configured and therefore fails.
+	handler, _ := newGatedRecipeHandler(userRepo)
+
+	r := gin.New()
+	r.POST("/recipes/chat/stream", setUser(user), handler.StreamGenerateRecipe)
+
+	req := httptest.NewRequest("POST", "/recipes/chat/stream", strings.NewReader(`{"user_prompt": "pancakes", "gen_image": false}`))
+	req.Header.Set("Content-Type", "application/json")
+	w := newCloseNotifyRecorder()
+	r.ServeHTTP(w, req)
+
+	if got := userRepo.Users[user.ID].Subscription.AIGenerationsUsed; got != 3 {
+		t.Errorf("AIGenerationsUsed = %d, want 3 (failed generation must not be charged)", got)
+	}
+}
+
+func TestStreamGenerateRecipe_CompleteChargesQuota(t *testing.T) {
+	user := testutil.TestUser()
+	user.Subscription = &models.Subscription{
+		Model:             gorm.Model{ID: 1},
+		UserID:            user.ID,
+		Tier:              models.TierFree,
+		AIGenerationsUsed: 3,
+		MonthlyResetAt:    time.Now().Add(time.Hour),
+	}
+	userRepo := testutil.NewMockUserRepo()
+	userRepo.Users[user.ID] = user
+
+	recipeRepo := testutil.NewMockRecipeRepo()
+	provider := &testutil.MockTextProvider{
+		GenerateRecipeFunc: func(ctx context.Context, req ai.RecipeRequest) (*ai.RecipeResult, error) {
+			return testutil.TestRecipeResult(), nil
+		},
+	}
+	svc := service.NewRecipeService(&config.Config{}, recipeRepo, provider, &testutil.MockImageProvider{})
+	handler := NewRecipeHandler(svc)
+	handler.SubService = service.NewSubscriptionService(&config.Config{}, userRepo)
+
+	r := gin.New()
+	r.POST("/recipes/chat/stream", setUser(user), handler.StreamGenerateRecipe)
+
+	req := httptest.NewRequest("POST", "/recipes/chat/stream", strings.NewReader(`{"user_prompt": "pancakes", "gen_image": false}`))
+	req.Header.Set("Content-Type", "application/json")
+	w := newCloseNotifyRecorder()
+	r.ServeHTTP(w, req)
+
+	if got := userRepo.Users[user.ID].Subscription.AIGenerationsUsed; got != 4 {
+		t.Errorf("AIGenerationsUsed = %d, want 4 (charged once on completion). body: %s", got, w.Body.String())
 	}
 }
 

--- a/internal/handlers/recipe_handler_test.go
+++ b/internal/handlers/recipe_handler_test.go
@@ -1,7 +1,9 @@
 package handlers
 
 import (
+	"context"
 	"encoding/json"
+	"fmt"
 	"net/http"
 	"net/http/httptest"
 	"testing"
@@ -143,6 +145,159 @@ func TestListRecipes_Unauthorized(t *testing.T) {
 
 	if w.Code != http.StatusUnauthorized {
 		t.Errorf("status = %d, want %d", w.Code, http.StatusUnauthorized)
+	}
+}
+
+func TestListRecipes_SemanticSearchMergesVectorAndTitleHits(t *testing.T) {
+	repo := testutil.NewMockRecipeRepo()
+	svc := newRecipeService(repo)
+
+	vectorHit := similarRecipe(1, "Classic Pancakes")
+	titleHit := similarRecipe(2, "Pancake Casserole")
+	duplicateOfVectorHit := similarRecipe(1, "Classic Pancakes")
+
+	vectorRepo := &testutil.MockVectorRepo{
+		SearchUserRecipesByEmbeddingFunc: func(userID uint, embeddingLiteral string, limit int) ([]models.Recipe, error) {
+			return []models.Recipe{vectorHit}, nil
+		},
+		SearchUserRecipesByTitleFunc: func(userID uint, query string, onlyMissingEmbedding bool, limit int) ([]models.Recipe, error) {
+			return []models.Recipe{duplicateOfVectorHit, titleHit}, nil
+		},
+	}
+	svc.VectorRepo = vectorRepo
+	svc.EmbedProvider = &testutil.MockEmbeddingProvider{
+		GenerateEmbeddingFunc: func(ctx context.Context, text string) ([]float32, error) {
+			return []float32{0.1, 0.2}, nil
+		},
+	}
+
+	handler := NewRecipeHandler(svc)
+	user := testutil.TestUser()
+	r := gin.New()
+	r.GET("/recipes", setUser(user), handler.ListRecipes)
+
+	req := httptest.NewRequest("GET", "/recipes?q=pancakes", nil)
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("status = %d, want %d. body: %s", w.Code, http.StatusOK, w.Body.String())
+	}
+
+	var body map[string]interface{}
+	json.Unmarshal(w.Body.Bytes(), &body)
+	recipes, ok := body["recipes"].([]interface{})
+	if !ok {
+		t.Fatalf("response should contain 'recipes' array, body: %s", w.Body.String())
+	}
+	if len(recipes) != 2 {
+		t.Fatalf("recipes len = %d, want 2 (deduped)", len(recipes))
+	}
+	first := recipes[0].(map[string]interface{})
+	second := recipes[1].(map[string]interface{})
+	if first["id"] != "1" {
+		t.Errorf("first result id = %v, want \"1\" (vector hits rank first)", first["id"])
+	}
+	if second["id"] != "2" {
+		t.Errorf("second result id = %v, want \"2\"", second["id"])
+	}
+	if body["total"].(float64) != 2 {
+		t.Errorf("total = %v, want 2", body["total"])
+	}
+
+	// The title pass should only cover recipes lacking embeddings when the
+	// vector search succeeded.
+	if len(vectorRepo.SearchUserRecipesByTitleCalls) != 1 {
+		t.Fatalf("title search calls = %d, want 1", len(vectorRepo.SearchUserRecipesByTitleCalls))
+	}
+	if !vectorRepo.SearchUserRecipesByTitleCalls[0].OnlyMissingEmbedding {
+		t.Error("title search should be scoped to recipes missing embeddings after a vector hit")
+	}
+	if vectorRepo.SearchUserRecipesByTitleCalls[0].Query != "pancakes" {
+		t.Errorf("title search query = %q, want \"pancakes\"", vectorRepo.SearchUserRecipesByTitleCalls[0].Query)
+	}
+}
+
+func TestListRecipes_SearchFallsBackToTitleOnEmbedFailure(t *testing.T) {
+	repo := testutil.NewMockRecipeRepo()
+	svc := newRecipeService(repo)
+
+	vectorRepo := &testutil.MockVectorRepo{
+		SearchUserRecipesByTitleFunc: func(userID uint, query string, onlyMissingEmbedding bool, limit int) ([]models.Recipe, error) {
+			return []models.Recipe{similarRecipe(3, "Pancake Muffins")}, nil
+		},
+	}
+	svc.VectorRepo = vectorRepo
+	svc.EmbedProvider = &testutil.MockEmbeddingProvider{
+		GenerateEmbeddingFunc: func(ctx context.Context, text string) ([]float32, error) {
+			return nil, fmt.Errorf("embedding service down")
+		},
+	}
+
+	handler := NewRecipeHandler(svc)
+	user := testutil.TestUser()
+	r := gin.New()
+	r.GET("/recipes", setUser(user), handler.ListRecipes)
+
+	req := httptest.NewRequest("GET", "/recipes?q=pancakes", nil)
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("status = %d, want %d. body: %s", w.Code, http.StatusOK, w.Body.String())
+	}
+
+	var body map[string]interface{}
+	json.Unmarshal(w.Body.Bytes(), &body)
+	recipes := body["recipes"].([]interface{})
+	if len(recipes) != 1 {
+		t.Fatalf("recipes len = %d, want 1", len(recipes))
+	}
+	if recipes[0].(map[string]interface{})["id"] != "3" {
+		t.Errorf("result id = %v, want \"3\"", recipes[0].(map[string]interface{})["id"])
+	}
+
+	// Pure ILIKE fallback must NOT be scoped to missing-embedding rows.
+	if len(vectorRepo.SearchUserRecipesByTitleCalls) != 1 {
+		t.Fatalf("title search calls = %d, want 1", len(vectorRepo.SearchUserRecipesByTitleCalls))
+	}
+	if vectorRepo.SearchUserRecipesByTitleCalls[0].OnlyMissingEmbedding {
+		t.Error("pure ILIKE fallback should search ALL of the user's recipes")
+	}
+}
+
+func TestListRecipes_ShortQueryUsesPlainListing(t *testing.T) {
+	repo := testutil.NewMockRecipeRepo()
+	recipe := testutil.TestRecipe()
+	recipe.CreatedAt = time.Now()
+	recipe.UpdatedAt = time.Now()
+	repo.Recipes[recipe.ID] = recipe
+
+	svc := newRecipeService(repo)
+	vectorRepo := &testutil.MockVectorRepo{}
+	svc.VectorRepo = vectorRepo
+	svc.EmbedProvider = &testutil.MockEmbeddingProvider{}
+
+	handler := NewRecipeHandler(svc)
+	user := testutil.TestUser()
+	r := gin.New()
+	r.GET("/recipes", setUser(user), handler.ListRecipes)
+
+	req := httptest.NewRequest("GET", "/recipes?q=a", nil)
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("status = %d, want %d. body: %s", w.Code, http.StatusOK, w.Body.String())
+	}
+	if len(vectorRepo.SearchUserRecipesByEmbeddingCalls) != 0 || len(vectorRepo.SearchUserRecipesByTitleCalls) != 0 {
+		t.Error("a query under 2 chars should use the plain listing, not search")
+	}
+
+	var body map[string]interface{}
+	json.Unmarshal(w.Body.Bytes(), &body)
+	if body["total"].(float64) != 1 {
+		t.Errorf("total = %v, want 1", body["total"])
 	}
 }
 

--- a/internal/handlers/search.go
+++ b/internal/handlers/search.go
@@ -31,10 +31,20 @@ func (h *SearchHandler) SearchRecipes(c *gin.Context) {
 		return
 	}
 
-	// Check subscription limits
-	if user.Subscription != nil && !user.Subscription.CanUseWebSearch() {
-		c.JSON(http.StatusForbidden, gin.H{"error": "search limit reached; upgrade to premium for unlimited searches"})
-		return
+	// Check subscription limits through the subscription service so stale
+	// monthly counters get reset and nil-subscription users are gated with
+	// free-tier defaults.
+	if h.Service.SubService != nil {
+		allowed, err := h.Service.SubService.CheckLimit(user.ID, "search")
+		if err != nil {
+			logger.Get().Error("failed to check search limit", zap.Uint("user_id", user.ID), zap.Error(err))
+			c.JSON(http.StatusInternalServerError, gin.H{"error": "Failed to check subscription limits"})
+			return
+		}
+		if !allowed {
+			c.JSON(http.StatusForbidden, gin.H{"error": "search limit reached; upgrade to premium for unlimited searches"})
+			return
+		}
 	}
 
 	query := c.Query("q")

--- a/internal/handlers/search_handler_test.go
+++ b/internal/handlers/search_handler_test.go
@@ -6,6 +6,7 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"testing"
+	"time"
 
 	"github.com/gin-gonic/gin"
 	"github.com/windoze95/saltybytes-api/internal/ai"
@@ -27,6 +28,14 @@ func newTestSearchService(searchFunc func(ctx context.Context, query string, cou
 	return service.NewSearchService(&config.Config{}, mock, nil, nil)
 }
 
+// newTestSearchServiceWithSub wires a SubscriptionService backed by the given
+// user repo so subscription gating paths are exercised.
+func newTestSearchServiceWithSub(userRepo *testutil.MockUserRepo, searchFunc func(ctx context.Context, query string, count int, offset int) ([]ai.SearchResult, error)) *service.SearchService {
+	mock := &testutil.MockSearchProvider{SearchRecipesFunc: searchFunc}
+	subService := service.NewSubscriptionService(&config.Config{}, userRepo)
+	return service.NewSearchService(&config.Config{}, mock, subService, nil)
+}
+
 func TestSearchRecipes_NoUser(t *testing.T) {
 	svc := newTestSearchService(nil)
 	handler := NewSearchHandler(svc)
@@ -44,16 +53,19 @@ func TestSearchRecipes_NoUser(t *testing.T) {
 }
 
 func TestSearchRecipes_LimitReached(t *testing.T) {
-	svc := newTestSearchService(nil)
-	handler := NewSearchHandler(svc)
-
 	user := testutil.TestUser()
 	user.Subscription = &models.Subscription{
 		Model:           gorm.Model{ID: 1},
 		UserID:          user.ID,
 		Tier:            models.TierFree,
 		WebSearchesUsed: 20,
+		MonthlyResetAt:  time.Now().Add(time.Hour), // not yet due for reset
 	}
+	userRepo := testutil.NewMockUserRepo()
+	userRepo.Users[user.ID] = user
+
+	svc := newTestSearchServiceWithSub(userRepo, nil)
+	handler := NewSearchHandler(svc)
 
 	r := gin.New()
 	r.GET("/recipes/search", setUser(user), handler.SearchRecipes)
@@ -67,19 +79,60 @@ func TestSearchRecipes_LimitReached(t *testing.T) {
 	}
 }
 
-func TestSearchRecipes_PremiumUnlimited(t *testing.T) {
-	svc := newTestSearchService(func(ctx context.Context, query string, count int, offset int) ([]ai.SearchResult, error) {
+func TestSearchRecipes_StaleCounterResets(t *testing.T) {
+	// A free user at the limit whose monthly reset is overdue should have
+	// their counters reset and be allowed to search again.
+	user := testutil.TestUser()
+	user.Subscription = &models.Subscription{
+		Model:           gorm.Model{ID: 1},
+		UserID:          user.ID,
+		Tier:            models.TierFree,
+		WebSearchesUsed: 20,
+		MonthlyResetAt:  time.Now().Add(-time.Hour), // overdue
+	}
+	userRepo := testutil.NewMockUserRepo()
+	userRepo.Users[user.ID] = user
+
+	svc := newTestSearchServiceWithSub(userRepo, func(ctx context.Context, query string, count int, offset int) ([]ai.SearchResult, error) {
 		return testSearchResults(), nil
 	})
 	handler := NewSearchHandler(svc)
 
+	r := gin.New()
+	r.GET("/recipes/search", setUser(user), handler.SearchRecipes)
+
+	req := httptest.NewRequest("GET", "/recipes/search?q=chicken", nil)
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("status = %d, want %d. body: %s", w.Code, http.StatusOK, w.Body.String())
+	}
+	sub := userRepo.Users[user.ID].Subscription
+	if sub.WebSearchesUsed != 1 {
+		t.Errorf("WebSearchesUsed = %d, want 1 (reset to 0, then incremented)", sub.WebSearchesUsed)
+	}
+	if !sub.MonthlyResetAt.After(time.Now()) {
+		t.Error("MonthlyResetAt should be advanced into the future after reset")
+	}
+}
+
+func TestSearchRecipes_PremiumUnlimited(t *testing.T) {
 	user := testutil.TestUser()
 	user.Subscription = &models.Subscription{
 		Model:           gorm.Model{ID: 1},
 		UserID:          user.ID,
 		Tier:            models.TierPremium,
 		WebSearchesUsed: 999,
+		MonthlyResetAt:  time.Now().Add(time.Hour),
 	}
+	userRepo := testutil.NewMockUserRepo()
+	userRepo.Users[user.ID] = user
+
+	svc := newTestSearchServiceWithSub(userRepo, func(ctx context.Context, query string, count int, offset int) ([]ai.SearchResult, error) {
+		return testSearchResults(), nil
+	})
+	handler := NewSearchHandler(svc)
 
 	r := gin.New()
 	r.GET("/recipes/search", setUser(user), handler.SearchRecipes)
@@ -90,6 +143,41 @@ func TestSearchRecipes_PremiumUnlimited(t *testing.T) {
 
 	if w.Code != http.StatusOK {
 		t.Errorf("status = %d, want %d. body: %s", w.Code, http.StatusOK, w.Body.String())
+	}
+}
+
+func TestSearchRecipes_NilSubscription_GetsFreeDefaults(t *testing.T) {
+	// A user with no subscription row must not bypass gating: a free-tier
+	// row is created on the fly and usage is tracked against it.
+	user := testutil.TestUser()
+	user.Subscription = nil
+	userRepo := testutil.NewMockUserRepo()
+	userRepo.Users[user.ID] = user
+
+	svc := newTestSearchServiceWithSub(userRepo, func(ctx context.Context, query string, count int, offset int) ([]ai.SearchResult, error) {
+		return testSearchResults(), nil
+	})
+	handler := NewSearchHandler(svc)
+
+	r := gin.New()
+	r.GET("/recipes/search", setUser(user), handler.SearchRecipes)
+
+	req := httptest.NewRequest("GET", "/recipes/search?q=chicken", nil)
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("status = %d, want %d. body: %s", w.Code, http.StatusOK, w.Body.String())
+	}
+	sub := userRepo.Users[user.ID].Subscription
+	if sub == nil {
+		t.Fatal("a free-tier subscription row should have been created")
+	}
+	if sub.Tier != models.TierFree {
+		t.Errorf("Tier = %q, want %q", sub.Tier, models.TierFree)
+	}
+	if sub.WebSearchesUsed != 1 {
+		t.Errorf("WebSearchesUsed = %d, want 1", sub.WebSearchesUsed)
 	}
 }
 

--- a/internal/handlers/similarity.go
+++ b/internal/handlers/similarity.go
@@ -2,6 +2,7 @@ package handlers
 
 import (
 	"net/http"
+	"strconv"
 
 	"github.com/gin-gonic/gin"
 	"github.com/windoze95/saltybytes-api/internal/ai"
@@ -11,15 +12,20 @@ import (
 	"go.uber.org/zap"
 )
 
+const (
+	defaultSimilarLimit = 10
+	maxSimilarLimit     = 25
+)
+
 // SimilarityHandler handles vector similarity search requests.
 type SimilarityHandler struct {
-	VectorRepo    *repository.VectorRepository
+	VectorRepo    repository.VectorRepo
 	EmbedProvider ai.EmbeddingProvider
 	RecipeService *service.RecipeService
 }
 
 // NewSimilarityHandler creates a new SimilarityHandler.
-func NewSimilarityHandler(vectorRepo *repository.VectorRepository, embedProvider ai.EmbeddingProvider, recipeService *service.RecipeService) *SimilarityHandler {
+func NewSimilarityHandler(vectorRepo repository.VectorRepo, embedProvider ai.EmbeddingProvider, recipeService *service.RecipeService) *SimilarityHandler {
 	return &SimilarityHandler{
 		VectorRepo:    vectorRepo,
 		EmbedProvider: embedProvider,
@@ -27,7 +33,7 @@ func NewSimilarityHandler(vectorRepo *repository.VectorRepository, embedProvider
 	}
 }
 
-// FindSimilar handles GET /v1/recipes/similar/:recipe_id
+// FindSimilar handles GET /v1/recipes/similar/:recipe_id?limit=N
 func (h *SimilarityHandler) FindSimilar(c *gin.Context) {
 	recipeIDStr := c.Param("recipe_id")
 	recipeID, err := parseUintParam(recipeIDStr)
@@ -36,7 +42,17 @@ func (h *SimilarityHandler) FindSimilar(c *gin.Context) {
 		return
 	}
 
-	// Get the recipe to build embedding text
+	limit := defaultSimilarLimit
+	if l := c.Query("limit"); l != "" {
+		if v, convErr := strconv.Atoi(l); convErr == nil && v > 0 {
+			limit = v
+		}
+	}
+	if limit > maxSimilarLimit {
+		limit = maxSimilarLimit
+	}
+
+	// Get the recipe for existence check and fallback embedding text
 	recipe, err := h.RecipeService.GetRecipeByID(recipeID)
 	if err != nil {
 		logger.Get().Error("failed to get recipe for similarity", zap.String("recipe_id", recipeIDStr), zap.Error(err))
@@ -44,25 +60,50 @@ func (h *SimilarityHandler) FindSimilar(c *gin.Context) {
 		return
 	}
 
-	// Generate embedding from recipe title and ingredients
-	embeddingText := recipe.Title
-	for _, ing := range recipe.Ingredients {
-		embeddingText += " " + ing.Name
-	}
-
-	embedding, err := h.EmbedProvider.GenerateEmbedding(c.Request.Context(), embeddingText)
+	// Use the stored embedding when present; only generate (and persist) one
+	// when the recipe has no embedding yet.
+	stored, err := h.VectorRepo.GetRecipeEmbedding(recipeID)
 	if err != nil {
-		logger.Get().Error("failed to generate embedding", zap.Uint("recipe_id", recipeID), zap.Error(err))
-		c.JSON(http.StatusInternalServerError, gin.H{"error": "Failed to generate embedding"})
+		logger.Get().Error("failed to read stored embedding", zap.Uint("recipe_id", recipeID), zap.Error(err))
+		c.JSON(http.StatusInternalServerError, gin.H{"error": "Failed to find similar recipes"})
 		return
 	}
 
-	similar, err := h.VectorRepo.FindSimilar(embedding, 10)
+	var embeddingLiteral string
+	if stored != nil && *stored != "" {
+		embeddingLiteral = *stored
+	} else {
+		if h.EmbedProvider == nil {
+			logger.Get().Error("no embedding provider configured", zap.Uint("recipe_id", recipeID))
+			c.JSON(http.StatusInternalServerError, gin.H{"error": "Failed to generate embedding"})
+			return
+		}
+
+		embeddingText := recipe.Title
+		for _, ing := range recipe.Ingredients {
+			embeddingText += " " + ing.Name
+		}
+
+		embedding, genErr := h.EmbedProvider.GenerateEmbedding(c.Request.Context(), embeddingText)
+		if genErr != nil {
+			logger.Get().Error("failed to generate embedding", zap.Uint("recipe_id", recipeID), zap.Error(genErr))
+			c.JSON(http.StatusInternalServerError, gin.H{"error": "Failed to generate embedding"})
+			return
+		}
+
+		if storeErr := h.VectorRepo.UpdateEmbedding(recipeID, embedding); storeErr != nil {
+			logger.Get().Warn("failed to store generated embedding", zap.Uint("recipe_id", recipeID), zap.Error(storeErr))
+		}
+
+		embeddingLiteral = repository.PgvectorLiteral(embedding)
+	}
+
+	similar, err := h.VectorRepo.FindSimilar(embeddingLiteral, recipeID, limit)
 	if err != nil {
 		logger.Get().Error("failed to find similar recipes", zap.Uint("recipe_id", recipeID), zap.Error(err))
 		c.JSON(http.StatusInternalServerError, gin.H{"error": "Failed to find similar recipes"})
 		return
 	}
 
-	c.JSON(http.StatusOK, gin.H{"similar_recipes": similar})
+	c.JSON(http.StatusOK, gin.H{"similar_recipes": h.RecipeService.ToRecipeListItems(similar)})
 }

--- a/internal/handlers/similarity_handler_test.go
+++ b/internal/handlers/similarity_handler_test.go
@@ -1,0 +1,225 @@
+package handlers
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/gin-gonic/gin"
+	"github.com/windoze95/saltybytes-api/internal/config"
+	"github.com/windoze95/saltybytes-api/internal/models"
+	"github.com/windoze95/saltybytes-api/internal/repository"
+	"github.com/windoze95/saltybytes-api/internal/service"
+	"github.com/windoze95/saltybytes-api/internal/testutil"
+	"gorm.io/gorm"
+)
+
+// newSimilarityFixture builds a SimilarityHandler with a recipe (ID 1) in the
+// repo, plus the given vector repo and embedding provider mocks.
+func newSimilarityFixture(vectorRepo *testutil.MockVectorRepo, embedProvider *testutil.MockEmbeddingProvider) *SimilarityHandler {
+	repo := testutil.NewMockRecipeRepo()
+	recipe := testutil.TestRecipe()
+	recipe.CreatedAt = time.Now()
+	recipe.UpdatedAt = time.Now()
+	repo.Recipes[recipe.ID] = recipe
+
+	svc := service.NewRecipeService(&config.Config{}, repo, &testutil.MockTextProvider{}, &testutil.MockImageProvider{})
+	return NewSimilarityHandler(vectorRepo, embedProvider, svc)
+}
+
+func similarRecipe(id uint, title string) models.Recipe {
+	r := testutil.TestRecipe()
+	r.Model = gorm.Model{ID: id}
+	r.Title = title
+	r.CreatedAt = time.Now()
+	r.UpdatedAt = time.Now()
+	return *r
+}
+
+func TestFindSimilar_UsesStoredEmbedding(t *testing.T) {
+	stored := "[0.1,0.2,0.3]"
+	embedCalled := false
+
+	vectorRepo := &testutil.MockVectorRepo{
+		GetRecipeEmbeddingFunc: func(recipeID uint) (*string, error) {
+			return &stored, nil
+		},
+		FindSimilarFunc: func(embeddingLiteral string, excludeRecipeID uint, limit int) ([]models.Recipe, error) {
+			return []models.Recipe{similarRecipe(2, "Blueberry Pancakes")}, nil
+		},
+	}
+	embedProvider := &testutil.MockEmbeddingProvider{
+		GenerateEmbeddingFunc: func(ctx context.Context, text string) ([]float32, error) {
+			embedCalled = true
+			return []float32{0.9}, nil
+		},
+	}
+
+	handler := newSimilarityFixture(vectorRepo, embedProvider)
+	r := gin.New()
+	r.GET("/recipes/similar/:recipe_id", handler.FindSimilar)
+
+	req := httptest.NewRequest("GET", "/recipes/similar/1", nil)
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("status = %d, want %d. body: %s", w.Code, http.StatusOK, w.Body.String())
+	}
+	if embedCalled {
+		t.Error("embedding provider should NOT be called when a stored embedding exists")
+	}
+	if len(vectorRepo.UpdateEmbeddingCalls) != 0 {
+		t.Errorf("UpdateEmbedding should not be called, got %d calls", len(vectorRepo.UpdateEmbeddingCalls))
+	}
+	if len(vectorRepo.FindSimilarCalls) != 1 {
+		t.Fatalf("FindSimilar calls = %d, want 1", len(vectorRepo.FindSimilarCalls))
+	}
+	call := vectorRepo.FindSimilarCalls[0]
+	if call.EmbeddingLiteral != stored {
+		t.Errorf("FindSimilar embedding = %q, want stored %q", call.EmbeddingLiteral, stored)
+	}
+	if call.ExcludeRecipeID != 1 {
+		t.Errorf("FindSimilar excludeRecipeID = %d, want 1", call.ExcludeRecipeID)
+	}
+	if call.Limit != 10 {
+		t.Errorf("FindSimilar limit = %d, want default 10", call.Limit)
+	}
+
+	// Response must use the camelCase RecipeListItem DTO shape
+	var body map[string]interface{}
+	json.Unmarshal(w.Body.Bytes(), &body)
+	items, ok := body["similar_recipes"].([]interface{})
+	if !ok || len(items) != 1 {
+		t.Fatalf("response should contain 1 similar_recipes entry, body: %s", w.Body.String())
+	}
+	item := items[0].(map[string]interface{})
+	if item["id"] != "2" {
+		t.Errorf("item id = %v, want \"2\"", item["id"])
+	}
+	if item["title"] != "Blueberry Pancakes" {
+		t.Errorf("item title = %v, want 'Blueberry Pancakes'", item["title"])
+	}
+	if _, ok := item["imageUrl"]; !ok {
+		t.Error("item should have camelCase 'imageUrl' field")
+	}
+	if _, ok := item["ownerId"]; !ok {
+		t.Error("item should have camelCase 'ownerId' field")
+	}
+}
+
+func TestFindSimilar_GeneratesAndStoresOnNullEmbedding(t *testing.T) {
+	embedCalls := 0
+
+	vectorRepo := &testutil.MockVectorRepo{
+		GetRecipeEmbeddingFunc: func(recipeID uint) (*string, error) {
+			return nil, nil // no stored embedding
+		},
+		FindSimilarFunc: func(embeddingLiteral string, excludeRecipeID uint, limit int) ([]models.Recipe, error) {
+			return []models.Recipe{}, nil
+		},
+	}
+	embedProvider := &testutil.MockEmbeddingProvider{
+		GenerateEmbeddingFunc: func(ctx context.Context, text string) ([]float32, error) {
+			embedCalls++
+			return []float32{0.5, 0.25}, nil
+		},
+	}
+
+	handler := newSimilarityFixture(vectorRepo, embedProvider)
+	r := gin.New()
+	r.GET("/recipes/similar/:recipe_id", handler.FindSimilar)
+
+	req := httptest.NewRequest("GET", "/recipes/similar/1", nil)
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("status = %d, want %d. body: %s", w.Code, http.StatusOK, w.Body.String())
+	}
+	if embedCalls != 1 {
+		t.Errorf("embedding provider calls = %d, want 1", embedCalls)
+	}
+	if len(vectorRepo.UpdateEmbeddingCalls) != 1 || vectorRepo.UpdateEmbeddingCalls[0] != 1 {
+		t.Errorf("UpdateEmbedding should be called once for recipe 1, got %v", vectorRepo.UpdateEmbeddingCalls)
+	}
+	if len(vectorRepo.FindSimilarCalls) != 1 {
+		t.Fatalf("FindSimilar calls = %d, want 1", len(vectorRepo.FindSimilarCalls))
+	}
+	wantLiteral := repository.PgvectorLiteral([]float32{0.5, 0.25})
+	if vectorRepo.FindSimilarCalls[0].EmbeddingLiteral != wantLiteral {
+		t.Errorf("FindSimilar embedding = %q, want %q", vectorRepo.FindSimilarCalls[0].EmbeddingLiteral, wantLiteral)
+	}
+
+	// Empty result still serializes as an array, not null
+	var body map[string]interface{}
+	json.Unmarshal(w.Body.Bytes(), &body)
+	if _, ok := body["similar_recipes"].([]interface{}); !ok {
+		t.Errorf("similar_recipes should be an array, body: %s", w.Body.String())
+	}
+}
+
+func TestFindSimilar_LimitParam(t *testing.T) {
+	stored := "[0.1]"
+	vectorRepo := &testutil.MockVectorRepo{
+		GetRecipeEmbeddingFunc: func(recipeID uint) (*string, error) { return &stored, nil },
+	}
+	handler := newSimilarityFixture(vectorRepo, &testutil.MockEmbeddingProvider{})
+
+	r := gin.New()
+	r.GET("/recipes/similar/:recipe_id", handler.FindSimilar)
+
+	// limit above the max is capped at 25
+	req := httptest.NewRequest("GET", "/recipes/similar/1?limit=100", nil)
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("status = %d, want %d. body: %s", w.Code, http.StatusOK, w.Body.String())
+	}
+	if got := vectorRepo.FindSimilarCalls[0].Limit; got != 25 {
+		t.Errorf("limit = %d, want capped 25", got)
+	}
+
+	// explicit valid limit passes through
+	req = httptest.NewRequest("GET", "/recipes/similar/1?limit=5", nil)
+	w = httptest.NewRecorder()
+	r.ServeHTTP(w, req)
+
+	if got := vectorRepo.FindSimilarCalls[1].Limit; got != 5 {
+		t.Errorf("limit = %d, want 5", got)
+	}
+}
+
+func TestFindSimilar_RecipeNotFound(t *testing.T) {
+	handler := newSimilarityFixture(&testutil.MockVectorRepo{}, &testutil.MockEmbeddingProvider{})
+
+	r := gin.New()
+	r.GET("/recipes/similar/:recipe_id", handler.FindSimilar)
+
+	req := httptest.NewRequest("GET", "/recipes/similar/999", nil)
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, req)
+
+	if w.Code != http.StatusNotFound {
+		t.Errorf("status = %d, want %d", w.Code, http.StatusNotFound)
+	}
+}
+
+func TestFindSimilar_InvalidID(t *testing.T) {
+	handler := newSimilarityFixture(&testutil.MockVectorRepo{}, &testutil.MockEmbeddingProvider{})
+
+	r := gin.New()
+	r.GET("/recipes/similar/:recipe_id", handler.FindSimilar)
+
+	req := httptest.NewRequest("GET", "/recipes/similar/abc", nil)
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, req)
+
+	if w.Code != http.StatusBadRequest {
+		t.Errorf("status = %d, want %d", w.Code, http.StatusBadRequest)
+	}
+}

--- a/internal/handlers/subscription.go
+++ b/internal/handlers/subscription.go
@@ -48,8 +48,10 @@ func (h *SubscriptionHandler) UpgradeSubscription(c *gin.Context) {
 
 	sub, err := h.Service.UpgradeSubscription(user.ID)
 	if err != nil {
-		logger.Get().Error("failed to upgrade subscription", zap.Uint("user_id", user.ID), zap.Error(err))
-		c.JSON(http.StatusInternalServerError, gin.H{"error": "Failed to upgrade subscription"})
+		// Paid plans are not wired up yet; surface that honestly rather than
+		// masking it as a server error.
+		logger.Get().Warn("subscription upgrade requested but unavailable", zap.Uint("user_id", user.ID), zap.Error(err))
+		c.JSON(http.StatusNotImplemented, gin.H{"error": err.Error()})
 		return
 	}
 

--- a/internal/handlers/subscription_handler_test.go
+++ b/internal/handlers/subscription_handler_test.go
@@ -1,0 +1,121 @@
+package handlers
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/gin-gonic/gin"
+	"github.com/windoze95/saltybytes-api/internal/config"
+	"github.com/windoze95/saltybytes-api/internal/models"
+	"github.com/windoze95/saltybytes-api/internal/service"
+	"github.com/windoze95/saltybytes-api/internal/testutil"
+	"gorm.io/gorm"
+)
+
+func newSubscriptionRouter(userRepo *testutil.MockUserRepo, user *models.User) *gin.Engine {
+	svc := service.NewSubscriptionService(&config.Config{}, userRepo)
+	handler := NewSubscriptionHandler(svc)
+
+	r := gin.New()
+	r.GET("/subscription", setUser(user), handler.GetSubscription)
+	r.POST("/subscription/upgrade", setUser(user), handler.UpgradeSubscription)
+	return r
+}
+
+func TestGetSubscription_Handler_Envelope(t *testing.T) {
+	user := testutil.TestUser()
+	user.Subscription = &models.Subscription{
+		Model:                gorm.Model{ID: 1},
+		UserID:               user.ID,
+		Tier:                 models.TierFree,
+		AllergenAnalysesUsed: 2,
+		MonthlyResetAt:       time.Now().Add(time.Hour),
+	}
+	userRepo := testutil.NewMockUserRepo()
+	userRepo.Users[user.ID] = user
+
+	r := newSubscriptionRouter(userRepo, user)
+
+	req := httptest.NewRequest("GET", "/subscription", nil)
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("status = %d, want %d. body: %s", w.Code, http.StatusOK, w.Body.String())
+	}
+
+	var resp map[string]map[string]interface{}
+	if err := json.Unmarshal(w.Body.Bytes(), &resp); err != nil {
+		t.Fatalf("failed to parse response: %v", err)
+	}
+	sub, ok := resp["subscription"]
+	if !ok {
+		t.Fatalf("response missing 'subscription' envelope key. body: %s", w.Body.String())
+	}
+	// models.Subscription has no json tags, so fields serialize PascalCase.
+	if sub["Tier"] != "free" {
+		t.Errorf("subscription.Tier = %v, want 'free'", sub["Tier"])
+	}
+	if sub["AllergenAnalysesUsed"] != float64(2) {
+		t.Errorf("subscription.AllergenAnalysesUsed = %v, want 2", sub["AllergenAnalysesUsed"])
+	}
+}
+
+func TestGetSubscription_Handler_NilSubscription_CreatesFreeRow(t *testing.T) {
+	user := testutil.TestUser()
+	user.Subscription = nil
+	userRepo := testutil.NewMockUserRepo()
+	userRepo.Users[user.ID] = user
+
+	r := newSubscriptionRouter(userRepo, user)
+
+	req := httptest.NewRequest("GET", "/subscription", nil)
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("status = %d, want %d. body: %s", w.Code, http.StatusOK, w.Body.String())
+	}
+
+	var resp map[string]map[string]interface{}
+	if err := json.Unmarshal(w.Body.Bytes(), &resp); err != nil {
+		t.Fatalf("failed to parse response: %v", err)
+	}
+	if resp["subscription"]["Tier"] != "free" {
+		t.Errorf("subscription.Tier = %v, want default 'free'", resp["subscription"]["Tier"])
+	}
+	if userRepo.Users[user.ID].Subscription == nil {
+		t.Error("free-tier subscription row should have been created on the fly")
+	}
+}
+
+func TestUpgradeSubscription_Handler_NotImplemented_501(t *testing.T) {
+	user := testutil.TestUser()
+	userRepo := testutil.NewMockUserRepo()
+	userRepo.Users[user.ID] = user
+
+	r := newSubscriptionRouter(userRepo, user)
+
+	req := httptest.NewRequest("POST", "/subscription/upgrade", nil)
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, req)
+
+	if w.Code != http.StatusNotImplemented {
+		t.Fatalf("status = %d, want %d (paid plans not wired up). body: %s", w.Code, http.StatusNotImplemented, w.Body.String())
+	}
+
+	var resp map[string]interface{}
+	if err := json.Unmarshal(w.Body.Bytes(), &resp); err != nil {
+		t.Fatalf("failed to parse response: %v", err)
+	}
+	if resp["error"] == nil {
+		t.Error("response should contain 'error' explaining upgrade is unavailable")
+	}
+	// The user must not be silently upgraded.
+	if sub := userRepo.Users[user.ID].Subscription; sub != nil && sub.Tier == models.TierPremium {
+		t.Error("user must not be upgraded to premium by a failed upgrade")
+	}
+}

--- a/internal/handlers/user.go
+++ b/internal/handlers/user.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/gin-gonic/gin"
 	"github.com/golang-jwt/jwt/v5"
+	"github.com/google/uuid"
 	"github.com/windoze95/saltybytes-api/internal/logger"
 	"github.com/windoze95/saltybytes-api/internal/models"
 	"github.com/windoze95/saltybytes-api/internal/service"
@@ -284,7 +285,9 @@ func (h *UserHandler) UpdateSettings(c *gin.Context) {
 	c.JSON(http.StatusOK, gin.H{"message": "Settings updated successfully"})
 }
 
-// UpdatePersonalization updates a user's personalization settings.
+// UpdatePersonalization partially updates a user's personalization settings.
+// Only fields present in the request body are written; omitted fields keep
+// their current values.
 func (h *UserHandler) UpdatePersonalization(c *gin.Context) {
 	user, err := util.GetUserFromContext(c)
 	if err != nil {
@@ -293,23 +296,36 @@ func (h *UserHandler) UpdatePersonalization(c *gin.Context) {
 	}
 
 	var req struct {
-		UnitSystem     string `json:"unit_system"`
-		Requirements   string `json:"requirements"`
-		CookingContext string `json:"cooking_context"`
+		UnitSystem     *string `json:"unit_system"`
+		Requirements   *string `json:"requirements"`
+		CookingContext *string `json:"cooking_context"`
+		UID            *string `json:"uid"`
 	}
 	if err := c.ShouldBindJSON(&req); err != nil {
 		c.JSON(http.StatusBadRequest, gin.H{"error": "Invalid request"})
 		return
 	}
 
-	updatedPersonalization := &models.Personalization{
+	if req.UnitSystem != nil && *req.UnitSystem != "us_customary" && *req.UnitSystem != "metric" {
+		c.JSON(http.StatusBadRequest, gin.H{"error": "unit_system must be 'us_customary' or 'metric'"})
+		return
+	}
+
+	update := &models.PersonalizationUpdate{
 		UnitSystem:     req.UnitSystem,
 		Requirements:   req.Requirements,
 		CookingContext: req.CookingContext,
-		UID:            user.Personalization.UID,
+	}
+	if req.UID != nil {
+		uid, parseErr := uuid.Parse(*req.UID)
+		if parseErr != nil {
+			c.JSON(http.StatusBadRequest, gin.H{"error": "uid must be a valid UUID"})
+			return
+		}
+		update.UID = &uid
 	}
 
-	if err := h.Service.UpdatePersonalization(user, updatedPersonalization); err != nil {
+	if err := h.Service.UpdatePersonalization(user, update); err != nil {
 		logger.Get().Error("failed to update personalization", zap.Uint("user_id", user.ID), zap.Error(err))
 		c.JSON(http.StatusInternalServerError, gin.H{"error": "Failed to update personalization"})
 		return

--- a/internal/handlers/user.go
+++ b/internal/handlers/user.go
@@ -1,6 +1,7 @@
 package handlers
 
 import (
+	"errors"
 	"fmt"
 	"net/http"
 	"time"
@@ -10,6 +11,7 @@ import (
 	"github.com/google/uuid"
 	"github.com/windoze95/saltybytes-api/internal/logger"
 	"github.com/windoze95/saltybytes-api/internal/models"
+	"github.com/windoze95/saltybytes-api/internal/repository"
 	"github.com/windoze95/saltybytes-api/internal/service"
 	"github.com/windoze95/saltybytes-api/internal/util"
 	"go.uber.org/zap"
@@ -61,7 +63,15 @@ func (h *UserHandler) CreateUser(c *gin.Context) {
 	// Create user
 	user, err := h.Service.CreateUser(newUser.Username, newUser.FirstName, newUser.Email, newUser.Password)
 	if err != nil {
-		c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
+		logger.Get().Error("failed to create user", zap.String("username", newUser.Username), zap.Error(err))
+		switch {
+		case errors.Is(err, repository.ErrUsernameTaken):
+			c.JSON(http.StatusConflict, gin.H{"error": "username already in use"})
+		case errors.Is(err, repository.ErrEmailTaken):
+			c.JSON(http.StatusConflict, gin.H{"error": "email already in use"})
+		default:
+			c.JSON(http.StatusInternalServerError, gin.H{"error": "Failed to create user"})
+		}
 		return
 	}
 
@@ -69,13 +79,13 @@ func (h *UserHandler) CreateUser(c *gin.Context) {
 	accessToken, err := generateAccessToken(user.ID, h.Service.Cfg.EnvVars.JwtSecretKey)
 	if err != nil {
 		logger.Get().Error("failed to generate access token on signup", zap.Uint("user_id", user.ID), zap.Error(err))
-		c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
+		c.JSON(http.StatusInternalServerError, gin.H{"error": "Failed to generate token"})
 		return
 	}
-	refreshToken, err := generateRefreshToken(user.ID, h.Service.Cfg.EnvVars.JwtSecretKey)
+	refreshToken, err := generateRefreshToken(user.ID, userTokenVersion(user), h.Service.Cfg.EnvVars.JwtSecretKey)
 	if err != nil {
 		logger.Get().Error("failed to generate refresh token on signup", zap.Uint("user_id", user.ID), zap.Error(err))
-		c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
+		c.JSON(http.StatusInternalServerError, gin.H{"error": "Failed to generate token"})
 		return
 	}
 
@@ -96,7 +106,9 @@ func (h *UserHandler) LoginUser(c *gin.Context) {
 
 	user, err := h.Service.LoginUser(userCredentials.Username, userCredentials.Password)
 	if err != nil {
-		c.JSON(http.StatusUnauthorized, gin.H{"error": err.Error()})
+		// Identical generic response for unknown-user and bad-password so the
+		// endpoint cannot be used to enumerate usernames.
+		c.JSON(http.StatusUnauthorized, gin.H{"error": "invalid username or password"})
 		return
 	}
 
@@ -104,13 +116,13 @@ func (h *UserHandler) LoginUser(c *gin.Context) {
 	accessToken, err := generateAccessToken(user.ID, h.Service.Cfg.EnvVars.JwtSecretKey)
 	if err != nil {
 		logger.Get().Error("failed to generate access token on login", zap.Uint("user_id", user.ID), zap.Error(err))
-		c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
+		c.JSON(http.StatusInternalServerError, gin.H{"error": "Failed to generate token"})
 		return
 	}
-	refreshToken, err := generateRefreshToken(user.ID, h.Service.Cfg.EnvVars.JwtSecretKey)
+	refreshToken, err := generateRefreshToken(user.ID, userTokenVersion(user), h.Service.Cfg.EnvVars.JwtSecretKey)
 	if err != nil {
 		logger.Get().Error("failed to generate refresh token on login", zap.Uint("user_id", user.ID), zap.Error(err))
-		c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
+		c.JSON(http.StatusInternalServerError, gin.H{"error": "Failed to generate token"})
 		return
 	}
 
@@ -134,12 +146,15 @@ func generateAccessToken(userID uint, secretKey string) (string, error) {
 }
 
 // generateRefreshToken generates a long-lived JWT refresh token for a user.
-func generateRefreshToken(userID uint, secretKey string) (string, error) {
+// tokenVersion is embedded as the "token_version" claim; tokens whose version
+// no longer matches UserAuth.TokenVersion are rejected on refresh.
+func generateRefreshToken(userID uint, tokenVersion int, secretKey string) (string, error) {
 	claims := jwt.MapClaims{
-		"user_id": userID,
-		"exp":     time.Now().Add(30 * 24 * time.Hour).Unix(),
-		"iat":     time.Now().Unix(),
-		"type":    "refresh",
+		"user_id":       userID,
+		"exp":           time.Now().Add(30 * 24 * time.Hour).Unix(),
+		"iat":           time.Now().Unix(),
+		"type":          "refresh",
+		"token_version": tokenVersion,
 	}
 	token := jwt.NewWithClaims(jwt.SigningMethodHS256, claims)
 	tokenString, err := token.SignedString([]byte(secretKey))
@@ -147,6 +162,15 @@ func generateRefreshToken(userID uint, secretKey string) (string, error) {
 		return "", fmt.Errorf("generateRefreshToken: %v", err)
 	}
 	return tokenString, nil
+}
+
+// userTokenVersion returns the user's current refresh-token version,
+// defaulting to 0 when no auth record is loaded.
+func userTokenVersion(user *models.User) int {
+	if user != nil && user.Auth != nil {
+		return user.Auth.TokenVersion
+	}
+	return 0
 }
 
 // RefreshToken validates a refresh token and issues a new access token.
@@ -182,6 +206,26 @@ func (h *UserHandler) RefreshToken(c *gin.Context) {
 	}
 	userID := uint(idFloat)
 
+	// Load the user and verify the token version so revoked refresh tokens
+	// (logout increments UserAuth.TokenVersion) stop working.
+	user, err := h.Service.GetUserWithAuthByID(userID)
+	if err != nil {
+		c.JSON(http.StatusUnauthorized, gin.H{"error": "Invalid or expired refresh token"})
+		return
+	}
+
+	// Tokens issued before versioning carry no claim; treat missing as 0,
+	// which matches the column default so existing tokens keep working.
+	claimVersion := 0
+	if v, ok := claims["token_version"].(float64); ok {
+		claimVersion = int(v)
+	}
+	currentVersion := userTokenVersion(user)
+	if claimVersion != currentVersion {
+		c.JSON(http.StatusUnauthorized, gin.H{"error": "Invalid or expired refresh token"})
+		return
+	}
+
 	accessToken, err := generateAccessToken(userID, h.Service.Cfg.EnvVars.JwtSecretKey)
 	if err != nil {
 		logger.Get().Error("failed to generate access token on refresh", zap.Uint("user_id", userID), zap.Error(err))
@@ -189,7 +233,7 @@ func (h *UserHandler) RefreshToken(c *gin.Context) {
 		return
 	}
 
-	newRefreshToken, err := generateRefreshToken(userID, h.Service.Cfg.EnvVars.JwtSecretKey)
+	newRefreshToken, err := generateRefreshToken(userID, currentVersion, h.Service.Cfg.EnvVars.JwtSecretKey)
 	if err != nil {
 		logger.Get().Error("failed to generate refresh token on refresh", zap.Uint("user_id", userID), zap.Error(err))
 		c.JSON(http.StatusInternalServerError, gin.H{"error": "Failed to generate refresh token"})
@@ -197,6 +241,25 @@ func (h *UserHandler) RefreshToken(c *gin.Context) {
 	}
 
 	c.JSON(http.StatusOK, gin.H{"access_token": accessToken, "refresh_token": newRefreshToken})
+}
+
+// Logout revokes all of the user's outstanding refresh tokens by
+// incrementing their token version.
+// POST /v1/auth/logout
+func (h *UserHandler) Logout(c *gin.Context) {
+	user, err := util.GetUserFromContext(c)
+	if err != nil {
+		c.JSON(http.StatusUnauthorized, gin.H{"error": "unauthorized"})
+		return
+	}
+
+	if err := h.Service.LogoutUser(user.ID); err != nil {
+		logger.Get().Error("failed to revoke refresh tokens on logout", zap.Uint("user_id", user.ID), zap.Error(err))
+		c.JSON(http.StatusInternalServerError, gin.H{"error": "Failed to log out"})
+		return
+	}
+
+	c.Status(http.StatusNoContent)
 }
 
 // VerifyToken verifies a user's JWT token.

--- a/internal/handlers/user_endpoints_test.go
+++ b/internal/handlers/user_endpoints_test.go
@@ -1,0 +1,390 @@
+package handlers
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/gin-gonic/gin"
+	"github.com/golang-jwt/jwt/v5"
+	"github.com/windoze95/saltybytes-api/internal/config"
+	"github.com/windoze95/saltybytes-api/internal/models"
+	"github.com/windoze95/saltybytes-api/internal/service"
+	"github.com/windoze95/saltybytes-api/internal/testutil"
+)
+
+// newUserEndpointsRouter wires the authenticated user endpoints with the
+// given user attached to the context.
+func newUserEndpointsRouter(repo *testutil.MockUserRepo, user *models.User) *gin.Engine {
+	cfg := &config.Config{EnvVars: config.EnvVars{JwtSecretKey: "test-jwt-secret-key"}}
+	svc := service.NewUserService(cfg, repo)
+	handler := NewUserHandler(svc)
+
+	r := gin.New()
+	r.GET("/auth/verify", setUser(user), handler.VerifyToken)
+	r.GET("/users/me", setUser(user), handler.GetUserByID)
+	r.GET("/users/me/settings", setUser(user), handler.GetUserSettings)
+	r.PUT("/users/me", setUser(user), handler.UpdateUser)
+	r.PUT("/users/me/settings", setUser(user), handler.UpdateSettings)
+	return r
+}
+
+// --- VerifyToken ---
+
+func TestVerifyToken_Handler_Authenticated(t *testing.T) {
+	repo := testutil.NewMockUserRepo()
+	user := testutil.TestUser()
+	repo.Users[user.ID] = user
+
+	r := newUserEndpointsRouter(repo, user)
+
+	req := httptest.NewRequest("GET", "/auth/verify", nil)
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("status = %d, want %d. body: %s", w.Code, http.StatusOK, w.Body.String())
+	}
+
+	var resp map[string]interface{}
+	if err := json.Unmarshal(w.Body.Bytes(), &resp); err != nil {
+		t.Fatalf("failed to parse response: %v", err)
+	}
+	if resp["isAuthenticated"] != true {
+		t.Errorf("isAuthenticated = %v, want true", resp["isAuthenticated"])
+	}
+	userResp, ok := resp["user"].(map[string]interface{})
+	if !ok {
+		t.Fatalf("user is not an object: %v", resp["user"])
+	}
+	if userResp["username"] != "testuser" {
+		t.Errorf("user.username = %v, want 'testuser'", userResp["username"])
+	}
+}
+
+func TestVerifyToken_Handler_NoUser_401(t *testing.T) {
+	handler, _ := newTestUserHandler()
+
+	r := gin.New()
+	r.GET("/auth/verify", handler.VerifyToken) // no setUser middleware
+
+	req := httptest.NewRequest("GET", "/auth/verify", nil)
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, req)
+
+	if w.Code != http.StatusUnauthorized {
+		t.Fatalf("status = %d, want %d", w.Code, http.StatusUnauthorized)
+	}
+	var resp map[string]interface{}
+	if err := json.Unmarshal(w.Body.Bytes(), &resp); err != nil {
+		t.Fatalf("failed to parse response: %v", err)
+	}
+	if resp["isAuthenticated"] != false {
+		t.Errorf("isAuthenticated = %v, want false", resp["isAuthenticated"])
+	}
+}
+
+// --- GetUserByID ---
+
+func TestGetUserByID_Handler_Envelope(t *testing.T) {
+	repo := testutil.NewMockUserRepo()
+	user := testutil.TestUser()
+	repo.Users[user.ID] = user
+
+	r := newUserEndpointsRouter(repo, user)
+
+	req := httptest.NewRequest("GET", "/users/me", nil)
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("status = %d, want %d. body: %s", w.Code, http.StatusOK, w.Body.String())
+	}
+
+	var resp map[string]map[string]interface{}
+	if err := json.Unmarshal(w.Body.Bytes(), &resp); err != nil {
+		t.Fatalf("failed to parse response: %v", err)
+	}
+	u, ok := resp["user"]
+	if !ok {
+		t.Fatalf("response missing 'user' envelope key. body: %s", w.Body.String())
+	}
+	if u["username"] != "testuser" || u["first_name"] != "Test" || u["email"] != "test@example.com" {
+		t.Errorf("user = %v, want testuser/Test/test@example.com", u)
+	}
+	// UserResponse serializes the ID as a string.
+	if u["id"] != "1" {
+		t.Errorf("user.id = %v, want \"1\"", u["id"])
+	}
+	personalization, ok := u["personalization"].(map[string]interface{})
+	if !ok {
+		t.Fatalf("user.personalization missing: %v", u)
+	}
+	if personalization["unit_system"] != "us_customary" {
+		t.Errorf("personalization.unit_system = %v, want 'us_customary'", personalization["unit_system"])
+	}
+}
+
+// --- GetUserSettings ---
+
+func TestGetUserSettings_Handler_Envelope(t *testing.T) {
+	repo := testutil.NewMockUserRepo()
+	user := testutil.TestUser()
+	user.Settings.KeepScreenAwake = true
+	repo.Users[user.ID] = user
+
+	r := newUserEndpointsRouter(repo, user)
+
+	req := httptest.NewRequest("GET", "/users/me/settings", nil)
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("status = %d, want %d. body: %s", w.Code, http.StatusOK, w.Body.String())
+	}
+
+	var resp map[string]map[string]interface{}
+	if err := json.Unmarshal(w.Body.Bytes(), &resp); err != nil {
+		t.Fatalf("failed to parse response: %v", err)
+	}
+	settings, ok := resp["settings"]
+	if !ok {
+		t.Fatalf("response missing 'settings' envelope key. body: %s", w.Body.String())
+	}
+	// models.UserSettings has no json tags, so fields serialize PascalCase.
+	if settings["KeepScreenAwake"] != true {
+		t.Errorf("settings.KeepScreenAwake = %v, want true", settings["KeepScreenAwake"])
+	}
+}
+
+// --- UpdateUser ---
+
+func TestUpdateUser_Handler_UpdatesNameAndEmail(t *testing.T) {
+	repo := testutil.NewMockUserRepo()
+	user := testutil.TestUser()
+	repo.Users[user.ID] = user
+
+	r := newUserEndpointsRouter(repo, user)
+
+	body := `{"first_name": "Updated", "email": "updated@example.com"}`
+	req := httptest.NewRequest("PUT", "/users/me", strings.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("status = %d, want %d. body: %s", w.Code, http.StatusOK, w.Body.String())
+	}
+	if got := repo.Users[user.ID].FirstName; got != "Updated" {
+		t.Errorf("FirstName = %q, want 'Updated'", got)
+	}
+	if got := repo.Users[user.ID].Email; got != "updated@example.com" {
+		t.Errorf("Email = %q, want 'updated@example.com'", got)
+	}
+}
+
+func TestUpdateUser_Handler_EmptyFields_NoChanges(t *testing.T) {
+	repo := testutil.NewMockUserRepo()
+	user := testutil.TestUser()
+	repo.Users[user.ID] = user
+
+	r := newUserEndpointsRouter(repo, user)
+
+	req := httptest.NewRequest("PUT", "/users/me", strings.NewReader(`{}`))
+	req.Header.Set("Content-Type", "application/json")
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("status = %d, want %d. body: %s", w.Code, http.StatusOK, w.Body.String())
+	}
+	if repo.Users[user.ID].FirstName != "Test" || repo.Users[user.ID].Email != "test@example.com" {
+		t.Error("empty update must not change existing fields")
+	}
+}
+
+func TestUpdateUser_Handler_InvalidEmail(t *testing.T) {
+	repo := testutil.NewMockUserRepo()
+	user := testutil.TestUser()
+	repo.Users[user.ID] = user
+
+	r := newUserEndpointsRouter(repo, user)
+
+	body := `{"email": "not-an-email"}`
+	req := httptest.NewRequest("PUT", "/users/me", strings.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, req)
+
+	if w.Code == http.StatusOK {
+		t.Errorf("status = %d, want an error status for an invalid email", w.Code)
+	}
+	if repo.Users[user.ID].Email != "test@example.com" {
+		t.Errorf("Email = %q, want unchanged after invalid update", repo.Users[user.ID].Email)
+	}
+}
+
+func TestUpdateUser_Handler_InvalidJSON_400(t *testing.T) {
+	repo := testutil.NewMockUserRepo()
+	user := testutil.TestUser()
+	repo.Users[user.ID] = user
+
+	r := newUserEndpointsRouter(repo, user)
+
+	req := httptest.NewRequest("PUT", "/users/me", strings.NewReader(`{invalid`))
+	req.Header.Set("Content-Type", "application/json")
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, req)
+
+	if w.Code != http.StatusBadRequest {
+		t.Errorf("status = %d, want %d", w.Code, http.StatusBadRequest)
+	}
+}
+
+// --- UpdateSettings ---
+
+func TestUpdateSettings_Handler_Persists(t *testing.T) {
+	repo := testutil.NewMockUserRepo()
+	user := testutil.TestUser()
+	user.Settings.KeepScreenAwake = true
+	repo.Users[user.ID] = user
+
+	r := newUserEndpointsRouter(repo, user)
+
+	body := `{"keep_screen_awake": false}`
+	req := httptest.NewRequest("PUT", "/users/me/settings", strings.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("status = %d, want %d. body: %s", w.Code, http.StatusOK, w.Body.String())
+	}
+	if repo.Users[user.ID].Settings.KeepScreenAwake {
+		t.Error("KeepScreenAwake = true, want false after update")
+	}
+}
+
+func TestUpdateSettings_Handler_InvalidJSON_400(t *testing.T) {
+	repo := testutil.NewMockUserRepo()
+	user := testutil.TestUser()
+	repo.Users[user.ID] = user
+
+	r := newUserEndpointsRouter(repo, user)
+
+	req := httptest.NewRequest("PUT", "/users/me/settings", strings.NewReader(`not json`))
+	req.Header.Set("Content-Type", "application/json")
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, req)
+
+	if w.Code != http.StatusBadRequest {
+		t.Errorf("status = %d, want %d", w.Code, http.StatusBadRequest)
+	}
+}
+
+// --- RefreshToken edge cases ---
+
+// makeRefreshTokenWithClaims signs a token with the given claims using the
+// test handler secret.
+func makeRefreshTokenWithClaims(t *testing.T, claims jwt.MapClaims, secret string) string {
+	t.Helper()
+	token := jwt.NewWithClaims(jwt.SigningMethodHS256, claims)
+	s, err := token.SignedString([]byte(secret))
+	if err != nil {
+		t.Fatalf("failed to sign token: %v", err)
+	}
+	return s
+}
+
+func TestRefreshToken_Expired_401(t *testing.T) {
+	r, _, user := newAuthTestRouter(t)
+
+	expired := makeRefreshTokenWithClaims(t, jwt.MapClaims{
+		"user_id":       user.ID,
+		"exp":           time.Now().Add(-time.Hour).Unix(),
+		"iat":           time.Now().Add(-2 * time.Hour).Unix(),
+		"type":          "refresh",
+		"token_version": 0,
+	}, "test-jwt-secret-key")
+
+	w := doRefresh(r, expired)
+	if w.Code != http.StatusUnauthorized {
+		t.Errorf("status = %d, want %d for expired refresh token. body: %s", w.Code, http.StatusUnauthorized, w.Body.String())
+	}
+}
+
+func TestRefreshToken_AccessTokenRejected_401(t *testing.T) {
+	r, _, user := newAuthTestRouter(t)
+
+	// Valid signature and expiry, but type=access: must not be usable as a
+	// refresh token.
+	accessToken := makeRefreshTokenWithClaims(t, jwt.MapClaims{
+		"user_id":       user.ID,
+		"exp":           time.Now().Add(15 * time.Minute).Unix(),
+		"iat":           time.Now().Unix(),
+		"type":          "access",
+		"token_version": 0,
+	}, "test-jwt-secret-key")
+
+	w := doRefresh(r, accessToken)
+	if w.Code != http.StatusUnauthorized {
+		t.Errorf("status = %d, want %d for access token used as refresh. body: %s", w.Code, http.StatusUnauthorized, w.Body.String())
+	}
+}
+
+func TestRefreshToken_TamperedSignature_401(t *testing.T) {
+	r, _, user := newAuthTestRouter(t)
+
+	// Signed with the wrong secret: signature does not verify.
+	forged := makeRefreshTokenWithClaims(t, jwt.MapClaims{
+		"user_id":       user.ID,
+		"exp":           time.Now().Add(30 * 24 * time.Hour).Unix(),
+		"iat":           time.Now().Unix(),
+		"type":          "refresh",
+		"token_version": 0,
+	}, "attacker-secret")
+
+	w := doRefresh(r, forged)
+	if w.Code != http.StatusUnauthorized {
+		t.Errorf("status = %d, want %d for forged signature. body: %s", w.Code, http.StatusUnauthorized, w.Body.String())
+	}
+}
+
+func TestRefreshToken_AlgNoneRejected_401(t *testing.T) {
+	r, _, user := newAuthTestRouter(t)
+
+	// alg=none token: must be rejected by the HS256 allowlist.
+	claims := jwt.MapClaims{
+		"user_id":       user.ID,
+		"exp":           time.Now().Add(30 * 24 * time.Hour).Unix(),
+		"iat":           time.Now().Unix(),
+		"type":          "refresh",
+		"token_version": 0,
+	}
+	token := jwt.NewWithClaims(jwt.SigningMethodNone, claims)
+	unsigned, err := token.SignedString(jwt.UnsafeAllowNoneSignatureType)
+	if err != nil {
+		t.Fatalf("failed to build alg=none token: %v", err)
+	}
+
+	w := doRefresh(r, unsigned)
+	if w.Code != http.StatusUnauthorized {
+		t.Errorf("status = %d, want %d for alg=none token. body: %s", w.Code, http.StatusUnauthorized, w.Body.String())
+	}
+}
+
+func TestRefreshToken_MissingBody_400(t *testing.T) {
+	r, _, _ := newAuthTestRouter(t)
+
+	req := httptest.NewRequest("POST", "/auth/refresh", strings.NewReader(`{}`))
+	req.Header.Set("Content-Type", "application/json")
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, req)
+
+	if w.Code != http.StatusBadRequest {
+		t.Errorf("status = %d, want %d when refresh_token is missing", w.Code, http.StatusBadRequest)
+	}
+}

--- a/internal/handlers/user_handler_test.go
+++ b/internal/handlers/user_handler_test.go
@@ -181,3 +181,98 @@ func TestLoginUser_Handler_MissingFields(t *testing.T) {
 		t.Errorf("status = %d, want %d", w.Code, http.StatusBadRequest)
 	}
 }
+
+// --- UpdatePersonalization (partial update) ---
+
+func newPersonalizationTestRouter(repo *testutil.MockUserRepo, user *models.User) (*gin.Engine, *UserHandler) {
+	cfg := &config.Config{EnvVars: config.EnvVars{JwtSecretKey: "test-jwt-secret-key"}}
+	svc := service.NewUserService(cfg, repo)
+	handler := NewUserHandler(svc)
+
+	r := gin.New()
+	r.PUT("/users/me/personalization", setUser(user), handler.UpdatePersonalization)
+	return r, handler
+}
+
+func TestUpdatePersonalization_PartialUpdate_PreservesCookingContext(t *testing.T) {
+	repo := testutil.NewMockUserRepo()
+	user := testutil.TestUser()
+	user.Personalization.CookingContext = "induction stove, small kitchen"
+	user.Personalization.Requirements = "No peanuts"
+	repo.Users[user.ID] = user
+
+	r, _ := newPersonalizationTestRouter(repo, user)
+
+	// Only unit_system is sent — a unit toggle must not wipe other fields.
+	body := `{"unit_system": "metric"}`
+	req := httptest.NewRequest("PUT", "/users/me/personalization", strings.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("status = %d, want %d. body: %s", w.Code, http.StatusOK, w.Body.String())
+	}
+
+	p := repo.Users[user.ID].Personalization
+	if p.UnitSystem != "metric" {
+		t.Errorf("UnitSystem = %q, want 'metric'", p.UnitSystem)
+	}
+	if p.CookingContext != "induction stove, small kitchen" {
+		t.Errorf("CookingContext = %q, want preserved value", p.CookingContext)
+	}
+	if p.Requirements != "No peanuts" {
+		t.Errorf("Requirements = %q, want preserved value", p.Requirements)
+	}
+}
+
+func TestUpdatePersonalization_UpdatesOnlyProvidedFields(t *testing.T) {
+	repo := testutil.NewMockUserRepo()
+	user := testutil.TestUser()
+	user.Personalization.CookingContext = "gas stove"
+	repo.Users[user.ID] = user
+
+	r, _ := newPersonalizationTestRouter(repo, user)
+
+	body := `{"cooking_context": "electric oven", "requirements": "vegetarian"}`
+	req := httptest.NewRequest("PUT", "/users/me/personalization", strings.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("status = %d, want %d. body: %s", w.Code, http.StatusOK, w.Body.String())
+	}
+
+	p := repo.Users[user.ID].Personalization
+	if p.CookingContext != "electric oven" {
+		t.Errorf("CookingContext = %q, want 'electric oven'", p.CookingContext)
+	}
+	if p.Requirements != "vegetarian" {
+		t.Errorf("Requirements = %q, want 'vegetarian'", p.Requirements)
+	}
+	if p.UnitSystem != "us_customary" {
+		t.Errorf("UnitSystem = %q, want unchanged 'us_customary'", p.UnitSystem)
+	}
+}
+
+func TestUpdatePersonalization_InvalidUnitSystem(t *testing.T) {
+	repo := testutil.NewMockUserRepo()
+	user := testutil.TestUser()
+	repo.Users[user.ID] = user
+
+	r, _ := newPersonalizationTestRouter(repo, user)
+
+	body := `{"unit_system": "imperial"}`
+	req := httptest.NewRequest("PUT", "/users/me/personalization", strings.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, req)
+
+	if w.Code != http.StatusBadRequest {
+		t.Errorf("status = %d, want %d", w.Code, http.StatusBadRequest)
+	}
+	if repo.Users[user.ID].Personalization.UnitSystem != "us_customary" {
+		t.Errorf("UnitSystem should be unchanged after invalid request")
+	}
+}

--- a/internal/handlers/user_handler_test.go
+++ b/internal/handlers/user_handler_test.go
@@ -6,8 +6,10 @@ import (
 	"net/http/httptest"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/gin-gonic/gin"
+	"github.com/golang-jwt/jwt/v5"
 	"github.com/windoze95/saltybytes-api/internal/config"
 	"github.com/windoze95/saltybytes-api/internal/models"
 	"github.com/windoze95/saltybytes-api/internal/service"
@@ -275,4 +277,208 @@ func TestUpdatePersonalization_InvalidUnitSystem(t *testing.T) {
 	if repo.Users[user.ID].Personalization.UnitSystem != "us_customary" {
 		t.Errorf("UnitSystem should be unchanged after invalid request")
 	}
+}
+
+// --- Login enumeration hardening ---
+
+func TestLoginUser_Handler_UnknownUserAndBadPassword_IdenticalResponse(t *testing.T) {
+	handler, repo := newTestUserHandler()
+
+	hashedPwd, _ := bcrypt.GenerateFromPassword([]byte("Correct1!"), 10)
+	repo.CreateUser(&models.User{
+		Username: "realuser",
+		Auth: &models.UserAuth{
+			HashedPassword: string(hashedPwd),
+			AuthType:       models.Standard,
+		},
+		Settings:        &models.UserSettings{},
+		Personalization: &models.Personalization{},
+	})
+
+	r := gin.New()
+	r.POST("/auth/login", handler.LoginUser)
+
+	doLogin := func(body string) (int, string) {
+		req := httptest.NewRequest("POST", "/auth/login", strings.NewReader(body))
+		req.Header.Set("Content-Type", "application/json")
+		w := httptest.NewRecorder()
+		r.ServeHTTP(w, req)
+		return w.Code, w.Body.String()
+	}
+
+	unknownCode, unknownBody := doLogin(`{"username": "nosuchuser", "password": "Whatever1!"}`)
+	badPwdCode, badPwdBody := doLogin(`{"username": "realuser", "password": "Wrong1!"}`)
+
+	if unknownCode != http.StatusUnauthorized {
+		t.Errorf("unknown-user status = %d, want %d", unknownCode, http.StatusUnauthorized)
+	}
+	if badPwdCode != http.StatusUnauthorized {
+		t.Errorf("bad-password status = %d, want %d", badPwdCode, http.StatusUnauthorized)
+	}
+	if unknownBody != badPwdBody {
+		t.Errorf("login failure bodies differ (username enumeration):\n unknown user: %s\n bad password: %s", unknownBody, badPwdBody)
+	}
+
+	var resp map[string]interface{}
+	json.Unmarshal([]byte(unknownBody), &resp)
+	if resp["error"] != "invalid username or password" {
+		t.Errorf("error = %v, want 'invalid username or password'", resp["error"])
+	}
+}
+
+// --- Refresh token versioning / revocation ---
+
+func loginAndGetRefreshToken(t *testing.T, r *gin.Engine, username, password string) string {
+	t.Helper()
+	body := `{"username": "` + username + `", "password": "` + password + `"}`
+	req := httptest.NewRequest("POST", "/auth/login", strings.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, req)
+	if w.Code != http.StatusOK {
+		t.Fatalf("login status = %d, body: %s", w.Code, w.Body.String())
+	}
+	var resp map[string]interface{}
+	json.Unmarshal(w.Body.Bytes(), &resp)
+	token, _ := resp["refresh_token"].(string)
+	if token == "" {
+		t.Fatal("login response missing refresh_token")
+	}
+	return token
+}
+
+func doRefresh(r *gin.Engine, refreshToken string) *httptest.ResponseRecorder {
+	body := `{"refresh_token": "` + refreshToken + `"}`
+	req := httptest.NewRequest("POST", "/auth/refresh", strings.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, req)
+	return w
+}
+
+func newAuthTestRouter(t *testing.T) (*gin.Engine, *testutil.MockUserRepo, *models.User) {
+	t.Helper()
+	handler, repo := newTestUserHandler()
+
+	hashedPwd, _ := bcrypt.GenerateFromPassword([]byte("Password1!"), 10)
+	user := &models.User{
+		Username: "refreshuser",
+		Auth: &models.UserAuth{
+			HashedPassword: string(hashedPwd),
+			AuthType:       models.Standard,
+		},
+		Settings:        &models.UserSettings{},
+		Personalization: &models.Personalization{},
+	}
+	repo.CreateUser(user)
+
+	r := gin.New()
+	r.POST("/auth/login", handler.LoginUser)
+	r.POST("/auth/refresh", handler.RefreshToken)
+	r.POST("/auth/logout", setUser(user), handler.Logout)
+	return r, repo, user
+}
+
+func TestRefreshToken_Success_WithCurrentVersion(t *testing.T) {
+	r, _, _ := newAuthTestRouter(t)
+
+	refreshToken := loginAndGetRefreshToken(t, r, "refreshuser", "Password1!")
+	w := doRefresh(r, refreshToken)
+
+	if w.Code != http.StatusOK {
+		t.Errorf("status = %d, want %d. body: %s", w.Code, http.StatusOK, w.Body.String())
+	}
+	var resp map[string]interface{}
+	json.Unmarshal(w.Body.Bytes(), &resp)
+	if resp["access_token"] == nil || resp["refresh_token"] == nil {
+		t.Error("refresh response should contain access_token and refresh_token")
+	}
+}
+
+func TestRefreshToken_MissingVersionClaim_TreatedAsZero(t *testing.T) {
+	// Tokens minted before versioning carry no token_version claim; they must
+	// keep working while UserAuth.TokenVersion is still 0.
+	r, _, user := newAuthTestRouter(t)
+
+	legacyToken := makeLegacyRefreshToken(t, user.ID)
+	w := doRefresh(r, legacyToken)
+
+	if w.Code != http.StatusOK {
+		t.Errorf("status = %d, want %d (legacy token with version 0). body: %s", w.Code, http.StatusOK, w.Body.String())
+	}
+}
+
+func TestRefreshToken_VersionMismatch_401(t *testing.T) {
+	r, repo, user := newAuthTestRouter(t)
+
+	refreshToken := loginAndGetRefreshToken(t, r, "refreshuser", "Password1!")
+
+	// Bump the version out from under the token (e.g. logout on another device)
+	repo.Users[user.ID].Auth.TokenVersion = 5
+
+	w := doRefresh(r, refreshToken)
+	if w.Code != http.StatusUnauthorized {
+		t.Errorf("status = %d, want %d. body: %s", w.Code, http.StatusUnauthorized, w.Body.String())
+	}
+}
+
+func TestRefreshToken_UnknownUser_401(t *testing.T) {
+	handler, _ := newTestUserHandler()
+	r := gin.New()
+	r.POST("/auth/refresh", handler.RefreshToken)
+
+	// Valid signature, but user 999 doesn't exist in the repo
+	token := makeLegacyRefreshToken(t, 999)
+	w := doRefresh(r, token)
+	if w.Code != http.StatusUnauthorized {
+		t.Errorf("status = %d, want %d. body: %s", w.Code, http.StatusUnauthorized, w.Body.String())
+	}
+}
+
+func TestLogout_RevokesRefreshTokens(t *testing.T) {
+	r, repo, user := newAuthTestRouter(t)
+
+	refreshToken := loginAndGetRefreshToken(t, r, "refreshuser", "Password1!")
+
+	// Logout
+	req := httptest.NewRequest("POST", "/auth/logout", nil)
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, req)
+	if w.Code != http.StatusNoContent {
+		t.Fatalf("logout status = %d, want %d. body: %s", w.Code, http.StatusNoContent, w.Body.String())
+	}
+	if got := repo.Users[user.ID].Auth.TokenVersion; got != 1 {
+		t.Errorf("TokenVersion after logout = %d, want 1", got)
+	}
+
+	// The pre-logout refresh token must now be rejected
+	w2 := doRefresh(r, refreshToken)
+	if w2.Code != http.StatusUnauthorized {
+		t.Errorf("refresh with revoked token status = %d, want %d", w2.Code, http.StatusUnauthorized)
+	}
+
+	// A fresh login issues a token carrying the new version, which works
+	newToken := loginAndGetRefreshToken(t, r, "refreshuser", "Password1!")
+	w3 := doRefresh(r, newToken)
+	if w3.Code != http.StatusOK {
+		t.Errorf("refresh with post-logout token status = %d, want %d. body: %s", w3.Code, http.StatusOK, w3.Body.String())
+	}
+}
+
+// makeLegacyRefreshToken mints a refresh token without a token_version claim,
+// mimicking tokens issued before revocation support.
+func makeLegacyRefreshToken(t *testing.T, userID uint) string {
+	t.Helper()
+	claims := jwt.MapClaims{
+		"user_id": userID,
+		"exp":     time.Now().Add(30 * 24 * time.Hour).Unix(),
+		"iat":     time.Now().Unix(),
+		"type":    "refresh",
+	}
+	token := jwt.NewWithClaims(jwt.SigningMethodHS256, claims)
+	s, err := token.SignedString([]byte("test-jwt-secret-key"))
+	if err != nil {
+		t.Fatalf("failed to sign legacy token: %v", err)
+	}
+	return s
 }

--- a/internal/middleware/context.go
+++ b/internal/middleware/context.go
@@ -1,27 +1,36 @@
 package middleware
 
 import (
+	"net/http"
+
 	"github.com/gin-gonic/gin"
+	"github.com/windoze95/saltybytes-api/internal/logger"
 	"github.com/windoze95/saltybytes-api/internal/service"
 	"github.com/windoze95/saltybytes-api/internal/util"
+	"go.uber.org/zap"
 )
 
-// AttachUserToContext attaches a user to the context.
+// AttachUserToContext attaches a user to the context. It runs after
+// VerifyTokenMiddleware on protected routes, so a missing user_id or a
+// failed user lookup (e.g. deleted account with a still-valid token) aborts
+// with 401 instead of letting handlers dereference a nil user. Public routes
+// do not use this middleware and are unaffected.
 func AttachUserToContext(userService *service.UserService) gin.HandlerFunc {
 	return func(c *gin.Context) {
 		userID, err := util.GetUserIDFromContext(c)
 		if err != nil {
-			c.Set("user", nil)
-			c.Next()
+			c.AbortWithStatusJSON(http.StatusUnauthorized, gin.H{"error": "unauthorized"})
 			return
 		}
 
 		user, err := userService.GetUserByID(userID)
 		if err != nil {
-			c.Set("user", nil)
-		} else {
-			c.Set("user", user)
+			logger.Get().Warn("failed to load user for valid token", zap.Uint("user_id", userID), zap.Error(err))
+			c.AbortWithStatusJSON(http.StatusUnauthorized, gin.H{"error": "unauthorized"})
+			return
 		}
+
+		c.Set("user", user)
 		c.Next()
 	}
 }

--- a/internal/middleware/context_test.go
+++ b/internal/middleware/context_test.go
@@ -1,0 +1,122 @@
+package middleware
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/gin-gonic/gin"
+	"github.com/windoze95/saltybytes-api/internal/config"
+	"github.com/windoze95/saltybytes-api/internal/models"
+	"github.com/windoze95/saltybytes-api/internal/service"
+	"github.com/windoze95/saltybytes-api/internal/testutil"
+	"github.com/windoze95/saltybytes-api/internal/util"
+)
+
+// setUserID is a test middleware that simulates VerifyTokenMiddleware having
+// placed the user_id in the context.
+func setUserID(userID uint) gin.HandlerFunc {
+	return func(c *gin.Context) {
+		c.Set("user_id", userID)
+		c.Next()
+	}
+}
+
+func setupAttachUserRouter(repo *testutil.MockUserRepo, pre ...gin.HandlerFunc) *gin.Engine {
+	svc := service.NewUserService(&config.Config{}, repo)
+
+	r := gin.New()
+	for _, mw := range pre {
+		r.Use(mw)
+	}
+	r.Use(AttachUserToContext(svc))
+	r.GET("/test", func(c *gin.Context) {
+		user, err := util.GetUserFromContext(c)
+		if err != nil || user == nil {
+			c.JSON(http.StatusInternalServerError, gin.H{"error": "user missing from context"})
+			return
+		}
+		c.JSON(http.StatusOK, gin.H{"username": user.Username})
+	})
+	return r
+}
+
+func TestAttachUserToContext_Success(t *testing.T) {
+	repo := testutil.NewMockUserRepo()
+	user := testutil.TestUser()
+	repo.Users[user.ID] = user
+
+	r := setupAttachUserRouter(repo, setUserID(user.ID))
+
+	req := httptest.NewRequest("GET", "/test", nil)
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Errorf("status = %d, want %d. body: %s", w.Code, http.StatusOK, w.Body.String())
+	}
+}
+
+func TestAttachUserToContext_MissingUserID_401(t *testing.T) {
+	repo := testutil.NewMockUserRepo()
+
+	// No setUserID middleware: simulates the middleware being reached without
+	// VerifyTokenMiddleware having set a user_id.
+	r := setupAttachUserRouter(repo)
+
+	req := httptest.NewRequest("GET", "/test", nil)
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, req)
+
+	if w.Code != http.StatusUnauthorized {
+		t.Errorf("status = %d, want %d. body: %s", w.Code, http.StatusUnauthorized, w.Body.String())
+	}
+}
+
+func TestAttachUserToContext_UserLookupFails_401(t *testing.T) {
+	repo := testutil.NewMockUserRepo() // empty: lookup will fail
+
+	r := setupAttachUserRouter(repo, setUserID(42))
+
+	req := httptest.NewRequest("GET", "/test", nil)
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, req)
+
+	if w.Code != http.StatusUnauthorized {
+		t.Errorf("status = %d, want %d (deleted user with valid token must not 500). body: %s", w.Code, http.StatusUnauthorized, w.Body.String())
+	}
+}
+
+func TestAttachUserToContext_ComposedWithVerifyToken(t *testing.T) {
+	// Full protected-route composition: VerifyTokenMiddleware extracts the
+	// user_id from a valid JWT, then AttachUserToContext loads the user.
+	repo := testutil.NewMockUserRepo()
+	user := testutil.TestUser()
+	repo.Users[user.ID] = user
+
+	cfg := &config.Config{EnvVars: config.EnvVars{JwtSecretKey: testSecret}}
+	svc := service.NewUserService(cfg, repo)
+
+	var attached *models.User
+	r := gin.New()
+	r.Use(VerifyTokenMiddleware(cfg))
+	r.Use(AttachUserToContext(svc))
+	r.GET("/test", func(c *gin.Context) {
+		attached, _ = util.GetUserFromContext(c)
+		c.JSON(http.StatusOK, gin.H{})
+	})
+
+	token := makeTestToken(user.ID, "access", time.Now().Add(15*time.Minute), testSecret)
+	req := httptest.NewRequest("GET", "/test", nil)
+	req.Header.Set("Authorization", "Bearer "+token)
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("status = %d, want %d. body: %s", w.Code, http.StatusOK, w.Body.String())
+	}
+	if attached == nil || attached.ID != user.ID {
+		t.Errorf("attached user = %+v, want user %d", attached, user.ID)
+	}
+}

--- a/internal/middleware/headers_test.go
+++ b/internal/middleware/headers_test.go
@@ -1,0 +1,58 @@
+package middleware
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/gin-gonic/gin"
+)
+
+const testIDHeaderValue = "test-identifier-value"
+
+func setupIDHeaderRouter() *gin.Engine {
+	r := gin.New()
+	r.Use(CheckIDHeader(testIDHeaderValue))
+	r.GET("/test", func(c *gin.Context) {
+		c.JSON(http.StatusOK, gin.H{"ok": true})
+	})
+	return r
+}
+
+func TestCheckIDHeader_CorrectValue(t *testing.T) {
+	r := setupIDHeaderRouter()
+
+	req := httptest.NewRequest("GET", "/test", nil)
+	req.Header.Set("X-SaltyBytes-Identifier", testIDHeaderValue)
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Errorf("status = %d, want %d. body: %s", w.Code, http.StatusOK, w.Body.String())
+	}
+}
+
+func TestCheckIDHeader_MissingHeader(t *testing.T) {
+	r := setupIDHeaderRouter()
+
+	req := httptest.NewRequest("GET", "/test", nil)
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, req)
+
+	if w.Code != http.StatusUnauthorized {
+		t.Errorf("status = %d, want %d", w.Code, http.StatusUnauthorized)
+	}
+}
+
+func TestCheckIDHeader_WrongValue(t *testing.T) {
+	r := setupIDHeaderRouter()
+
+	req := httptest.NewRequest("GET", "/test", nil)
+	req.Header.Set("X-SaltyBytes-Identifier", "wrong-value")
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, req)
+
+	if w.Code != http.StatusUnauthorized {
+		t.Errorf("status = %d, want %d", w.Code, http.StatusUnauthorized)
+	}
+}

--- a/internal/middleware/rate_limiters.go
+++ b/internal/middleware/rate_limiters.go
@@ -15,8 +15,10 @@ type limiterInfo struct {
 	lastSeen time.Time
 }
 
-// RateLimitByIP applies rate limiting to requests per IP address.
-func RateLimitByIP(rps int, cleanupInterval time.Duration, expiration time.Duration) gin.HandlerFunc {
+// RateLimitByIP applies rate limiting to requests per IP address. Each IP
+// gets a token bucket that refills at perMinute requests per minute and
+// allows bursts of up to burst requests.
+func RateLimitByIP(perMinute int, burst int, cleanupInterval time.Duration, expiration time.Duration) gin.HandlerFunc {
 	var limiters sync.Map
 
 	// Cleanup goroutine
@@ -31,12 +33,14 @@ func RateLimitByIP(rps int, cleanupInterval time.Duration, expiration time.Durat
 		}
 	}()
 
+	limit := rate.Limit(float64(perMinute) / 60.0)
+
 	return func(c *gin.Context) {
 		ip := c.ClientIP()
 
 		// Use LoadOrStore to ensure thread safety
 		actual, _ := limiters.LoadOrStore(ip, &limiterInfo{
-			limiter:  rate.NewLimiter(rate.Limit(rps), rps),
+			limiter:  rate.NewLimiter(limit, burst),
 			lastSeen: time.Now(),
 		})
 

--- a/internal/middleware/rate_limiters.go
+++ b/internal/middleware/rate_limiters.go
@@ -3,16 +3,20 @@ package middleware
 import (
 	"net/http"
 	"sync"
+	"sync/atomic"
 	"time"
 
 	"github.com/gin-gonic/gin"
 	"golang.org/x/time/rate"
 )
 
-// limiterInfo is a struct that holds a rate limiter and the last time it was seen.
+// limiterInfo is a struct that holds a rate limiter and the last time it was
+// seen. lastSeenNano is accessed atomically (UnixNano) because request
+// handlers write it while the cleanup goroutine reads it concurrently;
+// sync.Map only synchronizes the map slots, not the stored struct's fields.
 type limiterInfo struct {
-	limiter  *rate.Limiter
-	lastSeen time.Time
+	limiter      *rate.Limiter
+	lastSeenNano atomic.Int64
 }
 
 // RateLimitByIP applies rate limiting to requests per IP address. Each IP
@@ -25,7 +29,8 @@ func RateLimitByIP(perMinute int, burst int, cleanupInterval time.Duration, expi
 	go func() {
 		for range time.Tick(cleanupInterval) {
 			limiters.Range(func(key, value interface{}) bool {
-				if time.Since(value.(*limiterInfo).lastSeen) > expiration {
+				lastSeen := time.Unix(0, value.(*limiterInfo).lastSeenNano.Load())
+				if time.Since(lastSeen) > expiration {
 					limiters.Delete(key)
 				}
 				return true
@@ -39,13 +44,11 @@ func RateLimitByIP(perMinute int, burst int, cleanupInterval time.Duration, expi
 		ip := c.ClientIP()
 
 		// Use LoadOrStore to ensure thread safety
-		actual, _ := limiters.LoadOrStore(ip, &limiterInfo{
-			limiter:  rate.NewLimiter(limit, burst),
-			lastSeen: time.Now(),
-		})
+		fresh := &limiterInfo{limiter: rate.NewLimiter(limit, burst)}
+		actual, _ := limiters.LoadOrStore(ip, fresh)
 
 		info := actual.(*limiterInfo)
-		info.lastSeen = time.Now()
+		info.lastSeenNano.Store(time.Now().UnixNano())
 
 		if !info.limiter.Allow() {
 			// Too many requests

--- a/internal/middleware/rate_limiters_test.go
+++ b/internal/middleware/rate_limiters_test.go
@@ -1,0 +1,99 @@
+package middleware
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/gin-gonic/gin"
+)
+
+// setupRateLimitRouter builds a router with RateLimitByIP applied. The
+// limiter uses the real clock (golang.org/x/time/rate), so tests pick rates
+// where refill is either effectively zero or comfortably faster than the
+// sleeps used.
+func setupRateLimitRouter(perMinute, burst int) *gin.Engine {
+	r := gin.New()
+	r.Use(RateLimitByIP(perMinute, burst, time.Minute, time.Minute))
+	r.GET("/test", func(c *gin.Context) {
+		c.JSON(http.StatusOK, gin.H{"ok": true})
+	})
+	return r
+}
+
+func doRequestFromIP(r *gin.Engine, ip string) *httptest.ResponseRecorder {
+	req := httptest.NewRequest("GET", "/test", nil)
+	req.RemoteAddr = ip + ":12345"
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, req)
+	return w
+}
+
+func TestRateLimitByIP_BurstExhaustion_429(t *testing.T) {
+	// 1 request/minute refill is effectively zero within the test, so only
+	// the burst of 3 is available.
+	r := setupRateLimitRouter(1, 3)
+
+	for i := 1; i <= 3; i++ {
+		w := doRequestFromIP(r, "10.0.0.1")
+		if w.Code != http.StatusOK {
+			t.Fatalf("request %d: status = %d, want %d (within burst)", i, w.Code, http.StatusOK)
+		}
+	}
+
+	w := doRequestFromIP(r, "10.0.0.1")
+	if w.Code != http.StatusTooManyRequests {
+		t.Errorf("request 4: status = %d, want %d after burst exhausted", w.Code, http.StatusTooManyRequests)
+	}
+}
+
+func TestRateLimitByIP_429Body(t *testing.T) {
+	r := setupRateLimitRouter(1, 1)
+
+	doRequestFromIP(r, "10.0.0.2")
+	w := doRequestFromIP(r, "10.0.0.2")
+
+	if w.Code != http.StatusTooManyRequests {
+		t.Fatalf("status = %d, want %d", w.Code, http.StatusTooManyRequests)
+	}
+	if body := w.Body.String(); body == "" || body == "{}" {
+		t.Errorf("429 body = %q, want an error payload", body)
+	}
+}
+
+func TestRateLimitByIP_DistinctIPsIndependent(t *testing.T) {
+	r := setupRateLimitRouter(1, 1)
+
+	// Exhaust IP A's bucket.
+	if w := doRequestFromIP(r, "10.0.0.3"); w.Code != http.StatusOK {
+		t.Fatalf("first request from A: status = %d, want %d", w.Code, http.StatusOK)
+	}
+	if w := doRequestFromIP(r, "10.0.0.3"); w.Code != http.StatusTooManyRequests {
+		t.Fatalf("second request from A: status = %d, want %d", w.Code, http.StatusTooManyRequests)
+	}
+
+	// A different IP gets its own bucket.
+	if w := doRequestFromIP(r, "10.0.0.4"); w.Code != http.StatusOK {
+		t.Errorf("request from B: status = %d, want %d (buckets must be per-IP)", w.Code, http.StatusOK)
+	}
+}
+
+func TestRateLimitByIP_RefillsOverTime(t *testing.T) {
+	// 60/minute = 1 token per second, burst 1: after draining the bucket, a
+	// ~1.1s wait makes exactly one more request admissible.
+	r := setupRateLimitRouter(60, 1)
+
+	if w := doRequestFromIP(r, "10.0.0.5"); w.Code != http.StatusOK {
+		t.Fatalf("first request: status = %d, want %d", w.Code, http.StatusOK)
+	}
+	if w := doRequestFromIP(r, "10.0.0.5"); w.Code != http.StatusTooManyRequests {
+		t.Fatalf("immediate second request: status = %d, want %d", w.Code, http.StatusTooManyRequests)
+	}
+
+	time.Sleep(1100 * time.Millisecond)
+
+	if w := doRequestFromIP(r, "10.0.0.5"); w.Code != http.StatusOK {
+		t.Errorf("request after refill window: status = %d, want %d", w.Code, http.StatusOK)
+	}
+}

--- a/internal/models/allergen.go
+++ b/internal/models/allergen.go
@@ -5,31 +5,36 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"time"
 
 	"gorm.io/gorm"
 )
 
 // AllergenAnalysis is the model for allergen analysis results of a recipe.
+// gorm.Model fields are declared explicitly so JSON serializes snake_case.
 type AllergenAnalysis struct {
-	gorm.Model
-	RecipeID             uint                   `gorm:"index;not null"`
-	Recipe               *Recipe                `gorm:"foreignKey:RecipeID"`
-	NodeID               *uint                  `gorm:"index"`
-	IngredientAnalyses   IngredientAnalysisList `gorm:"type:jsonb"`
-	ContainsNuts         bool
-	ContainsDairy        bool
-	ContainsGluten       bool
-	ContainsSoy          bool
-	ContainsSeedOils     bool
-	ContainsShellfish    bool
-	ContainsEggs         bool
-	SafeForProfiles      UintList               `gorm:"type:jsonb"`
-	UnsafeForProfiles    UintList               `gorm:"type:jsonb"`
-	Confidence           float64                `gorm:"default:0"`
-	RequiresReview       bool                   `gorm:"default:true"`
-	IsPremium            bool                   `gorm:"default:false"`
-	PromptVersion        string
-	Disclaimer           string `gorm:"-"`
+	ID                 uint                   `gorm:"primarykey" json:"id"`
+	CreatedAt          time.Time              `json:"created_at"`
+	UpdatedAt          time.Time              `json:"updated_at"`
+	DeletedAt          gorm.DeletedAt         `gorm:"index" json:"-"`
+	RecipeID           uint                   `gorm:"index;not null" json:"recipe_id"`
+	Recipe             *Recipe                `gorm:"foreignKey:RecipeID" json:"-"`
+	NodeID             *uint                  `gorm:"index" json:"node_id"`
+	IngredientAnalyses IngredientAnalysisList `gorm:"type:jsonb" json:"ingredient_analyses"`
+	ContainsNuts       bool                   `json:"contains_nuts"`
+	ContainsDairy      bool                   `json:"contains_dairy"`
+	ContainsGluten     bool                   `json:"contains_gluten"`
+	ContainsSoy        bool                   `json:"contains_soy"`
+	ContainsSeedOils   bool                   `json:"contains_seed_oils"`
+	ContainsShellfish  bool                   `json:"contains_shellfish"`
+	ContainsEggs       bool                   `json:"contains_eggs"`
+	SafeForProfiles    UintList               `gorm:"type:jsonb" json:"safe_for_profiles"`
+	UnsafeForProfiles  UintList               `gorm:"type:jsonb" json:"unsafe_for_profiles"`
+	Confidence         float64                `gorm:"default:0" json:"confidence"`
+	RequiresReview     bool                   `gorm:"default:true" json:"requires_review"`
+	IsPremium          bool                   `gorm:"default:false" json:"is_premium"`
+	PromptVersion      string                 `json:"prompt_version"`
+	Disclaimer         string                 `gorm:"-" json:"disclaimer"`
 }
 
 // IngredientAnalysis represents the allergen analysis for a single ingredient.

--- a/internal/models/family.go
+++ b/internal/models/family.go
@@ -5,39 +5,52 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"time"
 
 	"gorm.io/gorm"
 )
 
 // Family is the model for a family group.
+// gorm.Model fields are declared explicitly so JSON serializes snake_case.
 type Family struct {
-	gorm.Model
-	Name    string         `gorm:"not null"`
-	OwnerID uint           `gorm:"index;not null"`
-	Owner   *User          `gorm:"foreignKey:OwnerID"`
-	Members []FamilyMember `gorm:"foreignKey:FamilyID"`
+	ID        uint           `gorm:"primarykey" json:"id"`
+	CreatedAt time.Time      `json:"created_at"`
+	UpdatedAt time.Time      `json:"updated_at"`
+	DeletedAt gorm.DeletedAt `gorm:"index" json:"-"`
+	Name      string         `gorm:"not null" json:"name"`
+	OwnerID   uint           `gorm:"index;not null" json:"owner_id"`
+	Owner     *User          `gorm:"foreignKey:OwnerID" json:"-"`
+	Members   []FamilyMember `gorm:"foreignKey:FamilyID" json:"members"`
 }
 
 // FamilyMember is the model for a member within a family.
+// gorm.Model fields are declared explicitly so JSON serializes snake_case.
 type FamilyMember struct {
-	gorm.Model
-	FamilyID       uint            `gorm:"index;not null"`
-	Name           string          `gorm:"not null"`
-	Relationship   string          `gorm:"type:text"`
-	UserID         *uint           `gorm:"index"`
-	User           *User           `gorm:"foreignKey:UserID"`
-	DietaryProfile *DietaryProfile `gorm:"foreignKey:MemberID"`
+	ID             uint            `gorm:"primarykey" json:"id"`
+	CreatedAt      time.Time       `json:"created_at"`
+	UpdatedAt      time.Time       `json:"updated_at"`
+	DeletedAt      gorm.DeletedAt  `gorm:"index" json:"-"`
+	FamilyID       uint            `gorm:"index;not null" json:"family_id"`
+	Name           string          `gorm:"not null" json:"name"`
+	Relationship   string          `gorm:"type:text" json:"relationship"`
+	UserID         *uint           `gorm:"index" json:"user_id"`
+	User           *User           `gorm:"foreignKey:UserID" json:"-"`
+	DietaryProfile *DietaryProfile `gorm:"foreignKey:MemberID" json:"dietary_profile"`
 }
 
 // DietaryProfile is the model for a family member's dietary information.
+// gorm.Model fields are declared explicitly so JSON serializes snake_case.
 type DietaryProfile struct {
-	gorm.Model
-	MemberID     uint        `gorm:"uniqueIndex;not null"`
-	Allergies    AllergyList `gorm:"type:jsonb"`
-	Intolerances StringList  `gorm:"type:jsonb"`
-	Restrictions StringList  `gorm:"type:jsonb"`
-	Preferences  StringList  `gorm:"type:jsonb"`
-	MedicalNotes string      `gorm:"type:text"`
+	ID           uint           `gorm:"primarykey" json:"id"`
+	CreatedAt    time.Time      `json:"created_at"`
+	UpdatedAt    time.Time      `json:"updated_at"`
+	DeletedAt    gorm.DeletedAt `gorm:"index" json:"-"`
+	MemberID     uint           `gorm:"uniqueIndex;not null" json:"member_id"`
+	Allergies    AllergyList    `gorm:"type:jsonb" json:"allergies"`
+	Intolerances StringList     `gorm:"type:jsonb" json:"intolerances"`
+	Restrictions StringList     `gorm:"type:jsonb" json:"restrictions"`
+	Preferences  StringList     `gorm:"type:jsonb" json:"preferences"`
+	MedicalNotes string         `gorm:"type:text" json:"medical_notes"`
 }
 
 // Allergy represents a single allergy entry.

--- a/internal/models/json_tags_test.go
+++ b/internal/models/json_tags_test.go
@@ -1,0 +1,226 @@
+package models
+
+import (
+	"encoding/json"
+	"testing"
+	"time"
+)
+
+// marshalToMap marshals v to JSON and unmarshals it into a map for key assertions.
+func marshalToMap(t *testing.T, v interface{}) map[string]json.RawMessage {
+	t.Helper()
+	data, err := json.Marshal(v)
+	if err != nil {
+		t.Fatalf("json.Marshal failed: %v", err)
+	}
+	var m map[string]json.RawMessage
+	if err := json.Unmarshal(data, &m); err != nil {
+		t.Fatalf("json.Unmarshal failed: %v", err)
+	}
+	return m
+}
+
+// assertKeys checks that all want keys are present and all exclude keys are absent.
+func assertKeys(t *testing.T, m map[string]json.RawMessage, want []string, exclude []string) {
+	t.Helper()
+	for _, k := range want {
+		if _, ok := m[k]; !ok {
+			t.Errorf("expected JSON key %q to be present, got keys: %v", k, keysOf(m))
+		}
+	}
+	for _, k := range exclude {
+		if _, ok := m[k]; ok {
+			t.Errorf("expected JSON key %q to be absent", k)
+		}
+	}
+}
+
+func keysOf(m map[string]json.RawMessage) []string {
+	keys := make([]string, 0, len(m))
+	for k := range m {
+		keys = append(keys, k)
+	}
+	return keys
+}
+
+// --- RecipeNode / RecipeTree serialization (contract C2) ---
+
+func TestRecipeNodeJSON_SnakeCaseKeys(t *testing.T) {
+	parentID := uint(1)
+	node := RecipeNode{
+		ID:          2,
+		CreatedAt:   time.Now(),
+		TreeID:      3,
+		ParentID:    &parentID,
+		Prompt:      "make it spicier",
+		Response:    &RecipeDef{Title: "Spicy Pancakes"},
+		Summary:     "Added cayenne",
+		Type:        RecipeTypeRegenChat,
+		BranchName:  "original",
+		CreatedByID: 1,
+		IsActive:    true,
+	}
+
+	m := marshalToMap(t, node)
+
+	assertKeys(t, m,
+		[]string{"id", "tree_id", "parent_id", "branch_name", "is_active", "created_at", "user_prompt", "response", "summary", "type", "is_ephemeral", "created_by_id"},
+		[]string{"ID", "TreeID", "ParentID", "BranchName", "IsActive", "CreatedAt", "Prompt", "Response", "DeletedAt", "Parent", "Children", "CreatedBy"},
+	)
+
+	// Response must keep the existing RecipeDef snake_case shape unchanged.
+	var response map[string]json.RawMessage
+	if err := json.Unmarshal(m["response"], &response); err != nil {
+		t.Fatalf("failed to unmarshal response: %v", err)
+	}
+	if _, ok := response["title"]; !ok {
+		t.Error("expected response.title key in RecipeDef serialization")
+	}
+}
+
+func TestRecipeNodeJSON_RootHasNullParentID(t *testing.T) {
+	node := RecipeNode{ID: 1, TreeID: 1}
+	m := marshalToMap(t, node)
+	if string(m["parent_id"]) != "null" {
+		t.Errorf("parent_id for root node = %s, want null", m["parent_id"])
+	}
+}
+
+func TestRecipeTreeJSON_SnakeCaseKeys(t *testing.T) {
+	rootNodeID := uint(1)
+	tree := RecipeTree{
+		ID:         5,
+		RecipeID:   10,
+		RootNodeID: &rootNodeID,
+		Nodes:      []RecipeNode{{ID: 1, TreeID: 5}},
+	}
+
+	m := marshalToMap(t, tree)
+
+	assertKeys(t, m,
+		[]string{"id", "recipe_id", "root_node_id", "nodes", "created_at"},
+		[]string{"ID", "RecipeID", "RootNodeID", "RootNode", "DeletedAt"},
+	)
+}
+
+// --- Family / FamilyMember / DietaryProfile serialization (contract C3) ---
+
+func TestFamilyJSON_SnakeCaseKeys(t *testing.T) {
+	family := Family{
+		ID:      1,
+		Name:    "The Does",
+		OwnerID: 7,
+		Owner:   &User{},
+		Members: []FamilyMember{{ID: 2, FamilyID: 1, Name: "Jane", Relationship: "spouse"}},
+	}
+
+	m := marshalToMap(t, family)
+
+	assertKeys(t, m,
+		[]string{"id", "name", "owner_id", "members", "created_at"},
+		[]string{"ID", "Name", "OwnerID", "Owner", "Members", "DeletedAt"},
+	)
+}
+
+func TestFamilyMemberJSON_SnakeCaseKeys(t *testing.T) {
+	userID := uint(3)
+	member := FamilyMember{
+		ID:           2,
+		FamilyID:     1,
+		Name:         "Jane",
+		Relationship: "spouse",
+		UserID:       &userID,
+		User:         &User{},
+		DietaryProfile: &DietaryProfile{
+			ID:       4,
+			MemberID: 2,
+		},
+	}
+
+	m := marshalToMap(t, member)
+
+	assertKeys(t, m,
+		[]string{"id", "family_id", "name", "relationship", "user_id", "dietary_profile", "created_at"},
+		[]string{"ID", "FamilyID", "Name", "Relationship", "UserID", "User", "DietaryProfile", "DeletedAt"},
+	)
+}
+
+func TestDietaryProfileJSON_SnakeCaseKeys(t *testing.T) {
+	profile := DietaryProfile{
+		ID:       4,
+		MemberID: 2,
+		Allergies: AllergyList{
+			{Name: "peanut", Severity: "severe", SubForms: []string{"peanut oil"}, Notes: "carries epipen"},
+		},
+		Intolerances: StringList{"lactose"},
+		Restrictions: StringList{"halal"},
+		Preferences:  StringList{"no cilantro"},
+		MedicalNotes: "see allergist notes",
+	}
+
+	m := marshalToMap(t, profile)
+
+	assertKeys(t, m,
+		[]string{"id", "member_id", "allergies", "intolerances", "restrictions", "preferences", "medical_notes", "created_at"},
+		[]string{"ID", "MemberID", "Allergies", "Intolerances", "Restrictions", "Preferences", "MedicalNotes", "DeletedAt"},
+	)
+
+	// Allergy entries keep their existing snake_case keys.
+	var allergies []map[string]json.RawMessage
+	if err := json.Unmarshal(m["allergies"], &allergies); err != nil {
+		t.Fatalf("failed to unmarshal allergies: %v", err)
+	}
+	if len(allergies) != 1 {
+		t.Fatalf("expected 1 allergy, got %d", len(allergies))
+	}
+	assertKeys(t, allergies[0], []string{"name", "severity", "sub_forms", "notes"}, nil)
+}
+
+// --- AllergenAnalysis serialization (contract C4) ---
+
+func TestAllergenAnalysisJSON_SnakeCaseKeys(t *testing.T) {
+	nodeID := uint(9)
+	analysis := AllergenAnalysis{
+		ID:       1,
+		RecipeID: 2,
+		Recipe:   &Recipe{},
+		NodeID:   &nodeID,
+		IngredientAnalyses: IngredientAnalysisList{
+			{IngredientName: "peanut butter", CommonAllergens: []string{"peanut"}, Confidence: 0.95},
+		},
+		ContainsNuts:      true,
+		SafeForProfiles:   UintList{1},
+		UnsafeForProfiles: UintList{2},
+		Confidence:        0.9,
+		RequiresReview:    false,
+		IsPremium:         true,
+		PromptVersion:     "v1",
+		Disclaimer:        "test disclaimer",
+	}
+
+	m := marshalToMap(t, analysis)
+
+	assertKeys(t, m,
+		[]string{
+			"id", "created_at", "recipe_id", "node_id", "ingredient_analyses",
+			"contains_nuts", "contains_dairy", "contains_gluten", "contains_soy",
+			"contains_seed_oils", "contains_shellfish", "contains_eggs",
+			"safe_for_profiles", "unsafe_for_profiles", "confidence",
+			"requires_review", "is_premium", "prompt_version", "disclaimer",
+		},
+		[]string{"ID", "CreatedAt", "RecipeID", "Recipe", "NodeID", "IngredientAnalyses", "ContainsNuts", "DeletedAt"},
+	)
+
+	// Nested ingredient analyses keep their existing snake_case keys.
+	var analyses []map[string]json.RawMessage
+	if err := json.Unmarshal(m["ingredient_analyses"], &analyses); err != nil {
+		t.Fatalf("failed to unmarshal ingredient_analyses: %v", err)
+	}
+	if len(analyses) != 1 {
+		t.Fatalf("expected 1 ingredient analysis, got %d", len(analyses))
+	}
+	assertKeys(t, analyses[0],
+		[]string{"ingredient_name", "common_allergens", "possible_allergens", "sub_ingredients", "seed_oil_risk", "confidence"},
+		nil,
+	)
+}

--- a/internal/models/openai_embedded.go
+++ b/internal/models/openai_embedded.go
@@ -17,10 +17,10 @@ type RecipeDef struct {
 	CookTime          int            `json:"cook_time" gorm:"column:cook_time"`
 	ImagePrompt       string         `json:"image_prompt" gorm:"column:image_prompt"`
 	LinkedSuggestions pq.StringArray `json:"linked_recipe_suggestions" gorm:"type:text[];column:linked_recipe_suggestions"`
-	Portions         int            `json:"portions,omitempty" gorm:"column:portions"`
-	PortionSize      string         `json:"portion_size,omitempty" gorm:"column:portion_size"`
-	SourceURL        string         `json:"source_url,omitempty" gorm:"column:source_url"`
-	UnitSystem       string         `json:"unit_system,omitempty" gorm:"column:unit_system"`
+	Portions          int            `json:"portions,omitempty" gorm:"column:portions"`
+	PortionSize       string         `json:"portion_size,omitempty" gorm:"column:portion_size"`
+	SourceURL         string         `json:"source_url,omitempty" gorm:"column:source_url"`
+	UnitSystem        string         `json:"unit_system,omitempty" gorm:"column:unit_system"`
 }
 
 // Scan is a GORM hook that scans jsonb into a RecipeDef.

--- a/internal/models/recipe.go
+++ b/internal/models/recipe.go
@@ -15,7 +15,7 @@ type Recipe struct {
 	// Ingredients  Ingredients    `gorm:"type:jsonb"` // Embedded slice of Ingredient
 	// Instructions pq.StringArray `gorm:"type:text[]"`
 	// CookTime      int
-	LinkedRecipes []*Recipe  `gorm:"many2many:recipe_linked_recipes;association_jointable_foreignkey:link_recipe_id"`
+	LinkedRecipes []*Recipe `gorm:"many2many:recipe_linked_recipes;association_jointable_foreignkey:link_recipe_id"`
 	// LinkedSuggestions  pq.StringArray `gorm:"type:text[]"`
 	Hashtags []*Tag `gorm:"many2many:recipe_tags;"`
 	// UserHashtags []*Tag `gorm:"many2many:recipe_tags;"`
@@ -25,17 +25,17 @@ type Recipe struct {
 	CreatedByID        uint
 	CreatedBy          *User `gorm:"foreignKey:CreatedByID"`
 	PersonalizationUID uuid.UUID
-	UserEdited         bool           `gorm:"default:false"`
-	ForkedFromID       *uint          `gorm:"index"`
-	ForkedFrom         *Recipe        `gorm:"-"` // loaded manually in repository to avoid self-referential GORM issues
-	TreeID             *uint          `gorm:"index"`
-	Tree               *RecipeTree    `gorm:"foreignKey:TreeID"`
-	OriginalImageURL   string         `json:"original_image_url,omitempty"`
-	Embedding          *string        `gorm:"type:vector(1536)" json:"-"`
-	CanonicalID        *uint              `gorm:"index"`
-	Canonical          *CanonicalRecipe   `gorm:"foreignKey:CanonicalID"`
-	HasDiverged        bool               `gorm:"default:false"`
-	PromptVersion      string             `json:"prompt_version,omitempty" gorm:"size:16"` // hash of prompt templates used
+	UserEdited         bool             `gorm:"default:false"`
+	ForkedFromID       *uint            `gorm:"index"`
+	ForkedFrom         *Recipe          `gorm:"-"` // loaded manually in repository to avoid self-referential GORM issues
+	TreeID             *uint            `gorm:"index"`
+	Tree               *RecipeTree      `gorm:"foreignKey:TreeID"`
+	OriginalImageURL   string           `json:"original_image_url,omitempty"`
+	Embedding          *string          `gorm:"type:vector(1536)" json:"-"`
+	CanonicalID        *uint            `gorm:"index"`
+	Canonical          *CanonicalRecipe `gorm:"foreignKey:CanonicalID"`
+	HasDiverged        bool             `gorm:"default:false"`
+	PromptVersion      string           `json:"prompt_version,omitempty" gorm:"size:16"` // hash of prompt templates used
 }
 
 // Tag is the model for a recipe hashtag.

--- a/internal/models/recipe.go
+++ b/internal/models/recipe.go
@@ -1,6 +1,8 @@
 package models
 
 import (
+	"time"
+
 	"github.com/google/uuid"
 	"gorm.io/gorm"
 )
@@ -59,28 +61,36 @@ const (
 )
 
 // RecipeTree is the model for a recipe's branching tree structure.
+// gorm.Model fields are declared explicitly so JSON serializes snake_case.
 type RecipeTree struct {
-	gorm.Model
-	RecipeID   uint         `gorm:"uniqueIndex;not null"`
-	RootNodeID *uint        `gorm:"index"`
-	RootNode   *RecipeNode  `gorm:"foreignKey:RootNodeID;constraint:OnUpdate:CASCADE,OnDelete:SET NULL"`
-	Nodes      []RecipeNode `gorm:"-"` // loaded manually to avoid circular migration
+	ID         uint           `gorm:"primarykey" json:"id"`
+	CreatedAt  time.Time      `json:"created_at"`
+	UpdatedAt  time.Time      `json:"updated_at"`
+	DeletedAt  gorm.DeletedAt `gorm:"index" json:"-"`
+	RecipeID   uint           `gorm:"uniqueIndex;not null" json:"recipe_id"`
+	RootNodeID *uint          `gorm:"index" json:"root_node_id"`
+	RootNode   *RecipeNode    `gorm:"foreignKey:RootNodeID;constraint:OnUpdate:CASCADE,OnDelete:SET NULL" json:"-"`
+	Nodes      []RecipeNode   `gorm:"-" json:"nodes,omitempty"` // loaded manually to avoid circular migration
 }
 
 // RecipeNode is the model for a single node in a recipe tree.
+// gorm.Model fields are declared explicitly so JSON serializes snake_case.
 type RecipeNode struct {
-	gorm.Model
-	TreeID      uint         `gorm:"index"`
-	ParentID    *uint        `gorm:"index"`
-	Parent      *RecipeNode  `gorm:"foreignKey:ParentID"`
-	Children    []RecipeNode `gorm:"-"` // loaded manually to avoid circular migration
-	Prompt      string
-	Response    *RecipeDef  `gorm:"type:jsonb"`
-	Summary     string
-	Type        RecipeType  `gorm:"type:text"`
-	BranchName  string      `gorm:"default:'original'"`
-	IsEphemeral bool        `gorm:"default:false"`
-	CreatedByID uint        `gorm:"index"`
-	CreatedBy   *User       `gorm:"foreignKey:CreatedByID"`
-	IsActive    bool        `gorm:"default:false"`
+	ID          uint           `gorm:"primarykey" json:"id"`
+	CreatedAt   time.Time      `json:"created_at"`
+	UpdatedAt   time.Time      `json:"updated_at"`
+	DeletedAt   gorm.DeletedAt `gorm:"index" json:"-"`
+	TreeID      uint           `gorm:"index" json:"tree_id"`
+	ParentID    *uint          `gorm:"index" json:"parent_id"`
+	Parent      *RecipeNode    `gorm:"foreignKey:ParentID" json:"-"`
+	Children    []RecipeNode   `gorm:"-" json:"-"` // loaded manually to avoid circular migration
+	Prompt      string         `json:"user_prompt"`
+	Response    *RecipeDef     `gorm:"type:jsonb" json:"response"`
+	Summary     string         `json:"summary"`
+	Type        RecipeType     `gorm:"type:text" json:"type"`
+	BranchName  string         `gorm:"default:'original'" json:"branch_name"`
+	IsEphemeral bool           `gorm:"default:false" json:"is_ephemeral"`
+	CreatedByID uint           `gorm:"index" json:"created_by_id"`
+	CreatedBy   *User          `gorm:"foreignKey:CreatedByID" json:"-"`
+	IsActive    bool           `gorm:"default:false" json:"is_active"`
 }

--- a/internal/models/user.go
+++ b/internal/models/user.go
@@ -28,6 +28,11 @@ type UserAuth struct {
 	UserID         uint `gorm:"unique;index"`
 	HashedPassword string
 	AuthType       UserAuthType `gorm:"type:text"`
+	// TokenVersion is embedded in refresh tokens as the "token_version" claim.
+	// Incrementing it (e.g. on logout) revokes all outstanding refresh tokens.
+	// Defaults to 0 so refresh tokens issued before this field existed (which
+	// carry no claim) remain valid.
+	TokenVersion int `gorm:"default:0"`
 }
 
 // UserAuthType is the type for the UserAuthType enum.

--- a/internal/models/user.go
+++ b/internal/models/user.go
@@ -12,11 +12,11 @@ import (
 // User is the model for a user.
 type User struct {
 	gorm.Model
-	Username  string    `gorm:"unique;index"`
-	FirstName string    `gorm:"default:null"`
-	Email     string    `gorm:"unique;default:null"`
-	Auth         *UserAuth     `gorm:"foreignKey:UserID"`
-	Subscription *Subscription `gorm:"foreignKey:UserID"`
+	Username         string           `gorm:"unique;index"`
+	FirstName        string           `gorm:"default:null"`
+	Email            string           `gorm:"unique;default:null"`
+	Auth             *UserAuth        `gorm:"foreignKey:UserID"`
+	Subscription     *Subscription    `gorm:"foreignKey:UserID"`
 	Settings         *UserSettings    `gorm:"foreignKey:UserID"`
 	Personalization  *Personalization `gorm:"foreignKey:UserID"`
 	CollectedRecipes []*Recipe        `gorm:"many2many:user_collected_recipes;"`
@@ -88,9 +88,9 @@ type Subscription struct {
 	UserID               uint             `gorm:"uniqueIndex;not null"`
 	Tier                 SubscriptionTier `gorm:"type:text;default:'free'"`
 	ExpiresAt            *time.Time
-	AllergenAnalysesUsed int              `gorm:"default:0"`
-	WebSearchesUsed      int              `gorm:"default:0"`
-	AIGenerationsUsed    int              `gorm:"default:0"`
+	AllergenAnalysesUsed int `gorm:"default:0"`
+	WebSearchesUsed      int `gorm:"default:0"`
+	AIGenerationsUsed    int `gorm:"default:0"`
 	MonthlyResetAt       time.Time
 }
 
@@ -156,10 +156,10 @@ type UserSettings struct {
 // Personalization is the model for a user's personalization settings.
 type Personalization struct {
 	gorm.Model
-	UserID         uint      `gorm:"unique;index"`
-	UnitSystem     string    `gorm:"type:text;default:'us_customary'"`
-	Requirements   string    // Additional instructions or guidelines
-	CookingContext string    `json:"cooking_context" gorm:"type:text"` // free-form cooking preferences injected into AI prompts
+	UserID         uint   `gorm:"unique;index"`
+	UnitSystem     string `gorm:"type:text;default:'us_customary'"`
+	Requirements   string // Additional instructions or guidelines
+	CookingContext string `json:"cooking_context" gorm:"type:text"` // free-form cooking preferences injected into AI prompts
 	UID            uuid.UUID
 }
 

--- a/internal/models/user.go
+++ b/internal/models/user.go
@@ -158,6 +158,15 @@ type Personalization struct {
 	UID            uuid.UUID
 }
 
+// PersonalizationUpdate carries a partial update to a user's Personalization.
+// Nil fields are left unchanged.
+type PersonalizationUpdate struct {
+	UnitSystem     *string
+	Requirements   *string
+	CookingContext *string
+	UID            *uuid.UUID
+}
+
 // UnitSystemText returns the display text for the current UnitSystem.
 func (p *Personalization) UnitSystemText() string {
 	switch p.UnitSystem {

--- a/internal/repository/errors.go
+++ b/internal/repository/errors.go
@@ -1,5 +1,15 @@
 package repository
 
+import "errors"
+
+// Sentinel errors for unique-constraint violations on user creation. Handlers
+// match these with errors.Is to return meaningful conflict responses without
+// leaking raw database errors.
+var (
+	ErrUsernameTaken = errors.New("username already in use")
+	ErrEmailTaken    = errors.New("email already in use")
+)
+
 // NotFoundError is an error type for when a resource is not found.
 type NotFoundError struct {
 	message string

--- a/internal/repository/interfaces.go
+++ b/internal/repository/interfaces.go
@@ -68,6 +68,6 @@ type UserRepo interface {
 	UpdateUserFirstName(userID uint, firstName string) error
 	UpdateUserEmail(userID uint, email string) error
 	UpdateUserSettingsKeepScreenAwake(userID uint, keepScreenAwake bool) error
-	UpdatePersonalization(userID uint, updatedPersonalization *models.Personalization) error
+	UpdatePersonalization(userID uint, update *models.PersonalizationUpdate) error
 	UsernameExists(username string) (bool, error)
 }

--- a/internal/repository/interfaces.go
+++ b/internal/repository/interfaces.go
@@ -60,6 +60,18 @@ type SearchCacheRepo interface {
 	DeleteStale(maxAge time.Duration) (int64, error)
 }
 
+// FamilyRepo is the interface for family repository operations.
+type FamilyRepo interface {
+	CreateFamily(family *models.Family) error
+	GetFamilyByOwnerID(ownerID uint) (*models.Family, error)
+	CreateFamilyMember(member *models.FamilyMember) error
+	GetFamilyMemberByID(id uint) (*models.FamilyMember, error)
+	UpdateFamilyMember(member *models.FamilyMember) error
+	DeleteFamilyMember(id uint) error
+	UpdateDietaryProfile(profile *models.DietaryProfile) error
+	GetOrCreateDietaryProfile(memberID uint) (*models.DietaryProfile, error)
+}
+
 // UserRepo is the interface for user repository operations.
 type UserRepo interface {
 	CreateUser(user *models.User) (*models.User, error)
@@ -79,3 +91,4 @@ type UserRepo interface {
 
 // Compile-time check that the concrete repository satisfies the interface.
 var _ UserRepo = (*UserRepository)(nil)
+var _ FamilyRepo = (*FamilyRepository)(nil)

--- a/internal/repository/interfaces.go
+++ b/internal/repository/interfaces.go
@@ -64,10 +64,18 @@ type SearchCacheRepo interface {
 type UserRepo interface {
 	CreateUser(user *models.User) (*models.User, error)
 	GetUserByID(userID uint) (*models.User, error)
+	GetUserWithAuthByID(userID uint) (*models.User, error)
 	GetUserAuthByUsername(username string) (*models.User, error)
 	UpdateUserFirstName(userID uint, firstName string) error
 	UpdateUserEmail(userID uint, email string) error
 	UpdateUserSettingsKeepScreenAwake(userID uint, keepScreenAwake bool) error
 	UpdatePersonalization(userID uint, update *models.PersonalizationUpdate) error
 	UsernameExists(username string) (bool, error)
+	IncrementTokenVersion(userID uint) error
+	CreateSubscription(sub *models.Subscription) error
+	IncrementSubscriptionUsage(userID uint, column string) error
+	ResetSubscriptionUsage(userID uint, nextReset time.Time) error
 }
+
+// Compile-time check that the concrete repository satisfies the interface.
+var _ UserRepo = (*UserRepository)(nil)

--- a/internal/repository/interfaces.go
+++ b/internal/repository/interfaces.go
@@ -72,6 +72,15 @@ type FamilyRepo interface {
 	GetOrCreateDietaryProfile(memberID uint) (*models.DietaryProfile, error)
 }
 
+// AllergenRepo is the interface for allergen analysis repository operations.
+type AllergenRepo interface {
+	CreateAnalysis(analysis *models.AllergenAnalysis) error
+	GetAnalysisByRecipeID(recipeID uint) (*models.AllergenAnalysis, error)
+	GetAnalysisByNodeID(nodeID uint) (*models.AllergenAnalysis, error)
+	UpdateAnalysis(analysis *models.AllergenAnalysis) error
+	DeleteAnalysisByRecipeID(recipeID uint) error
+}
+
 // UserRepo is the interface for user repository operations.
 type UserRepo interface {
 	CreateUser(user *models.User) (*models.User, error)
@@ -92,3 +101,4 @@ type UserRepo interface {
 // Compile-time check that the concrete repository satisfies the interface.
 var _ UserRepo = (*UserRepository)(nil)
 var _ FamilyRepo = (*FamilyRepository)(nil)
+var _ AllergenRepo = (*AllergenRepository)(nil)

--- a/internal/repository/interfaces.go
+++ b/internal/repository/interfaces.go
@@ -32,6 +32,15 @@ type RecipeRepo interface {
 	MaterializeRecipeFromCanonical(recipeID uint, data models.RecipeDef) error
 }
 
+// VectorRepo is the interface for pgvector similarity search operations.
+type VectorRepo interface {
+	FindSimilar(embeddingLiteral string, excludeRecipeID uint, limit int) ([]models.Recipe, error)
+	GetRecipeEmbedding(recipeID uint) (*string, error)
+	UpdateEmbedding(recipeID uint, embedding []float32) error
+	SearchUserRecipesByEmbedding(userID uint, embeddingLiteral string, limit int) ([]models.Recipe, error)
+	SearchUserRecipesByTitle(userID uint, query string, onlyMissingEmbedding bool, limit int) ([]models.Recipe, error)
+}
+
 // CanonicalRecipeRepo is the interface for canonical recipe repository operations.
 type CanonicalRecipeRepo interface {
 	GetByID(id uint) (*models.CanonicalRecipe, error)

--- a/internal/repository/pgvector_test.go
+++ b/internal/repository/pgvector_test.go
@@ -1,0 +1,55 @@
+package repository
+
+import (
+	"strconv"
+	"strings"
+	"testing"
+)
+
+func TestPgvectorLiteral_Formatting(t *testing.T) {
+	tests := []struct {
+		name string
+		in   []float32
+		want string
+	}{
+		{"empty slice", []float32{}, "[]"},
+		{"nil slice", nil, "[]"},
+		{"single value", []float32{0.5}, "[0.5]"},
+		{"multiple values", []float32{0.1, 0.2, 0.3}, "[0.1,0.2,0.3]"},
+		{"negative and zero", []float32{-1.5, 0, 2}, "[-1.5,0,2]"},
+		{"large value uses exponent", []float32{1e10}, "[1e+10]"},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got := PgvectorLiteral(tc.in)
+			if got != tc.want {
+				t.Errorf("PgvectorLiteral(%v) = %q, want %q", tc.in, got, tc.want)
+			}
+		})
+	}
+}
+
+func TestPgvectorLiteral_RoundTrip(t *testing.T) {
+	in := []float32{0.1, -2.5, 3.1415927, 1e-7, 12345.678, -0.000123}
+
+	literal := PgvectorLiteral(in)
+	if !strings.HasPrefix(literal, "[") || !strings.HasSuffix(literal, "]") {
+		t.Fatalf("literal %q is not bracketed", literal)
+	}
+
+	parts := strings.Split(strings.Trim(literal, "[]"), ",")
+	if len(parts) != len(in) {
+		t.Fatalf("literal has %d components, want %d: %q", len(parts), len(in), literal)
+	}
+
+	for i, part := range parts {
+		f, err := strconv.ParseFloat(part, 32)
+		if err != nil {
+			t.Fatalf("component %d (%q) does not parse as float: %v", i, part, err)
+		}
+		if float32(f) != in[i] {
+			t.Errorf("component %d round-tripped to %g, want %g", i, float32(f), in[i])
+		}
+	}
+}

--- a/internal/repository/recipe.go
+++ b/internal/repository/recipe.go
@@ -97,9 +97,27 @@ func (r *RecipeRepository) CreateRecipe(recipe *models.Recipe) error {
 	return tx.Commit().Error
 }
 
-// DeleteRecipe deletes a recipe.
+// DeleteRecipe deletes a recipe along with its tree and nodes. The recipe row
+// is soft-deleted, so the FK ON DELETE cascade never fires — the tree and its
+// nodes are deleted explicitly in the same transaction.
 func (r *RecipeRepository) DeleteRecipe(recipeID uint) error {
-	err := r.DB.Delete(&models.Recipe{}, recipeID).Error
+	err := r.DB.Transaction(func(tx *gorm.DB) error {
+		var tree models.RecipeTree
+		treeErr := tx.Where("recipe_id = ?", recipeID).First(&tree).Error
+		switch {
+		case treeErr == nil:
+			if err := tx.Where("tree_id = ?", tree.ID).Delete(&models.RecipeNode{}).Error; err != nil {
+				return err
+			}
+			if err := tx.Delete(&tree).Error; err != nil {
+				return err
+			}
+		case !errors.Is(treeErr, gorm.ErrRecordNotFound):
+			return treeErr
+		}
+
+		return tx.Delete(&models.Recipe{}, recipeID).Error
+	})
 	if err != nil {
 		logger.Get().Error("failed to delete recipe", zap.Uint("recipe_id", recipeID), zap.Error(err))
 	}

--- a/internal/repository/search_cache.go
+++ b/internal/repository/search_cache.go
@@ -42,7 +42,7 @@ func (r *SearchCacheRepository) IncrementHitCount(id uint) error {
 	return r.DB.Model(&models.SearchCache{}).
 		Where("id = ?", id).
 		Updates(map[string]interface{}{
-			"hit_count":      gorm.Expr("hit_count + 1"),
+			"hit_count":        gorm.Expr("hit_count + 1"),
 			"last_accessed_at": time.Now(),
 		}).Error
 }

--- a/internal/repository/user.go
+++ b/internal/repository/user.go
@@ -33,9 +33,9 @@ func (r *UserRepository) CreateUser(user *models.User) (*models.User, error) {
 		// Check for unique constraints
 		if pgErr, ok := err.(*pq.Error); ok && pgErr.Code == "23505" {
 			if strings.Contains(pgErr.Error(), "username") {
-				return nil, errors.New("username already in use")
+				return nil, ErrUsernameTaken
 			} else if strings.Contains(pgErr.Error(), "email") {
-				return nil, errors.New("email already in use")
+				return nil, ErrEmailTaken
 			}
 		}
 		return nil, err
@@ -50,6 +50,19 @@ func (r *UserRepository) GetUserByID(userID uint) (*models.User, error) {
 	if err := r.DB.Preload("Settings").
 		Preload("Personalization").
 		Preload("Subscription").
+		Where("id = ?", userID).
+		First(&user).Error; err != nil {
+		return nil, err
+	}
+
+	return &user, nil
+}
+
+// GetUserWithAuthByID retrieves a user with their auth record preloaded.
+// Used by the refresh-token flow to check the current token version.
+func (r *UserRepository) GetUserWithAuthByID(userID uint) (*models.User, error) {
+	var user models.User
+	if err := r.DB.Preload("Auth").
 		Where("id = ?", userID).
 		First(&user).Error; err != nil {
 		return nil, err
@@ -140,6 +153,33 @@ func (r *UserRepository) UpdatePersonalization(userID uint, update *models.Perso
 	}
 
 	return err
+}
+
+// IncrementTokenVersion atomically increments a user's refresh-token version,
+// revoking all outstanding refresh tokens. UpdateColumn skips GORM hooks so
+// the UserAuth BeforeUpdate AuthType validation does not apply.
+func (r *UserRepository) IncrementTokenVersion(userID uint) error {
+	result := r.DB.Model(&models.UserAuth{}).
+		Where("user_id = ?", userID).
+		UpdateColumn("token_version", gorm.Expr("token_version + 1"))
+	if result.Error != nil {
+		logger.Get().Error("failed to increment token version", zap.Uint("user_id", userID), zap.Error(result.Error))
+		return result.Error
+	}
+	if result.RowsAffected == 0 {
+		return errors.New("no auth record found for user")
+	}
+	return nil
+}
+
+// CreateSubscription creates a subscription row for a user. Used to backfill
+// users that predate subscription rows being created at signup.
+func (r *UserRepository) CreateSubscription(sub *models.Subscription) error {
+	if err := r.DB.Create(sub).Error; err != nil {
+		logger.Get().Error("failed to create subscription", zap.Uint("user_id", sub.UserID), zap.Error(err))
+		return err
+	}
+	return nil
 }
 
 // IncrementSubscriptionUsage atomically increments a usage counter on the

--- a/internal/repository/user.go
+++ b/internal/repository/user.go
@@ -105,8 +105,10 @@ func (r *UserRepository) UpdateUserSettingsKeepScreenAwake(userID uint, keepScre
 	return err
 }
 
-// UpdatePersonalization updates a user's personalization settings.
-func (r *UserRepository) UpdatePersonalization(userID uint, updatedPersonalization *models.Personalization) error {
+// UpdatePersonalization partially updates a user's personalization settings.
+// Only non-nil fields in the update are written; nil fields keep their
+// current values.
+func (r *UserRepository) UpdatePersonalization(userID uint, update *models.PersonalizationUpdate) error {
 	var existingPersonalization models.Personalization
 
 	// First, find the existing record
@@ -117,11 +119,19 @@ func (r *UserRepository) UpdatePersonalization(userID uint, updatedPersonalizati
 		return err
 	}
 
-	// Update fields
-	existingPersonalization.UnitSystem = updatedPersonalization.UnitSystem
-	existingPersonalization.Requirements = updatedPersonalization.Requirements
-	existingPersonalization.CookingContext = updatedPersonalization.CookingContext
-	existingPersonalization.UID = updatedPersonalization.UID
+	// Apply only the fields present in the update
+	if update.UnitSystem != nil {
+		existingPersonalization.UnitSystem = *update.UnitSystem
+	}
+	if update.Requirements != nil {
+		existingPersonalization.Requirements = *update.Requirements
+	}
+	if update.CookingContext != nil {
+		existingPersonalization.CookingContext = *update.CookingContext
+	}
+	if update.UID != nil {
+		existingPersonalization.UID = *update.UID
+	}
 
 	// Perform the update
 	err = r.DB.Save(&existingPersonalization).Error

--- a/internal/repository/vector.go
+++ b/internal/repository/vector.go
@@ -7,6 +7,15 @@ import (
 	"gorm.io/gorm"
 )
 
+// SimilarRecipeDistanceThreshold is the maximum cosine distance for a recipe
+// to be considered similar to another recipe.
+const SimilarRecipeDistanceThreshold = 0.65
+
+// UserSearchDistanceThreshold is the maximum cosine distance for a recipe to
+// match a user's semantic search query. It is looser than the similar-recipe
+// threshold because query text is much shorter than recipe text.
+const UserSearchDistanceThreshold = 0.75
+
 // VectorRepository handles pgvector similarity search operations.
 type VectorRepository struct {
 	DB *gorm.DB
@@ -17,18 +26,30 @@ func NewVectorRepository(db *gorm.DB) *VectorRepository {
 	return &VectorRepository{DB: db}
 }
 
-// FindSimilar finds recipes similar to the given embedding vector using cosine similarity.
-func (r *VectorRepository) FindSimilar(embedding []float32, limit int) ([]models.Recipe, error) {
+// Compile-time interface check.
+var _ VectorRepo = (*VectorRepository)(nil)
+
+// FindSimilar finds recipes similar to the given embedding (a pgvector literal)
+// using cosine distance. The source recipe is excluded and only matches within
+// SimilarRecipeDistanceThreshold are returned.
+func (r *VectorRepository) FindSimilar(embeddingLiteral string, excludeRecipeID uint, limit int) ([]models.Recipe, error) {
 	if limit <= 0 {
 		limit = 10
 	}
 
+	distanceExpr := fmt.Sprintf("embedding <=> '%s'", embeddingLiteral)
+
 	var recipes []models.Recipe
 	err := r.DB.
-		Preload("CreatedBy").
 		Preload("Hashtags").
+		Preload("Canonical").
+		Preload("CreatedBy", func(db *gorm.DB) *gorm.DB {
+			return db.Select("ID", "Username")
+		}).
 		Where("embedding IS NOT NULL").
-		Order(fmt.Sprintf("embedding <=> '%v'", PgvectorLiteral(embedding))).
+		Where("id != ?", excludeRecipeID).
+		Where(distanceExpr+" < ?", SimilarRecipeDistanceThreshold).
+		Order(distanceExpr).
 		Limit(limit).
 		Find(&recipes).Error
 	if err != nil {
@@ -38,6 +59,22 @@ func (r *VectorRepository) FindSimilar(embedding []float32, limit int) ([]models
 	return recipes, nil
 }
 
+// GetRecipeEmbedding returns the stored embedding literal for a recipe, or nil
+// when the recipe has no embedding.
+func (r *VectorRepository) GetRecipeEmbedding(recipeID uint) (*string, error) {
+	var row struct {
+		Embedding *string
+	}
+	err := r.DB.Model(&models.Recipe{}).
+		Select("embedding").
+		Where("id = ?", recipeID).
+		First(&row).Error
+	if err != nil {
+		return nil, fmt.Errorf("failed to get recipe embedding: %w", err)
+	}
+	return row.Embedding, nil
+}
+
 // UpdateEmbedding sets the embedding vector for a recipe.
 func (r *VectorRepository) UpdateEmbedding(recipeID uint, embedding []float32) error {
 	err := r.DB.Model(&models.Recipe{}).
@@ -45,6 +82,122 @@ func (r *VectorRepository) UpdateEmbedding(recipeID uint, embedding []float32) e
 		Update("embedding", PgvectorLiteral(embedding)).Error
 	if err != nil {
 		return fmt.Errorf("failed to update embedding: %w", err)
+	}
+	return nil
+}
+
+// SearchUserRecipesByEmbedding performs a semantic search over a user's own
+// recipes using cosine distance against the given embedding literal.
+func (r *VectorRepository) SearchUserRecipesByEmbedding(userID uint, embeddingLiteral string, limit int) ([]models.Recipe, error) {
+	if limit <= 0 {
+		limit = 10
+	}
+
+	distanceExpr := fmt.Sprintf("embedding <=> '%s'", embeddingLiteral)
+
+	var recipes []models.Recipe
+	err := r.DB.
+		Preload("Hashtags").
+		Preload("Canonical").
+		Preload("CreatedBy", func(db *gorm.DB) *gorm.DB {
+			return db.Select("ID", "Username")
+		}).
+		Where("created_by_id = ?", userID).
+		Where("embedding IS NOT NULL").
+		Where(distanceExpr+" < ?", UserSearchDistanceThreshold).
+		Order(distanceExpr).
+		Limit(limit).
+		Find(&recipes).Error
+	if err != nil {
+		return nil, fmt.Errorf("failed to search user recipes by embedding: %w", err)
+	}
+
+	return recipes, nil
+}
+
+// SearchUserRecipesByTitle performs an ILIKE title match over a user's own
+// recipes. When onlyMissingEmbedding is true, only recipes without an
+// embedding are considered (used to complement a vector search).
+func (r *VectorRepository) SearchUserRecipesByTitle(userID uint, query string, onlyMissingEmbedding bool, limit int) ([]models.Recipe, error) {
+	if limit <= 0 {
+		limit = 10
+	}
+
+	q := r.DB.
+		Preload("Hashtags").
+		Preload("Canonical").
+		Preload("CreatedBy", func(db *gorm.DB) *gorm.DB {
+			return db.Select("ID", "Username")
+		}).
+		Where("created_by_id = ?", userID).
+		Where("title ILIKE ?", "%"+query+"%")
+
+	if onlyMissingEmbedding {
+		q = q.Where("embedding IS NULL")
+	}
+
+	var recipes []models.Recipe
+	err := q.Order("created_at DESC").
+		Limit(limit).
+		Find(&recipes).Error
+	if err != nil {
+		return nil, fmt.Errorf("failed to search user recipes by title: %w", err)
+	}
+
+	return recipes, nil
+}
+
+// ListRecipesMissingEmbedding returns a batch of recipes without an embedding,
+// ordered by ID, starting after afterID. Used by the embedding backfill task.
+func (r *VectorRepository) ListRecipesMissingEmbedding(afterID uint, limit int) ([]models.Recipe, error) {
+	if limit <= 0 {
+		limit = 25
+	}
+
+	var recipes []models.Recipe
+	err := r.DB.
+		Preload("Canonical").
+		Where("embedding IS NULL").
+		Where("id > ?", afterID).
+		Order("id ASC").
+		Limit(limit).
+		Find(&recipes).Error
+	if err != nil {
+		return nil, fmt.Errorf("failed to list recipes missing embedding: %w", err)
+	}
+
+	return recipes, nil
+}
+
+// ListCanonicalsMissingEmbedding returns a batch of canonical recipes without
+// an embedding, ordered by ID, starting after afterID. Used by the embedding
+// backfill task.
+func (r *VectorRepository) ListCanonicalsMissingEmbedding(afterID uint, limit int) ([]models.CanonicalRecipe, error) {
+	if limit <= 0 {
+		limit = 25
+	}
+
+	var entries []models.CanonicalRecipe
+	err := r.DB.
+		Where("embedding IS NULL").
+		Where("id > ?", afterID).
+		Order("id ASC").
+		Limit(limit).
+		Find(&entries).Error
+	if err != nil {
+		return nil, fmt.Errorf("failed to list canonicals missing embedding: %w", err)
+	}
+
+	return entries, nil
+}
+
+// UpdateCanonicalEmbedding sets the embedding vector for a canonical recipe.
+func (r *VectorRepository) UpdateCanonicalEmbedding(canonicalID uint, embedding []float32) error {
+	err := r.DB.Model(&models.CanonicalRecipe{}).
+		Where("id = ?", canonicalID).
+		Update("embedding", PgvectorLiteral(embedding)).Error
+	if err != nil {
+		return fmt.Errorf("failed to update canonical embedding: %w", err)
 	}
 	return nil
 }

--- a/internal/router/router.go
+++ b/internal/router/router.go
@@ -67,6 +67,8 @@ func SetupRouter(cfg *config.Config, database *gorm.DB) *gin.Engine {
 	canonicalRepo := repository.NewCanonicalRecipeRepository(database)
 	importService := service.NewImportService(cfg, recipeRepo, recipeService, textProvider, textProvider, previewProvider)
 	importService.CanonicalRepo = canonicalRepo
+	// Portion estimation for imports that lack a serving count (cheap Haiku task)
+	importService.Normalize = service.NewNormalizeService(cfg, previewProvider)
 	importHandler := handlers.NewImportHandler(importService)
 	// MultiResolver is wired later after search setup; set via field
 

--- a/internal/router/router.go
+++ b/internal/router/router.go
@@ -1,6 +1,8 @@
 package router
 
 import (
+	"time"
+
 	"github.com/gin-contrib/cors"
 	"github.com/gin-gonic/gin"
 	"github.com/windoze95/saltybytes-api/internal/ai"
@@ -27,6 +29,7 @@ func SetupRouter(cfg *config.Config, database *gorm.DB) *gin.Engine {
 		"https://saltybytes.ai",
 		"https://www.saltybytes.ai",
 	}
+	config.AddAllowHeaders("Authorization", "X-SaltyBytes-Identifier")
 	r.Use(cors.New(config))
 
 	// Add request ID middleware for request correlation
@@ -44,6 +47,10 @@ func SetupRouter(cfg *config.Config, database *gorm.DB) *gin.Engine {
 	userService := service.NewUserService(cfg, userRepo)
 	userHandler := handlers.NewUserHandler(userService)
 
+	// Subscription service (shared by AI-generation, allergen, search and
+	// subscription routes for usage gating)
+	subService := service.NewSubscriptionService(cfg, userRepo)
+
 	// AI provider setup
 	textProvider := ai.NewAnthropicProvider(cfg.EnvVars.AnthropicAPIKey, cfg.Prompts)
 	imageProvider := ai.NewDALLEProvider(cfg.EnvVars.OpenAIAPIKey)
@@ -60,6 +67,7 @@ func SetupRouter(cfg *config.Config, database *gorm.DB) *gin.Engine {
 	recipeService.EmbedProvider = embedProvider
 	recipeService.VectorRepo = vectorRepo
 	recipeHandler := handlers.NewRecipeHandler(recipeService)
+	recipeHandler.SubService = subService
 
 	// Import-related routes setup
 	previewProvider := ai.NewAnthropicLightProvider(cfg.EnvVars.AnthropicAPIKey, cfg.Prompts)
@@ -75,6 +83,9 @@ func SetupRouter(cfg *config.Config, database *gorm.DB) *gin.Engine {
 	// Group for API routes that don't require token verification
 	apiPublic := r.Group("/v1")
 	apiPublic.Use(middleware.CheckIDHeader(cfg.EnvVars.IDHeader))
+	// Rate-limit the public auth endpoints per IP (5 req/min, burst 10) to
+	// slow down credential stuffing and signup abuse.
+	apiPublic.Use(middleware.RateLimitByIP(5, 10, 5*time.Minute, 15*time.Minute))
 	{
 		// User-related routes
 
@@ -94,6 +105,8 @@ func SetupRouter(cfg *config.Config, database *gorm.DB) *gin.Engine {
 
 		// User-related routes
 
+		// Log out: revoke all outstanding refresh tokens
+		apiProtected.POST("/auth/logout", middleware.AttachUserToContext(userService), userHandler.Logout)
 		// Verify a user's token
 		apiProtected.GET("/users/verify", middleware.AttachUserToContext(userService), userHandler.VerifyToken)
 		// Get a user by their ID
@@ -151,9 +164,6 @@ func SetupRouter(cfg *config.Config, database *gorm.DB) *gin.Engine {
 	apiProtected.DELETE("/family/members/:member_id", middleware.AttachUserToContext(userService), familyHandler.DeleteMember)
 	apiProtected.PUT("/family/members/:member_id/dietary", middleware.AttachUserToContext(userService), familyHandler.UpdateDietaryProfile)
 	apiProtected.POST("/family/members/:member_id/dietary/interview", middleware.AttachUserToContext(userService), familyHandler.DietaryInterview)
-
-	// Subscription service (shared by allergen + subscription routes)
-	subService := service.NewSubscriptionService(cfg, userRepo)
 
 	// Allergen analysis routes setup
 	allergenRepo := repository.NewAllergenRepository(database)

--- a/internal/router/router.go
+++ b/internal/router/router.go
@@ -52,7 +52,7 @@ func SetupRouter(cfg *config.Config, database *gorm.DB) *gin.Engine {
 	subService := service.NewSubscriptionService(cfg, userRepo)
 
 	// AI provider setup
-	textProvider := ai.NewAnthropicProvider(cfg.EnvVars.AnthropicAPIKey, cfg.Prompts)
+	textProvider := ai.NewAnthropicProvider(cfg.EnvVars.AnthropicAPIKey, cfg.EnvVars.AnthropicModel, cfg.Prompts)
 	imageProvider := ai.NewDALLEProvider(cfg.EnvVars.OpenAIAPIKey)
 
 	// AI observability middleware
@@ -70,7 +70,7 @@ func SetupRouter(cfg *config.Config, database *gorm.DB) *gin.Engine {
 	recipeHandler.SubService = subService
 
 	// Import-related routes setup
-	previewProvider := ai.NewAnthropicLightProvider(cfg.EnvVars.AnthropicAPIKey, cfg.Prompts)
+	previewProvider := ai.NewAnthropicLightProvider(cfg.EnvVars.AnthropicAPIKey, cfg.EnvVars.AnthropicLightModel, cfg.Prompts)
 	previewProvider.WithMiddleware(aiMW)
 	canonicalRepo := repository.NewCanonicalRecipeRepository(database)
 	importService := service.NewImportService(cfg, recipeRepo, recipeService, textProvider, textProvider, previewProvider)

--- a/internal/router/router.go
+++ b/internal/router/router.go
@@ -82,11 +82,6 @@ func SetupRouter(cfg *config.Config, database *gorm.DB) *gin.Engine {
 		apiPublic.POST("/auth/login", userHandler.LoginUser)
 		// Refresh an access token
 		apiPublic.POST("/auth/refresh", userHandler.RefreshToken)
-
-		// Recipe-related routes
-
-		// Get a single recipe by it's ID
-		apiPublic.GET("/recipes/:recipe_id", recipeHandler.GetRecipe)
 	}
 
 	// Group for API routes that require token verification
@@ -106,6 +101,10 @@ func SetupRouter(cfg *config.Config, database *gorm.DB) *gin.Engine {
 
 		// Recipe-related routes
 
+		// Get a single recipe by its ID (any authenticated user may view any
+		// recipe; kept out of the public group to prevent anonymous
+		// sequential-ID enumeration)
+		apiProtected.GET("/recipes/:recipe_id", middleware.AttachUserToContext(userService), recipeHandler.GetRecipe)
 		// List the authenticated user's recipes
 		apiProtected.GET("/recipes", middleware.AttachUserToContext(userService), recipeHandler.ListRecipes)
 		// Generate a new recipe with chat
@@ -129,6 +128,8 @@ func SetupRouter(cfg *config.Config, database *gorm.DB) *gin.Engine {
 
 		// Recipe tree/branching routes
 		treeService := service.NewRecipeTreeService(cfg, recipeRepo)
+		treeService.EmbedProvider = embedProvider
+		treeService.VectorRepo = vectorRepo
 		treeHandler := handlers.NewRecipeTreeHandler(treeService)
 
 		apiProtected.GET("/recipes/:recipe_id/tree", middleware.AttachUserToContext(userService), treeHandler.GetTree)
@@ -176,6 +177,9 @@ func SetupRouter(cfg *config.Config, database *gorm.DB) *gin.Engine {
 	searchService.EmbedProvider = embedProvider
 	searchService.StartBackgroundTasks()
 	importService.StartCanonicalBackgroundTasks()
+
+	// Backfill missing recipe/canonical embeddings in the background
+	service.StartEmbeddingBackfill(vectorRepo, embedProvider)
 
 	// Multi-recipe resolution (detection happens on click via preview, not search)
 	multiRegistry := service.NewMultiRecipeRegistry()

--- a/internal/router/router.go
+++ b/internal/router/router.go
@@ -13,6 +13,7 @@ import (
 	"github.com/windoze95/saltybytes-api/internal/repository"
 	"github.com/windoze95/saltybytes-api/internal/service"
 	"github.com/windoze95/saltybytes-api/internal/ws"
+	"go.uber.org/zap"
 	"gorm.io/gorm"
 )
 
@@ -20,6 +21,15 @@ import (
 func SetupRouter(cfg *config.Config, database *gorm.DB) *gin.Engine {
 	// Create default Gin router
 	r := gin.Default()
+
+	// Trust only the load balancer in front of the app (private VPC ranges).
+	// Gin's default trusts every hop, which lets clients spoof
+	// X-Forwarded-For and defeat the per-IP rate limiting below. With this
+	// set, ClientIP() resolves to the rightmost non-private address in the
+	// chain (the real client as seen by the ALB).
+	if err := r.SetTrustedProxies([]string{"10.0.0.0/8", "172.16.0.0/12", "192.168.0.0/16", "127.0.0.1", "::1"}); err != nil {
+		logger.Get().Error("failed to set trusted proxies", zap.Error(err))
+	}
 
 	config := cors.DefaultConfig()
 	config.AllowCredentials = true

--- a/internal/s3/s3.go
+++ b/internal/s3/s3.go
@@ -4,12 +4,16 @@ import (
 	"bytes"
 	"context"
 	"fmt"
+	"net/url"
+	"strings"
+	"time"
 
 	"github.com/aws/aws-sdk-go-v2/aws"
 	awsconfig "github.com/aws/aws-sdk-go-v2/config"
 	"github.com/aws/aws-sdk-go-v2/credentials"
 	"github.com/aws/aws-sdk-go-v2/feature/s3/manager"
 	"github.com/aws/aws-sdk-go-v2/service/s3"
+	"github.com/google/uuid"
 	"github.com/windoze95/saltybytes-api/internal/config"
 )
 
@@ -37,8 +41,10 @@ func newS3Client(ctx context.Context, cfg *config.Config) (*s3.Client, error) {
 	return s3.NewFromConfig(awsCfg), nil
 }
 
-// UploadRecipeImageToS3 uploads a given byte array to an S3 bucket and returns the location URL.
-func UploadRecipeImageToS3(ctx context.Context, cfg *config.Config, imgBytes []byte, s3Key string) (string, error) {
+// UploadRecipeImageToS3 uploads a given byte array to an S3 bucket and returns
+// the location URL. contentType, when non-empty, is stored as the object's
+// Content-Type so browsers and CDNs serve the image correctly.
+func UploadRecipeImageToS3(ctx context.Context, cfg *config.Config, imgBytes []byte, s3Key string, contentType string) (string, error) {
 	client, err := newS3Client(ctx, cfg)
 	if err != nil {
 		return "", err
@@ -46,11 +52,16 @@ func UploadRecipeImageToS3(ctx context.Context, cfg *config.Config, imgBytes []b
 
 	uploader := manager.NewUploader(client)
 
-	result, err := uploader.Upload(ctx, &s3.PutObjectInput{
+	input := &s3.PutObjectInput{
 		Bucket: aws.String(cfg.EnvVars.S3Bucket),
 		Key:    aws.String(s3Key),
 		Body:   bytes.NewReader(imgBytes),
-	})
+	}
+	if contentType != "" {
+		input.ContentType = aws.String(contentType)
+	}
+
+	result, err := uploader.Upload(ctx, input)
 	if err != nil {
 		return "", fmt.Errorf("failed to upload to S3: %v", err)
 	}
@@ -76,7 +87,53 @@ func DeleteRecipeImageFromS3(ctx context.Context, cfg *config.Config, s3Key stri
 	return nil
 }
 
-// GenerateS3Key generates the S3 key for a recipe image, given the recipe ID.
+// GenerateS3Key generates a timestamp-versioned S3 key for a generated recipe
+// image. Versioning the key gives regenerated images a fresh URL so URL-keyed
+// caches (Flutter cached_network_image, CDNs) pick up the new image. Generated
+// images are DALL-E PNG bytes, hence the .png extension.
 func GenerateS3Key(recipeID uint) string {
-	return fmt.Sprintf("recipes/%d/images/recipe_image_%d.jpg", recipeID, recipeID)
+	return generateS3KeyAt(recipeID, time.Now().Unix())
+}
+
+// generateS3KeyAt is the deterministic core of GenerateS3Key, split out for testing.
+func generateS3KeyAt(recipeID uint, unixTS int64) string {
+	return fmt.Sprintf("recipes/%d/images/recipe_image_%d_%d.png", recipeID, recipeID, unixTS)
+}
+
+// GenerateUploadKey generates a collision-free S3 key for a user-uploaded
+// image. The key is server-generated (never derived from the client filename)
+// so uploads cannot overwrite each other or smuggle path segments. ext must
+// include the leading dot (e.g. ".png").
+func GenerateUploadKey(userID uint, ext string) string {
+	return fmt.Sprintf("uploads/%d/images/%s%s", userID, uuid.NewString(), ext)
+}
+
+// S3KeyFromURL derives the S3 object key from an object URL previously
+// returned by an upload. Returns "" when the URL is empty or cannot be parsed.
+func S3KeyFromURL(imageURL string) string {
+	if imageURL == "" {
+		return ""
+	}
+
+	u, err := url.Parse(imageURL)
+	if err != nil {
+		return ""
+	}
+
+	key := strings.TrimPrefix(u.Path, "/")
+
+	// Path-style URLs (https://s3.<region>.amazonaws.com/<bucket>/<key>)
+	// include the bucket as the first path segment; strip it. Virtual-hosted
+	// URLs (https://<bucket>.s3.<region>.amazonaws.com/<key>) do not.
+	if strings.HasPrefix(u.Host, "s3.") || strings.HasPrefix(u.Host, "s3-") {
+		if i := strings.Index(key, "/"); i >= 0 {
+			key = key[i+1:]
+		}
+	}
+
+	if unescaped, err := url.PathUnescape(key); err == nil {
+		key = unescaped
+	}
+
+	return key
 }

--- a/internal/s3/s3.go
+++ b/internal/s3/s3.go
@@ -125,7 +125,7 @@ func S3KeyFromURL(imageURL string) string {
 	// Path-style URLs (https://s3.<region>.amazonaws.com/<bucket>/<key>)
 	// include the bucket as the first path segment; strip it. Virtual-hosted
 	// URLs (https://<bucket>.s3.<region>.amazonaws.com/<key>) do not.
-	if strings.HasPrefix(u.Host, "s3.") || strings.HasPrefix(u.Host, "s3-") {
+	if isPathStyleS3Host(u.Host) {
 		if i := strings.Index(key, "/"); i >= 0 {
 			key = key[i+1:]
 		}
@@ -135,5 +135,48 @@ func S3KeyFromURL(imageURL string) string {
 		key = unescaped
 	}
 
+	return key
+}
+
+// isPathStyleS3Host reports whether the host is a bare S3 service endpoint
+// (path-style: "s3.<region>.amazonaws.com", "s3-<region>.amazonaws.com", or
+// "s3.amazonaws.com"). Virtual-hosted hosts carry the bucket as a subdomain
+// ("<bucket>.s3.<region>.amazonaws.com") — including buckets whose own name
+// starts with "s3-" — and must not have a path segment stripped.
+func isPathStyleS3Host(host string) bool {
+	if host == "s3.amazonaws.com" {
+		return true
+	}
+	rest, ok := strings.CutSuffix(host, ".amazonaws.com")
+	if !ok {
+		return false
+	}
+	var region string
+	switch {
+	case strings.HasPrefix(rest, "s3."):
+		region = rest[len("s3."):]
+	case strings.HasPrefix(rest, "s3-"):
+		region = rest[len("s3-"):]
+	default:
+		return false
+	}
+	// A bucket subdomain would introduce extra dots before the s3 label.
+	return region != "" && !strings.Contains(region, ".")
+}
+
+// RecipeImageKeyFromURL derives the deletable S3 key for a recipe's image
+// from its stored URL, returning "" unless the key lies under the recipe's
+// own "recipes/<recipeID>/" prefix. A recipe's ImageURL can be
+// client-supplied (manual import) or scraped from external pages (JSON-LD),
+// so a key derived from it must never be trusted to reference objects
+// outside the recipe's own folder.
+func RecipeImageKeyFromURL(imageURL string, recipeID uint) string {
+	key := S3KeyFromURL(imageURL)
+	if key == "" {
+		return ""
+	}
+	if !strings.HasPrefix(key, fmt.Sprintf("recipes/%d/", recipeID)) {
+		return ""
+	}
 	return key
 }

--- a/internal/s3/s3_test.go
+++ b/internal/s3/s3_test.go
@@ -1,0 +1,95 @@
+package s3
+
+import (
+	"regexp"
+	"testing"
+)
+
+func TestGenerateS3Key_VersionedPNG(t *testing.T) {
+	key := GenerateS3Key(42)
+
+	pattern := regexp.MustCompile(`^recipes/42/images/recipe_image_42_\d+\.png$`)
+	if !pattern.MatchString(key) {
+		t.Errorf("GenerateS3Key(42) = %q, want match for %q", key, pattern)
+	}
+}
+
+func TestGenerateS3KeyAt_Deterministic(t *testing.T) {
+	key := generateS3KeyAt(7, 1700000000)
+	want := "recipes/7/images/recipe_image_7_1700000000.png"
+	if key != want {
+		t.Errorf("generateS3KeyAt(7, 1700000000) = %q, want %q", key, want)
+	}
+}
+
+func TestGenerateS3KeyAt_VersionChangesKey(t *testing.T) {
+	first := generateS3KeyAt(1, 1700000000)
+	second := generateS3KeyAt(1, 1700000001)
+	if first == second {
+		t.Errorf("keys for different timestamps should differ, both = %q", first)
+	}
+}
+
+func TestGenerateUploadKey_UUIDFormat(t *testing.T) {
+	key := GenerateUploadKey(9, ".png")
+
+	pattern := regexp.MustCompile(`^uploads/9/images/[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}\.png$`)
+	if !pattern.MatchString(key) {
+		t.Errorf("GenerateUploadKey(9, \".png\") = %q, want match for %q", key, pattern)
+	}
+}
+
+func TestGenerateUploadKey_Unique(t *testing.T) {
+	first := GenerateUploadKey(1, ".jpg")
+	second := GenerateUploadKey(1, ".jpg")
+	if first == second {
+		t.Errorf("upload keys should be unique, both = %q", first)
+	}
+}
+
+func TestS3KeyFromURL(t *testing.T) {
+	tests := []struct {
+		name string
+		url  string
+		want string
+	}{
+		{
+			name: "virtual-hosted style",
+			url:  "https://my-bucket.s3.us-east-2.amazonaws.com/recipes/1/images/recipe_image_1_1700000000.png",
+			want: "recipes/1/images/recipe_image_1_1700000000.png",
+		},
+		{
+			name: "path style",
+			url:  "https://s3.us-east-2.amazonaws.com/my-bucket/recipes/1/images/recipe_image_1.jpg",
+			want: "recipes/1/images/recipe_image_1.jpg",
+		},
+		{
+			name: "legacy static key",
+			url:  "https://my-bucket.s3.us-east-2.amazonaws.com/recipes/5/images/recipe_image_5.jpg",
+			want: "recipes/5/images/recipe_image_5.jpg",
+		},
+		{
+			name: "url-encoded path",
+			url:  "https://my-bucket.s3.us-east-2.amazonaws.com/uploads/1/images/my%20image.png",
+			want: "uploads/1/images/my image.png",
+		},
+		{
+			name: "empty",
+			url:  "",
+			want: "",
+		},
+		{
+			name: "no path",
+			url:  "https://my-bucket.s3.us-east-2.amazonaws.com",
+			want: "",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := S3KeyFromURL(tt.url); got != tt.want {
+				t.Errorf("S3KeyFromURL(%q) = %q, want %q", tt.url, got, tt.want)
+			}
+		})
+	}
+}

--- a/internal/s3/s3_test.go
+++ b/internal/s3/s3_test.go
@@ -74,6 +74,21 @@ func TestS3KeyFromURL(t *testing.T) {
 			want: "uploads/1/images/my image.png",
 		},
 		{
+			name: "legacy path style without region",
+			url:  "https://s3.amazonaws.com/my-bucket/recipes/2/images/recipe_image_2.jpg",
+			want: "recipes/2/images/recipe_image_2.jpg",
+		},
+		{
+			name: "legacy dashed path style",
+			url:  "https://s3-us-west-2.amazonaws.com/my-bucket/recipes/2/images/recipe_image_2.jpg",
+			want: "recipes/2/images/recipe_image_2.jpg",
+		},
+		{
+			name: "virtual-hosted bucket named with s3- prefix keeps full key",
+			url:  "https://s3-images.s3.us-east-2.amazonaws.com/recipes/1/images/recipe_image_1.png",
+			want: "recipes/1/images/recipe_image_1.png",
+		},
+		{
 			name: "empty",
 			url:  "",
 			want: "",
@@ -89,6 +104,60 @@ func TestS3KeyFromURL(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			if got := S3KeyFromURL(tt.url); got != tt.want {
 				t.Errorf("S3KeyFromURL(%q) = %q, want %q", tt.url, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestRecipeImageKeyFromURL(t *testing.T) {
+	tests := []struct {
+		name     string
+		url      string
+		recipeID uint
+		want     string
+	}{
+		{
+			name:     "own recipe prefix is allowed",
+			url:      "https://my-bucket.s3.us-east-2.amazonaws.com/recipes/7/images/recipe_image_7_1700000000.png",
+			recipeID: 7,
+			want:     "recipes/7/images/recipe_image_7_1700000000.png",
+		},
+		{
+			name:     "another recipe's key is rejected",
+			url:      "https://my-bucket.s3.us-east-2.amazonaws.com/recipes/99/images/recipe_image_99_1700000000.png",
+			recipeID: 7,
+			want:     "",
+		},
+		{
+			name:     "prefix must match the whole ID segment",
+			url:      "https://my-bucket.s3.us-east-2.amazonaws.com/recipes/77/images/recipe_image_77.png",
+			recipeID: 7,
+			want:     "",
+		},
+		{
+			name:     "external (non-S3) image URL is rejected",
+			url:      "https://example.com/some/image.png",
+			recipeID: 7,
+			want:     "",
+		},
+		{
+			name:     "upload-prefixed key is rejected",
+			url:      "https://my-bucket.s3.us-east-2.amazonaws.com/uploads/3/images/abc.png",
+			recipeID: 7,
+			want:     "",
+		},
+		{
+			name:     "empty URL",
+			url:      "",
+			recipeID: 7,
+			want:     "",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := RecipeImageKeyFromURL(tt.url, tt.recipeID); got != tt.want {
+				t.Errorf("RecipeImageKeyFromURL(%q, %d) = %q, want %q", tt.url, tt.recipeID, got, tt.want)
 			}
 		})
 	}

--- a/internal/service/allergen.go
+++ b/internal/service/allergen.go
@@ -24,15 +24,15 @@ const promptVersion = "v1"
 // AllergenService is the business logic layer for allergen analysis operations.
 type AllergenService struct {
 	Cfg          *config.Config
-	AllergenRepo *repository.AllergenRepository
-	FamilyRepo   *repository.FamilyRepository
-	RecipeRepo   *repository.RecipeRepository
+	AllergenRepo repository.AllergenRepo
+	FamilyRepo   repository.FamilyRepo
+	RecipeRepo   repository.RecipeRepo
 	AIProvider   ai.TextProvider
 	SubService   *SubscriptionService
 }
 
 // NewAllergenService is the constructor function for initializing a new AllergenService.
-func NewAllergenService(cfg *config.Config, allergenRepo *repository.AllergenRepository, familyRepo *repository.FamilyRepository, recipeRepo *repository.RecipeRepository, aiProvider ai.TextProvider, subService *SubscriptionService) *AllergenService {
+func NewAllergenService(cfg *config.Config, allergenRepo repository.AllergenRepo, familyRepo repository.FamilyRepo, recipeRepo repository.RecipeRepo, aiProvider ai.TextProvider, subService *SubscriptionService) *AllergenService {
 	return &AllergenService{
 		Cfg:          cfg,
 		AllergenRepo: allergenRepo,

--- a/internal/service/allergen.go
+++ b/internal/service/allergen.go
@@ -154,7 +154,8 @@ func (s *AllergenService) AnalyzeRecipe(ctx context.Context, recipeID uint, isPr
 
 	// 7. Save to DB (update if existing, create if not)
 	if existing != nil {
-		analysis.Model = existing.Model
+		analysis.ID = existing.ID
+		analysis.CreatedAt = existing.CreatedAt
 		if err := s.AllergenRepo.UpdateAnalysis(analysis); err != nil {
 			logger.Get().Error("failed to update allergen analysis", zap.Uint("recipe_id", recipeID), zap.Error(err))
 			return nil, fmt.Errorf("failed to save allergen analysis: %w", err)

--- a/internal/service/allergen_test.go
+++ b/internal/service/allergen_test.go
@@ -1,0 +1,439 @@
+package service
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"testing"
+
+	"github.com/windoze95/saltybytes-api/internal/ai"
+	"github.com/windoze95/saltybytes-api/internal/config"
+	"github.com/windoze95/saltybytes-api/internal/models"
+	"github.com/windoze95/saltybytes-api/internal/testutil"
+)
+
+// newAllergenTestService wires an AllergenService with a recipe already in the
+// repo and the given allergen repo / AI provider mocks.
+func newAllergenTestService(allergenRepo *testutil.MockAllergenRepo, provider ai.TextProvider) (*AllergenService, *testutil.MockRecipeRepo) {
+	recipeRepo := testutil.NewMockRecipeRepo()
+	recipe := testutil.TestRecipe()
+	recipeRepo.Recipes[recipe.ID] = recipe
+
+	svc := NewAllergenService(&config.Config{}, allergenRepo, &testutil.MockFamilyRepo{}, recipeRepo, provider, nil)
+	return svc, recipeRepo
+}
+
+func TestAnalyzeRecipe_NilProvider(t *testing.T) {
+	svc, _ := newAllergenTestService(&testutil.MockAllergenRepo{}, nil)
+
+	if _, err := svc.AnalyzeRecipe(context.Background(), 1, false); err == nil {
+		t.Fatal("expected error when AI provider is not configured")
+	}
+}
+
+func TestAnalyzeRecipe_RecipeNotFound(t *testing.T) {
+	svc, _ := newAllergenTestService(&testutil.MockAllergenRepo{}, &testutil.MockTextProvider{})
+
+	if _, err := svc.AnalyzeRecipe(context.Background(), 999, false); err == nil {
+		t.Fatal("expected error for missing recipe")
+	}
+}
+
+func TestAnalyzeRecipe_CachedAnalysis_SkipsAI(t *testing.T) {
+	aiCalled := false
+	provider := &testutil.MockTextProvider{
+		AnalyzeAllergensFunc: func(ctx context.Context, req ai.AllergenRequest) (*ai.AllergenResult, error) {
+			aiCalled = true
+			return &ai.AllergenResult{}, nil
+		},
+	}
+	allergenRepo := &testutil.MockAllergenRepo{
+		GetAnalysisByRecipeIDFunc: func(recipeID uint) (*models.AllergenAnalysis, error) {
+			return &models.AllergenAnalysis{
+				ID:            42,
+				RecipeID:      recipeID,
+				PromptVersion: promptVersion,
+				IsPremium:     false,
+				ContainsNuts:  true,
+			}, nil
+		},
+	}
+	svc, _ := newAllergenTestService(allergenRepo, provider)
+
+	resp, err := svc.AnalyzeRecipe(context.Background(), 1, false)
+	if err != nil {
+		t.Fatalf("AnalyzeRecipe error: %v", err)
+	}
+	if aiCalled {
+		t.Error("AI provider should not be called when a matching cached analysis exists")
+	}
+	if resp.ID != 42 || !resp.ContainsNuts {
+		t.Errorf("cached analysis not returned: %+v", resp.AllergenAnalysis)
+	}
+	if resp.Disclaimer != AllergenDisclaimer {
+		t.Errorf("Disclaimer = %q, want standard disclaimer", resp.Disclaimer)
+	}
+}
+
+func TestAnalyzeRecipe_CacheBypassedOnPremiumMismatch(t *testing.T) {
+	var updated *models.AllergenAnalysis
+	provider := &testutil.MockTextProvider{
+		AnalyzeAllergensFunc: func(ctx context.Context, req ai.AllergenRequest) (*ai.AllergenResult, error) {
+			if !req.IsPremium {
+				t.Error("AllergenRequest.IsPremium = false, want true")
+			}
+			return &ai.AllergenResult{Confidence: 0.95}, nil
+		},
+	}
+	allergenRepo := &testutil.MockAllergenRepo{
+		GetAnalysisByRecipeIDFunc: func(recipeID uint) (*models.AllergenAnalysis, error) {
+			// Cached as a free-tier analysis; the premium request must re-run.
+			return &models.AllergenAnalysis{ID: 42, RecipeID: recipeID, PromptVersion: promptVersion, IsPremium: false}, nil
+		},
+		UpdateAnalysisFunc: func(analysis *models.AllergenAnalysis) error {
+			updated = analysis
+			return nil
+		},
+		CreateAnalysisFunc: func(analysis *models.AllergenAnalysis) error {
+			t.Error("CreateAnalysis called, want UpdateAnalysis for an existing row")
+			return nil
+		},
+	}
+	svc, _ := newAllergenTestService(allergenRepo, provider)
+
+	resp, err := svc.AnalyzeRecipe(context.Background(), 1, true)
+	if err != nil {
+		t.Fatalf("AnalyzeRecipe error: %v", err)
+	}
+	if updated == nil {
+		t.Fatal("UpdateAnalysis was not called")
+	}
+	if updated.ID != 42 {
+		t.Errorf("updated.ID = %d, want existing row ID 42", updated.ID)
+	}
+	if !updated.IsPremium {
+		t.Error("updated.IsPremium = false, want true")
+	}
+	if !resp.IsPremium {
+		t.Error("response IsPremium = false, want true")
+	}
+}
+
+func TestAnalyzeRecipe_CreatesAnalysis_StampsPromptVersion(t *testing.T) {
+	var created *models.AllergenAnalysis
+	provider := &testutil.MockTextProvider{
+		AnalyzeAllergensFunc: func(ctx context.Context, req ai.AllergenRequest) (*ai.AllergenResult, error) {
+			// The test recipe has 4 ingredients; all must be forwarded.
+			if len(req.Ingredients) != 4 {
+				t.Errorf("len(Ingredients) = %d, want 4", len(req.Ingredients))
+			}
+			return &ai.AllergenResult{
+				IngredientAnalyses: []ai.IngredientAnalysisResult{
+					{IngredientName: "All-purpose flour", CommonAllergens: []string{"gluten", "wheat"}, Confidence: 0.97},
+					{IngredientName: "Milk", CommonAllergens: []string{"dairy"}, Confidence: 0.99},
+					{IngredientName: "Egg", CommonAllergens: []string{"egg"}, Confidence: 0.99},
+					{IngredientName: "Vegetable oil", PossibleAllergens: []string{"soy"}, SeedOilRisk: true, Confidence: 0.7},
+				},
+				Confidence:     0.92,
+				RequiresReview: false,
+			}, nil
+		},
+	}
+	allergenRepo := &testutil.MockAllergenRepo{
+		CreateAnalysisFunc: func(analysis *models.AllergenAnalysis) error {
+			analysis.ID = 7
+			created = analysis
+			return nil
+		},
+	}
+	svc, _ := newAllergenTestService(allergenRepo, provider)
+
+	resp, err := svc.AnalyzeRecipe(context.Background(), 1, false)
+	if err != nil {
+		t.Fatalf("AnalyzeRecipe error: %v", err)
+	}
+	if created == nil {
+		t.Fatal("CreateAnalysis was not called")
+	}
+	if created.PromptVersion != promptVersion {
+		t.Errorf("PromptVersion = %q, want %q", created.PromptVersion, promptVersion)
+	}
+	if created.RecipeID != 1 {
+		t.Errorf("RecipeID = %d, want 1", created.RecipeID)
+	}
+	if created.IsPremium {
+		t.Error("IsPremium = true, want false")
+	}
+	if created.RequiresReview {
+		t.Error("RequiresReview = true, want false for confidence 0.92")
+	}
+	// Aggregate flags derived from ingredient analyses.
+	if !created.ContainsGluten || !created.ContainsDairy || !created.ContainsEggs {
+		t.Errorf("aggregate flags wrong: gluten=%v dairy=%v eggs=%v", created.ContainsGluten, created.ContainsDairy, created.ContainsEggs)
+	}
+	if !created.ContainsSoy {
+		t.Error("ContainsSoy = false; possible allergens must also set aggregate flags")
+	}
+	if !created.ContainsSeedOils {
+		t.Error("ContainsSeedOils = false, want true when SeedOilRisk is set")
+	}
+	if created.ContainsNuts || created.ContainsShellfish {
+		t.Errorf("unexpected flags: nuts=%v shellfish=%v", created.ContainsNuts, created.ContainsShellfish)
+	}
+	if resp.Disclaimer != AllergenDisclaimer {
+		t.Errorf("Disclaimer = %q, want standard disclaimer", resp.Disclaimer)
+	}
+	if len(resp.IngredientAnalyses) != 4 {
+		t.Errorf("len(IngredientAnalyses) = %d, want 4", len(resp.IngredientAnalyses))
+	}
+}
+
+func TestAnalyzeRecipe_LowConfidence_RequiresReview(t *testing.T) {
+	var created *models.AllergenAnalysis
+	provider := &testutil.MockTextProvider{
+		AnalyzeAllergensFunc: func(ctx context.Context, req ai.AllergenRequest) (*ai.AllergenResult, error) {
+			return &ai.AllergenResult{Confidence: 0.5, RequiresReview: false}, nil
+		},
+	}
+	allergenRepo := &testutil.MockAllergenRepo{
+		CreateAnalysisFunc: func(analysis *models.AllergenAnalysis) error {
+			created = analysis
+			return nil
+		},
+	}
+	svc, _ := newAllergenTestService(allergenRepo, provider)
+
+	if _, err := svc.AnalyzeRecipe(context.Background(), 1, false); err != nil {
+		t.Fatalf("AnalyzeRecipe error: %v", err)
+	}
+	if created == nil || !created.RequiresReview {
+		t.Error("RequiresReview should be forced true when confidence < 0.8")
+	}
+}
+
+func TestAnalyzeRecipe_AIError(t *testing.T) {
+	provider := &testutil.MockTextProvider{
+		AnalyzeAllergensFunc: func(ctx context.Context, req ai.AllergenRequest) (*ai.AllergenResult, error) {
+			return nil, errors.New("model overloaded")
+		},
+	}
+	svc, _ := newAllergenTestService(&testutil.MockAllergenRepo{}, provider)
+
+	if _, err := svc.AnalyzeRecipe(context.Background(), 1, false); err == nil {
+		t.Fatal("expected error when AI analysis fails")
+	}
+}
+
+func TestAnalyzeRecipe_PersistFails(t *testing.T) {
+	provider := &testutil.MockTextProvider{
+		AnalyzeAllergensFunc: func(ctx context.Context, req ai.AllergenRequest) (*ai.AllergenResult, error) {
+			return &ai.AllergenResult{Confidence: 0.9}, nil
+		},
+	}
+	allergenRepo := &testutil.MockAllergenRepo{
+		CreateAnalysisFunc: func(analysis *models.AllergenAnalysis) error {
+			return errors.New("db down")
+		},
+	}
+	svc, _ := newAllergenTestService(allergenRepo, provider)
+
+	if _, err := svc.AnalyzeRecipe(context.Background(), 1, false); err == nil {
+		t.Fatal("expected error when persisting the analysis fails")
+	}
+}
+
+// --- CheckFamily ---
+
+// checkFamilyFixture wires an AllergenService whose stored analysis flags
+// peanuts as a common allergen and soy as a possible allergen, with the given
+// family members.
+func checkFamilyFixture(members []models.FamilyMember, onUpdate func(*models.AllergenAnalysis)) *AllergenService {
+	allergenRepo := &testutil.MockAllergenRepo{
+		GetAnalysisByRecipeIDFunc: func(recipeID uint) (*models.AllergenAnalysis, error) {
+			return &models.AllergenAnalysis{
+				ID:       1,
+				RecipeID: recipeID,
+				IngredientAnalyses: models.IngredientAnalysisList{
+					{IngredientName: "Peanut butter", CommonAllergens: []string{"peanuts"}, PossibleAllergens: []string{"soy"}},
+					{IngredientName: "Milk", CommonAllergens: []string{"dairy"}},
+				},
+			}, nil
+		},
+		UpdateAnalysisFunc: func(analysis *models.AllergenAnalysis) error {
+			if onUpdate != nil {
+				onUpdate(analysis)
+			}
+			return nil
+		},
+	}
+	familyRepo := &testutil.MockFamilyRepo{
+		GetFamilyByOwnerIDFunc: func(ownerID uint) (*models.Family, error) {
+			return &models.Family{ID: 7, OwnerID: ownerID, Members: members}, nil
+		},
+	}
+	return NewAllergenService(&config.Config{}, allergenRepo, familyRepo, testutil.NewMockRecipeRepo(), &testutil.MockTextProvider{}, nil)
+}
+
+func TestCheckFamily_MemberStatusMapping(t *testing.T) {
+	members := []models.FamilyMember{
+		{ID: 1, FamilyID: 7, Name: "Alice", DietaryProfile: &models.DietaryProfile{
+			Allergies: models.AllergyList{{Name: "peanuts", Severity: "severe"}},
+		}},
+		{ID: 2, FamilyID: 7, Name: "Bob", DietaryProfile: &models.DietaryProfile{
+			Allergies: models.AllergyList{{Name: "soy"}},
+		}},
+		{ID: 3, FamilyID: 7, Name: "Carol", DietaryProfile: &models.DietaryProfile{
+			Intolerances: models.StringList{"dairy"},
+		}},
+		{ID: 4, FamilyID: 7, Name: "NoProfile"},
+		{ID: 5, FamilyID: 7, Name: "Eve", DietaryProfile: &models.DietaryProfile{
+			Allergies: models.AllergyList{{Name: "shellfish"}},
+		}},
+	}
+	var persisted *models.AllergenAnalysis
+	svc := checkFamilyFixture(members, func(a *models.AllergenAnalysis) { persisted = a })
+
+	resp, err := svc.CheckFamily(context.Background(), 1, 10)
+	if err != nil {
+		t.Fatalf("CheckFamily error: %v", err)
+	}
+	if resp.RecipeID != 1 {
+		t.Errorf("RecipeID = %d, want 1", resp.RecipeID)
+	}
+	if resp.Disclaimer != AllergenDisclaimer {
+		t.Errorf("Disclaimer = %q, want standard disclaimer", resp.Disclaimer)
+	}
+	if len(resp.MemberResults) != 5 {
+		t.Fatalf("len(MemberResults) = %d, want 5", len(resp.MemberResults))
+	}
+
+	wantStatus := map[string]string{
+		"Alice":     "unsafe",  // common allergen match
+		"Bob":       "caution", // possible allergen match
+		"Carol":     "caution", // intolerance match
+		"NoProfile": "safe",    // no profile to check
+		"Eve":       "safe",    // no matching allergen
+	}
+	for _, mr := range resp.MemberResults {
+		if mr.Status != wantStatus[mr.MemberName] {
+			t.Errorf("%s status = %q, want %q (warnings: %v)", mr.MemberName, mr.Status, wantStatus[mr.MemberName], mr.Warnings)
+		}
+	}
+
+	// Alice (unsafe) must have a specific warning; safe members none.
+	for _, mr := range resp.MemberResults {
+		switch mr.MemberName {
+		case "Alice":
+			if len(mr.Warnings) == 0 {
+				t.Error("Alice should have at least one warning")
+			}
+		case "NoProfile", "Eve":
+			if len(mr.Warnings) != 0 {
+				t.Errorf("%s warnings = %v, want none", mr.MemberName, mr.Warnings)
+			}
+		}
+	}
+
+	// Safe/unsafe profile lists are persisted back onto the analysis.
+	if persisted == nil {
+		t.Fatal("UpdateAnalysis was not called to persist profile results")
+	}
+	if len(persisted.UnsafeForProfiles) != 1 || persisted.UnsafeForProfiles[0] != 1 {
+		t.Errorf("UnsafeForProfiles = %v, want [1]", persisted.UnsafeForProfiles)
+	}
+	// Caution counts as safe in the persisted lists (only unsafe is excluded).
+	if len(persisted.SafeForProfiles) != 4 {
+		t.Errorf("SafeForProfiles = %v, want the 4 non-unsafe member IDs", persisted.SafeForProfiles)
+	}
+}
+
+func TestCheckFamily_SubFormMatch_Unsafe(t *testing.T) {
+	members := []models.FamilyMember{
+		{ID: 1, FamilyID: 7, Name: "Dana", DietaryProfile: &models.DietaryProfile{
+			Allergies: models.AllergyList{{Name: "legumes", SubForms: []string{"peanuts"}}},
+		}},
+	}
+	svc := checkFamilyFixture(members, nil)
+
+	resp, err := svc.CheckFamily(context.Background(), 1, 10)
+	if err != nil {
+		t.Fatalf("CheckFamily error: %v", err)
+	}
+	if resp.MemberResults[0].Status != "unsafe" {
+		t.Errorf("status = %q, want unsafe via allergy sub-form match", resp.MemberResults[0].Status)
+	}
+}
+
+func TestCheckFamily_UnsafeNotDowngradedByCaution(t *testing.T) {
+	// A member allergic to peanuts (unsafe) AND soy (caution) stays unsafe.
+	members := []models.FamilyMember{
+		{ID: 1, FamilyID: 7, Name: "Frank", DietaryProfile: &models.DietaryProfile{
+			Allergies: models.AllergyList{{Name: "peanuts"}, {Name: "soy"}},
+		}},
+	}
+	svc := checkFamilyFixture(members, nil)
+
+	resp, err := svc.CheckFamily(context.Background(), 1, 10)
+	if err != nil {
+		t.Fatalf("CheckFamily error: %v", err)
+	}
+	if resp.MemberResults[0].Status != "unsafe" {
+		t.Errorf("status = %q, want unsafe (caution must not downgrade)", resp.MemberResults[0].Status)
+	}
+}
+
+func TestCheckFamily_NoAnalysis(t *testing.T) {
+	svc := NewAllergenService(&config.Config{}, &testutil.MockAllergenRepo{}, &testutil.MockFamilyRepo{}, testutil.NewMockRecipeRepo(), &testutil.MockTextProvider{}, nil)
+
+	if _, err := svc.CheckFamily(context.Background(), 1, 10); err == nil {
+		t.Fatal("expected error when no analysis exists for the recipe")
+	}
+}
+
+func TestCheckFamily_FamilyLookupFails(t *testing.T) {
+	allergenRepo := &testutil.MockAllergenRepo{
+		GetAnalysisByRecipeIDFunc: func(recipeID uint) (*models.AllergenAnalysis, error) {
+			return &models.AllergenAnalysis{ID: 1, RecipeID: recipeID}, nil
+		},
+	}
+	familyRepo := &testutil.MockFamilyRepo{
+		GetFamilyByOwnerIDFunc: func(ownerID uint) (*models.Family, error) {
+			return nil, fmt.Errorf("record not found")
+		},
+	}
+	svc := NewAllergenService(&config.Config{}, allergenRepo, familyRepo, testutil.NewMockRecipeRepo(), &testutil.MockTextProvider{}, nil)
+
+	if _, err := svc.CheckFamily(context.Background(), 1, 10); err == nil {
+		t.Fatal("expected error when family lookup fails")
+	}
+}
+
+// --- GetAnalysis ---
+
+func TestGetAnalysis_Success(t *testing.T) {
+	allergenRepo := &testutil.MockAllergenRepo{
+		GetAnalysisByRecipeIDFunc: func(recipeID uint) (*models.AllergenAnalysis, error) {
+			return &models.AllergenAnalysis{ID: 9, RecipeID: recipeID, ContainsDairy: true}, nil
+		},
+	}
+	svc, _ := newAllergenTestService(allergenRepo, &testutil.MockTextProvider{})
+
+	resp, err := svc.GetAnalysis(context.Background(), 1)
+	if err != nil {
+		t.Fatalf("GetAnalysis error: %v", err)
+	}
+	if resp.ID != 9 || !resp.ContainsDairy {
+		t.Errorf("analysis = %+v, want stored analysis", resp.AllergenAnalysis)
+	}
+	if resp.Disclaimer != AllergenDisclaimer {
+		t.Errorf("Disclaimer = %q, want standard disclaimer", resp.Disclaimer)
+	}
+}
+
+func TestGetAnalysis_NotFound(t *testing.T) {
+	svc, _ := newAllergenTestService(&testutil.MockAllergenRepo{}, &testutil.MockTextProvider{})
+
+	if _, err := svc.GetAnalysis(context.Background(), 1); err == nil {
+		t.Fatal("expected error when no analysis exists")
+	}
+}

--- a/internal/service/embedding_backfill.go
+++ b/internal/service/embedding_backfill.go
@@ -8,6 +8,7 @@ import (
 	"github.com/windoze95/saltybytes-api/internal/ai"
 	"github.com/windoze95/saltybytes-api/internal/logger"
 	"github.com/windoze95/saltybytes-api/internal/models"
+	"github.com/windoze95/saltybytes-api/internal/util"
 	"go.uber.org/zap"
 )
 
@@ -17,6 +18,11 @@ const embeddingBackfillBatchSize = 25
 // embeddingBackfillDelay is the pause between embedding API calls to avoid
 // hammering the provider. Package-level var so tests can shorten it.
 var embeddingBackfillDelay = 200 * time.Millisecond
+
+// embeddingCallTimeout bounds a single embedding API call made with a
+// background context. Without it a stalled provider connection would wedge
+// background loops (backfill, canonical refresh) indefinitely.
+const embeddingCallTimeout = 30 * time.Second
 
 // EmbeddingBackfillRepo is the subset of VectorRepository needed by the
 // embedding backfill task.
@@ -36,6 +42,8 @@ func StartEmbeddingBackfill(repo EmbeddingBackfillRepo, embedProvider ai.Embeddi
 	}
 
 	go func() {
+		defer util.RecoverPanic("embedding backfill")
+
 		backfillRecipeEmbeddings(repo, embedProvider)
 		backfillCanonicalEmbeddings(repo, embedProvider)
 	}()
@@ -68,7 +76,9 @@ func backfillRecipeEmbeddings(repo EmbeddingBackfillRepo, embedProvider ai.Embed
 				continue
 			}
 
-			embedding, err := embedProvider.GenerateEmbedding(context.Background(), text)
+			embedCtx, cancel := context.WithTimeout(context.Background(), embeddingCallTimeout)
+			embedding, err := embedProvider.GenerateEmbedding(embedCtx, text)
+			cancel()
 			if err != nil {
 				log.Warn("embedding backfill: failed to embed recipe", zap.Uint("recipe_id", recipe.ID), zap.Error(err))
 				skipped++
@@ -122,7 +132,9 @@ func backfillCanonicalEmbeddings(repo EmbeddingBackfillRepo, embedProvider ai.Em
 				continue
 			}
 
-			embedding, err := embedProvider.GenerateEmbedding(context.Background(), text)
+			embedCtx, cancel := context.WithTimeout(context.Background(), embeddingCallTimeout)
+			embedding, err := embedProvider.GenerateEmbedding(embedCtx, text)
+			cancel()
 			if err != nil {
 				log.Warn("embedding backfill: failed to embed canonical", zap.Uint("canonical_id", entry.ID), zap.Error(err))
 				skipped++

--- a/internal/service/embedding_backfill.go
+++ b/internal/service/embedding_backfill.go
@@ -1,0 +1,150 @@
+package service
+
+import (
+	"context"
+	"strings"
+	"time"
+
+	"github.com/windoze95/saltybytes-api/internal/ai"
+	"github.com/windoze95/saltybytes-api/internal/logger"
+	"github.com/windoze95/saltybytes-api/internal/models"
+	"go.uber.org/zap"
+)
+
+// embeddingBackfillBatchSize is how many rows are scanned per batch.
+const embeddingBackfillBatchSize = 25
+
+// embeddingBackfillDelay is the pause between embedding API calls to avoid
+// hammering the provider. Package-level var so tests can shorten it.
+var embeddingBackfillDelay = 200 * time.Millisecond
+
+// EmbeddingBackfillRepo is the subset of VectorRepository needed by the
+// embedding backfill task.
+type EmbeddingBackfillRepo interface {
+	ListRecipesMissingEmbedding(afterID uint, limit int) ([]models.Recipe, error)
+	UpdateEmbedding(recipeID uint, embedding []float32) error
+	ListCanonicalsMissingEmbedding(afterID uint, limit int) ([]models.CanonicalRecipe, error)
+	UpdateCanonicalEmbedding(canonicalID uint, embedding []float32) error
+}
+
+// StartEmbeddingBackfill launches a background goroutine that scans recipes
+// and canonical recipes missing embeddings and populates them. Per-row
+// failures are logged and skipped; the scan always makes forward progress.
+func StartEmbeddingBackfill(repo EmbeddingBackfillRepo, embedProvider ai.EmbeddingProvider) {
+	if repo == nil || embedProvider == nil {
+		return
+	}
+
+	go func() {
+		backfillRecipeEmbeddings(repo, embedProvider)
+		backfillCanonicalEmbeddings(repo, embedProvider)
+	}()
+}
+
+// backfillRecipeEmbeddings populates recipes.embedding for rows where it is NULL.
+func backfillRecipeEmbeddings(repo EmbeddingBackfillRepo, embedProvider ai.EmbeddingProvider) {
+	log := logger.Get()
+	var lastID uint
+	filled, skipped := 0, 0
+
+	for {
+		batch, err := repo.ListRecipesMissingEmbedding(lastID, embeddingBackfillBatchSize)
+		if err != nil {
+			log.Warn("embedding backfill: failed to list recipes", zap.Error(err))
+			return
+		}
+		if len(batch) == 0 {
+			break
+		}
+
+		for i := range batch {
+			recipe := &batch[i]
+			lastID = recipe.ID
+
+			def := effectiveRecipeDef(recipe)
+			text := strings.TrimSpace(embeddingText(&def))
+			if text == "" {
+				skipped++
+				continue
+			}
+
+			embedding, err := embedProvider.GenerateEmbedding(context.Background(), text)
+			if err != nil {
+				log.Warn("embedding backfill: failed to embed recipe", zap.Uint("recipe_id", recipe.ID), zap.Error(err))
+				skipped++
+				time.Sleep(embeddingBackfillDelay)
+				continue
+			}
+
+			if err := repo.UpdateEmbedding(recipe.ID, embedding); err != nil {
+				log.Warn("embedding backfill: failed to store recipe embedding", zap.Uint("recipe_id", recipe.ID), zap.Error(err))
+				skipped++
+			} else {
+				filled++
+			}
+
+			time.Sleep(embeddingBackfillDelay)
+		}
+
+		log.Info("embedding backfill: recipes progress",
+			zap.Uint("last_id", lastID), zap.Int("filled", filled), zap.Int("skipped", skipped))
+	}
+
+	if filled > 0 || skipped > 0 {
+		log.Info("embedding backfill: recipes complete", zap.Int("filled", filled), zap.Int("skipped", skipped))
+	}
+}
+
+// backfillCanonicalEmbeddings populates canonical_recipes.embedding for rows
+// where it is NULL.
+func backfillCanonicalEmbeddings(repo EmbeddingBackfillRepo, embedProvider ai.EmbeddingProvider) {
+	log := logger.Get()
+	var lastID uint
+	filled, skipped := 0, 0
+
+	for {
+		batch, err := repo.ListCanonicalsMissingEmbedding(lastID, embeddingBackfillBatchSize)
+		if err != nil {
+			log.Warn("embedding backfill: failed to list canonicals", zap.Error(err))
+			return
+		}
+		if len(batch) == 0 {
+			break
+		}
+
+		for i := range batch {
+			entry := &batch[i]
+			lastID = entry.ID
+
+			text := strings.TrimSpace(embeddingText(&entry.RecipeData))
+			if text == "" {
+				skipped++
+				continue
+			}
+
+			embedding, err := embedProvider.GenerateEmbedding(context.Background(), text)
+			if err != nil {
+				log.Warn("embedding backfill: failed to embed canonical", zap.Uint("canonical_id", entry.ID), zap.Error(err))
+				skipped++
+				time.Sleep(embeddingBackfillDelay)
+				continue
+			}
+
+			if err := repo.UpdateCanonicalEmbedding(entry.ID, embedding); err != nil {
+				log.Warn("embedding backfill: failed to store canonical embedding", zap.Uint("canonical_id", entry.ID), zap.Error(err))
+				skipped++
+			} else {
+				filled++
+			}
+
+			time.Sleep(embeddingBackfillDelay)
+		}
+
+		log.Info("embedding backfill: canonicals progress",
+			zap.Uint("last_id", lastID), zap.Int("filled", filled), zap.Int("skipped", skipped))
+	}
+
+	if filled > 0 || skipped > 0 {
+		log.Info("embedding backfill: canonicals complete", zap.Int("filled", filled), zap.Int("skipped", skipped))
+	}
+}

--- a/internal/service/embedding_backfill_test.go
+++ b/internal/service/embedding_backfill_test.go
@@ -1,0 +1,178 @@
+package service
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	"github.com/windoze95/saltybytes-api/internal/models"
+	"github.com/windoze95/saltybytes-api/internal/testutil"
+	"gorm.io/gorm"
+)
+
+// mockBackfillRepo is an in-memory EmbeddingBackfillRepo for backfill tests.
+type mockBackfillRepo struct {
+	recipes    []models.Recipe
+	canonicals []models.CanonicalRecipe
+
+	recipeEmbeds    map[uint][]float32
+	canonicalEmbeds map[uint][]float32
+}
+
+func (m *mockBackfillRepo) ListRecipesMissingEmbedding(afterID uint, limit int) ([]models.Recipe, error) {
+	var out []models.Recipe
+	for _, r := range m.recipes {
+		if r.ID > afterID && m.recipeEmbeds[r.ID] == nil {
+			out = append(out, r)
+			if len(out) >= limit {
+				break
+			}
+		}
+	}
+	return out, nil
+}
+
+func (m *mockBackfillRepo) UpdateEmbedding(recipeID uint, embedding []float32) error {
+	m.recipeEmbeds[recipeID] = embedding
+	return nil
+}
+
+func (m *mockBackfillRepo) ListCanonicalsMissingEmbedding(afterID uint, limit int) ([]models.CanonicalRecipe, error) {
+	var out []models.CanonicalRecipe
+	for _, c := range m.canonicals {
+		if c.ID > afterID && m.canonicalEmbeds[c.ID] == nil {
+			out = append(out, c)
+			if len(out) >= limit {
+				break
+			}
+		}
+	}
+	return out, nil
+}
+
+func (m *mockBackfillRepo) UpdateCanonicalEmbedding(canonicalID uint, embedding []float32) error {
+	m.canonicalEmbeds[canonicalID] = embedding
+	return nil
+}
+
+func backfillRecipeFixture(id uint, title string) models.Recipe {
+	return models.Recipe{
+		Model:       gorm.Model{ID: id},
+		RecipeDef:   recipeDefWithTitle(title),
+		HasDiverged: true,
+	}
+}
+
+// recipeDefWithTitle builds a minimal RecipeDef with the given title.
+func recipeDefWithTitle(title string) models.RecipeDef {
+	return models.RecipeDef{
+		Title: title,
+		Ingredients: models.Ingredients{
+			{Name: "Flour"},
+			{Name: "Milk"},
+		},
+	}
+}
+
+func TestBackfillRecipeEmbeddings_FillsMissingAndSkipsEmpty(t *testing.T) {
+	origDelay := embeddingBackfillDelay
+	embeddingBackfillDelay = 0
+	defer func() { embeddingBackfillDelay = origDelay }()
+
+	repo := &mockBackfillRepo{
+		recipes: []models.Recipe{
+			backfillRecipeFixture(1, "Pancakes"),
+			{Model: gorm.Model{ID: 2}, HasDiverged: true}, // empty def — skipped
+			backfillRecipeFixture(3, "Waffles"),
+		},
+		recipeEmbeds:    map[uint][]float32{},
+		canonicalEmbeds: map[uint][]float32{},
+	}
+
+	var embeddedTexts []string
+	embedProvider := &testutil.MockEmbeddingProvider{
+		GenerateEmbeddingFunc: func(ctx context.Context, text string) ([]float32, error) {
+			embeddedTexts = append(embeddedTexts, text)
+			return []float32{0.1}, nil
+		},
+	}
+
+	backfillRecipeEmbeddings(repo, embedProvider)
+
+	if len(repo.recipeEmbeds) != 2 {
+		t.Fatalf("filled %d embeddings, want 2", len(repo.recipeEmbeds))
+	}
+	if repo.recipeEmbeds[1] == nil || repo.recipeEmbeds[3] == nil {
+		t.Errorf("recipes 1 and 3 should be embedded, got %v", repo.recipeEmbeds)
+	}
+	if repo.recipeEmbeds[2] != nil {
+		t.Error("recipe 2 (empty def) should be skipped")
+	}
+	if len(embeddedTexts) != 2 {
+		t.Errorf("embed calls = %d, want 2", len(embeddedTexts))
+	}
+}
+
+func TestBackfillCanonicalEmbeddings_FillsMissing(t *testing.T) {
+	origDelay := embeddingBackfillDelay
+	embeddingBackfillDelay = 0
+	defer func() { embeddingBackfillDelay = origDelay }()
+
+	repo := &mockBackfillRepo{
+		canonicals: []models.CanonicalRecipe{
+			{Model: gorm.Model{ID: 10}, RecipeData: recipeDefWithTitle("Pancakes")},
+			{Model: gorm.Model{ID: 11}, RecipeData: recipeDefWithTitle("Waffles")},
+		},
+		recipeEmbeds:    map[uint][]float32{},
+		canonicalEmbeds: map[uint][]float32{},
+	}
+
+	embedProvider := &testutil.MockEmbeddingProvider{
+		GenerateEmbeddingFunc: func(ctx context.Context, text string) ([]float32, error) {
+			return []float32{0.2}, nil
+		},
+	}
+
+	backfillCanonicalEmbeddings(repo, embedProvider)
+
+	if len(repo.canonicalEmbeds) != 2 {
+		t.Fatalf("filled %d canonical embeddings, want 2", len(repo.canonicalEmbeds))
+	}
+	if repo.canonicalEmbeds[10] == nil || repo.canonicalEmbeds[11] == nil {
+		t.Errorf("canonicals 10 and 11 should be embedded, got %v", repo.canonicalEmbeds)
+	}
+}
+
+func TestBackfillRecipeEmbeddings_PerRowErrorIsSkipped(t *testing.T) {
+	origDelay := embeddingBackfillDelay
+	embeddingBackfillDelay = 0
+	defer func() { embeddingBackfillDelay = origDelay }()
+
+	repo := &mockBackfillRepo{
+		recipes: []models.Recipe{
+			backfillRecipeFixture(1, "Pancakes"),
+			backfillRecipeFixture(2, "Waffles"),
+		},
+		recipeEmbeds:    map[uint][]float32{},
+		canonicalEmbeds: map[uint][]float32{},
+	}
+
+	embedProvider := &testutil.MockEmbeddingProvider{
+		GenerateEmbeddingFunc: func(ctx context.Context, text string) ([]float32, error) {
+			// Fail only the first recipe's row
+			if strings.Contains(text, "Pancakes") {
+				return nil, context.DeadlineExceeded
+			}
+			return []float32{0.3}, nil
+		},
+	}
+
+	backfillRecipeEmbeddings(repo, embedProvider)
+
+	if repo.recipeEmbeds[1] != nil {
+		t.Error("recipe 1 should have been skipped after embed error")
+	}
+	if repo.recipeEmbeds[2] == nil {
+		t.Error("recipe 2 should still be embedded despite recipe 1 failing")
+	}
+}

--- a/internal/service/family.go
+++ b/internal/service/family.go
@@ -14,12 +14,12 @@ import (
 // FamilyService is the business logic layer for family-related operations.
 type FamilyService struct {
 	Cfg        *config.Config
-	Repo       *repository.FamilyRepository
+	Repo       repository.FamilyRepo
 	AIProvider ai.TextProvider
 }
 
 // NewFamilyService is the constructor function for initializing a new FamilyService.
-func NewFamilyService(cfg *config.Config, repo *repository.FamilyRepository, aiProvider ai.TextProvider) *FamilyService {
+func NewFamilyService(cfg *config.Config, repo repository.FamilyRepo, aiProvider ai.TextProvider) *FamilyService {
 	return &FamilyService{
 		Cfg:        cfg,
 		Repo:       repo,
@@ -110,16 +110,50 @@ func (s *FamilyService) UpdateDietaryProfile(memberID uint, profile *models.Diet
 	return s.Repo.UpdateDietaryProfile(existing)
 }
 
-// DietaryInterview conducts a multi-turn dietary interview for a family member.
-func (s *FamilyService) DietaryInterview(ctx context.Context, memberID uint, messages []ai.Message) (string, error) {
+// DietaryInterview conducts a multi-turn dietary interview for a family
+// member. It returns the assistant's response text, whether the interview is
+// complete, and — only when complete — the structured dietary profile
+// extracted from the conversation.
+func (s *FamilyService) DietaryInterview(ctx context.Context, memberID uint, messages []ai.Message) (string, bool, *models.DietaryProfile, error) {
 	if s.AIProvider == nil {
-		return "", errors.New("AI provider is not configured")
+		return "", false, nil, errors.New("AI provider is not configured")
 	}
 
 	member, err := s.Repo.GetFamilyMemberByID(memberID)
 	if err != nil {
-		return "", fmt.Errorf("failed to get family member: %w", err)
+		return "", false, nil, fmt.Errorf("failed to get family member: %w", err)
 	}
 
-	return s.AIProvider.DietaryInterview(ctx, messages, member.Name)
+	result, err := s.AIProvider.DietaryInterview(ctx, messages, member.Name)
+	if err != nil {
+		return "", false, nil, err
+	}
+
+	if !result.Complete || result.Profile == nil {
+		return result.Response, false, nil, nil
+	}
+
+	return result.Response, true, dietaryProfileFromAI(result.Profile), nil
+}
+
+// dietaryProfileFromAI converts the AI-layer dietary profile into the
+// persistence model. ID and MemberID are intentionally left zero: the profile
+// is returned to the client for confirmation, not persisted here.
+func dietaryProfileFromAI(p *ai.DietaryProfileResult) *models.DietaryProfile {
+	allergies := make(models.AllergyList, len(p.Allergies))
+	for i, a := range p.Allergies {
+		allergies[i] = models.Allergy{
+			Name:     a.Name,
+			Severity: a.Severity,
+			SubForms: a.SubForms,
+			Notes:    a.Notes,
+		}
+	}
+	return &models.DietaryProfile{
+		Allergies:    allergies,
+		Intolerances: models.StringList(p.Intolerances),
+		Restrictions: models.StringList(p.Restrictions),
+		Preferences:  models.StringList(p.Preferences),
+		MedicalNotes: p.MedicalNotes,
+	}
 }

--- a/internal/service/family_crud_test.go
+++ b/internal/service/family_crud_test.go
@@ -1,0 +1,259 @@
+package service
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/windoze95/saltybytes-api/internal/config"
+	"github.com/windoze95/saltybytes-api/internal/models"
+	"github.com/windoze95/saltybytes-api/internal/testutil"
+)
+
+func newCrudFamilyService(repo *testutil.MockFamilyRepo) *FamilyService {
+	return NewFamilyService(&config.Config{}, repo, &testutil.MockTextProvider{})
+}
+
+// --- CreateFamily ---
+
+func TestCreateFamily_Success(t *testing.T) {
+	var created *models.Family
+	repo := &testutil.MockFamilyRepo{
+		CreateFamilyFunc: func(family *models.Family) error {
+			family.ID = 7
+			created = family
+			return nil
+		},
+	}
+	svc := newCrudFamilyService(repo)
+
+	family, err := svc.CreateFamily(10, "The Does")
+	if err != nil {
+		t.Fatalf("CreateFamily error: %v", err)
+	}
+	if created == nil {
+		t.Fatal("repo CreateFamily was not called")
+	}
+	if family.Name != "The Does" || family.OwnerID != 10 {
+		t.Errorf("family = %+v, want Name='The Does' OwnerID=10", family)
+	}
+	if family.ID != 7 {
+		t.Errorf("family.ID = %d, want repo-assigned 7", family.ID)
+	}
+}
+
+func TestCreateFamily_RepoError(t *testing.T) {
+	repo := &testutil.MockFamilyRepo{
+		CreateFamilyFunc: func(family *models.Family) error {
+			return errors.New("duplicate key value violates unique constraint")
+		},
+	}
+	svc := newCrudFamilyService(repo)
+
+	if _, err := svc.CreateFamily(10, "The Does"); err == nil {
+		t.Fatal("expected error when repo create fails")
+	}
+}
+
+// --- AddMember ---
+
+func TestAddMember_Success(t *testing.T) {
+	linkedUserID := uint(33)
+	var created *models.FamilyMember
+	repo := &testutil.MockFamilyRepo{
+		CreateFamilyMemberFunc: func(member *models.FamilyMember) error {
+			member.ID = 5
+			created = member
+			return nil
+		},
+	}
+	svc := newCrudFamilyService(repo)
+
+	member, err := svc.AddMember(7, "Joey", "son", &linkedUserID)
+	if err != nil {
+		t.Fatalf("AddMember error: %v", err)
+	}
+	if created == nil {
+		t.Fatal("repo CreateFamilyMember was not called")
+	}
+	if member.FamilyID != 7 || member.Name != "Joey" || member.Relationship != "son" {
+		t.Errorf("member = %+v, want FamilyID=7 Name=Joey Relationship=son", member)
+	}
+	if member.UserID == nil || *member.UserID != linkedUserID {
+		t.Errorf("member.UserID = %v, want %d", member.UserID, linkedUserID)
+	}
+}
+
+func TestAddMember_NilUserID(t *testing.T) {
+	repo := &testutil.MockFamilyRepo{}
+	svc := newCrudFamilyService(repo)
+
+	member, err := svc.AddMember(7, "Grandma", "grandmother", nil)
+	if err != nil {
+		t.Fatalf("AddMember error: %v", err)
+	}
+	if member.UserID != nil {
+		t.Errorf("member.UserID = %v, want nil for non-app members", member.UserID)
+	}
+}
+
+func TestAddMember_RepoError(t *testing.T) {
+	repo := &testutil.MockFamilyRepo{
+		CreateFamilyMemberFunc: func(member *models.FamilyMember) error {
+			return errors.New("db down")
+		},
+	}
+	svc := newCrudFamilyService(repo)
+
+	if _, err := svc.AddMember(7, "Joey", "son", nil); err == nil {
+		t.Fatal("expected error when repo create fails")
+	}
+}
+
+// --- VerifyMemberOwnership ---
+
+func TestVerifyMemberOwnership_Owner(t *testing.T) {
+	repo := &testutil.MockFamilyRepo{
+		GetFamilyMemberByIDFunc: func(id uint) (*models.FamilyMember, error) {
+			return &models.FamilyMember{ID: id, FamilyID: 7}, nil
+		},
+		GetFamilyByOwnerIDFunc: func(ownerID uint) (*models.Family, error) {
+			return &models.Family{ID: 7, OwnerID: ownerID}, nil
+		},
+	}
+	svc := newCrudFamilyService(repo)
+
+	if err := svc.VerifyMemberOwnership(5, 10); err != nil {
+		t.Errorf("VerifyMemberOwnership error for owner: %v", err)
+	}
+}
+
+func TestVerifyMemberOwnership_NonOwner(t *testing.T) {
+	repo := &testutil.MockFamilyRepo{
+		GetFamilyMemberByIDFunc: func(id uint) (*models.FamilyMember, error) {
+			return &models.FamilyMember{ID: id, FamilyID: 99}, nil // belongs to someone else's family
+		},
+		GetFamilyByOwnerIDFunc: func(ownerID uint) (*models.Family, error) {
+			return &models.Family{ID: 7, OwnerID: ownerID}, nil
+		},
+	}
+	svc := newCrudFamilyService(repo)
+
+	if err := svc.VerifyMemberOwnership(5, 10); err == nil {
+		t.Error("expected error when member belongs to a different family")
+	}
+}
+
+func TestVerifyMemberOwnership_MemberNotFound(t *testing.T) {
+	repo := &testutil.MockFamilyRepo{
+		GetFamilyMemberByIDFunc: func(id uint) (*models.FamilyMember, error) {
+			return nil, errors.New("record not found")
+		},
+	}
+	svc := newCrudFamilyService(repo)
+
+	if err := svc.VerifyMemberOwnership(5, 10); err == nil {
+		t.Error("expected error when member does not exist")
+	}
+}
+
+func TestVerifyMemberOwnership_NoFamily(t *testing.T) {
+	repo := &testutil.MockFamilyRepo{
+		GetFamilyMemberByIDFunc: func(id uint) (*models.FamilyMember, error) {
+			return &models.FamilyMember{ID: id, FamilyID: 7}, nil
+		},
+		GetFamilyByOwnerIDFunc: func(ownerID uint) (*models.Family, error) {
+			return nil, errors.New("record not found")
+		},
+	}
+	svc := newCrudFamilyService(repo)
+
+	if err := svc.VerifyMemberOwnership(5, 10); err == nil {
+		t.Error("expected error when the user has no family")
+	}
+}
+
+// --- UpdateMember ---
+
+func TestUpdateMember_Success(t *testing.T) {
+	var updated *models.FamilyMember
+	repo := &testutil.MockFamilyRepo{
+		GetFamilyMemberByIDFunc: func(id uint) (*models.FamilyMember, error) {
+			return &models.FamilyMember{ID: id, FamilyID: 7, Name: "Old", Relationship: "cousin"}, nil
+		},
+		UpdateFamilyMemberFunc: func(member *models.FamilyMember) error {
+			updated = member
+			return nil
+		},
+	}
+	svc := newCrudFamilyService(repo)
+
+	member, err := svc.UpdateMember(5, "New", "daughter")
+	if err != nil {
+		t.Fatalf("UpdateMember error: %v", err)
+	}
+	if updated == nil {
+		t.Fatal("repo UpdateFamilyMember was not called")
+	}
+	if member.Name != "New" || member.Relationship != "daughter" {
+		t.Errorf("member = %+v, want Name=New Relationship=daughter", member)
+	}
+	if member.ID != 5 || member.FamilyID != 7 {
+		t.Errorf("member identity changed: ID=%d FamilyID=%d", member.ID, member.FamilyID)
+	}
+}
+
+// --- UpdateDietaryProfile ---
+
+func TestUpdateDietaryProfile_MergesIntoExistingRow(t *testing.T) {
+	var saved *models.DietaryProfile
+	repo := &testutil.MockFamilyRepo{
+		GetOrCreateDietaryProfileFunc: func(memberID uint) (*models.DietaryProfile, error) {
+			return &models.DietaryProfile{ID: 3, MemberID: memberID}, nil
+		},
+		UpdateDietaryProfileFunc: func(profile *models.DietaryProfile) error {
+			saved = profile
+			return nil
+		},
+	}
+	svc := newCrudFamilyService(repo)
+
+	incoming := &models.DietaryProfile{
+		Allergies:    models.AllergyList{{Name: "peanuts", Severity: "severe", SubForms: []string{"peanut butter"}}},
+		Intolerances: models.StringList{"lactose"},
+		Restrictions: models.StringList{"halal"},
+		Preferences:  models.StringList{"spicy"},
+		MedicalNotes: "type 1 diabetes",
+	}
+	if err := svc.UpdateDietaryProfile(5, incoming); err != nil {
+		t.Fatalf("UpdateDietaryProfile error: %v", err)
+	}
+	if saved == nil {
+		t.Fatal("repo UpdateDietaryProfile was not called")
+	}
+	// The existing row identity is preserved; client-supplied IDs are ignored.
+	if saved.ID != 3 || saved.MemberID != 5 {
+		t.Errorf("saved identity ID=%d MemberID=%d, want 3/5", saved.ID, saved.MemberID)
+	}
+	if len(saved.Allergies) != 1 || saved.Allergies[0].Name != "peanuts" || len(saved.Allergies[0].SubForms) != 1 {
+		t.Errorf("saved.Allergies = %+v, want incoming allergy with sub-forms", saved.Allergies)
+	}
+	if saved.MedicalNotes != "type 1 diabetes" {
+		t.Errorf("saved.MedicalNotes = %q, want 'type 1 diabetes'", saved.MedicalNotes)
+	}
+	if len(saved.Intolerances) != 1 || len(saved.Restrictions) != 1 || len(saved.Preferences) != 1 {
+		t.Errorf("saved lists = %v/%v/%v, want all copied", saved.Intolerances, saved.Restrictions, saved.Preferences)
+	}
+}
+
+func TestUpdateDietaryProfile_GetOrCreateFails(t *testing.T) {
+	repo := &testutil.MockFamilyRepo{
+		GetOrCreateDietaryProfileFunc: func(memberID uint) (*models.DietaryProfile, error) {
+			return nil, errors.New("db down")
+		},
+	}
+	svc := newCrudFamilyService(repo)
+
+	if err := svc.UpdateDietaryProfile(5, &models.DietaryProfile{}); err == nil {
+		t.Fatal("expected error when profile lookup fails")
+	}
+}

--- a/internal/service/family_test.go
+++ b/internal/service/family_test.go
@@ -1,0 +1,130 @@
+package service
+
+import (
+	"context"
+	"fmt"
+	"testing"
+
+	"github.com/windoze95/saltybytes-api/internal/ai"
+	"github.com/windoze95/saltybytes-api/internal/config"
+	"github.com/windoze95/saltybytes-api/internal/models"
+	"github.com/windoze95/saltybytes-api/internal/testutil"
+)
+
+func newDietaryFamilyService(provider ai.TextProvider) *FamilyService {
+	repo := &testutil.MockFamilyRepo{
+		GetFamilyMemberByIDFunc: func(id uint) (*models.FamilyMember, error) {
+			return &models.FamilyMember{ID: id, FamilyID: 7, Name: "Joey"}, nil
+		},
+	}
+	return NewFamilyService(&config.Config{}, repo, provider)
+}
+
+func TestDietaryInterview_IncompleteTurn(t *testing.T) {
+	provider := &testutil.MockTextProvider{
+		DietaryInterviewFunc: func(ctx context.Context, messages []ai.Message, memberName string) (*ai.DietaryInterviewResult, error) {
+			if memberName != "Joey" {
+				t.Errorf("memberName = %q, want Joey", memberName)
+			}
+			return &ai.DietaryInterviewResult{Response: "Do you have any food allergies?"}, nil
+		},
+	}
+	svc := newDietaryFamilyService(provider)
+
+	response, complete, profile, err := svc.DietaryInterview(context.Background(), 5, []ai.Message{{Role: "user", Content: "hi"}})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if response != "Do you have any food allergies?" {
+		t.Errorf("response = %q, want passthrough of provider text", response)
+	}
+	if complete {
+		t.Error("complete = true, want false")
+	}
+	if profile != nil {
+		t.Errorf("profile = %+v, want nil", profile)
+	}
+}
+
+func TestDietaryInterview_CompleteTurn_MapsProfile(t *testing.T) {
+	provider := &testutil.MockTextProvider{
+		DietaryInterviewFunc: func(ctx context.Context, messages []ai.Message, memberName string) (*ai.DietaryInterviewResult, error) {
+			return &ai.DietaryInterviewResult{
+				Response: "All saved!",
+				Complete: true,
+				Profile: &ai.DietaryProfileResult{
+					Allergies: []ai.DietaryAllergyResult{
+						{Name: "peanuts", Severity: "severe", SubForms: []string{"raw peanuts", "peanut butter"}, Notes: "carries an EpiPen"},
+					},
+					Intolerances: []string{"lactose"},
+					Restrictions: []string{"vegetarian"},
+					Preferences:  []string{"dislikes cilantro"},
+					MedicalNotes: "low sodium",
+				},
+			}, nil
+		},
+	}
+	svc := newDietaryFamilyService(provider)
+
+	response, complete, profile, err := svc.DietaryInterview(context.Background(), 5, []ai.Message{{Role: "user", Content: "that's everything"}})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if response != "All saved!" {
+		t.Errorf("response = %q, want wrap-up text", response)
+	}
+	if !complete {
+		t.Fatal("complete = false, want true")
+	}
+	if profile == nil {
+		t.Fatal("profile = nil, want mapped profile")
+	}
+	if profile.ID != 0 || profile.MemberID != 0 {
+		t.Errorf("profile IDs should be zero, got ID=%d MemberID=%d", profile.ID, profile.MemberID)
+	}
+	if len(profile.Allergies) != 1 {
+		t.Fatalf("len(Allergies) = %d, want 1", len(profile.Allergies))
+	}
+	a := profile.Allergies[0]
+	if a.Name != "peanuts" || a.Severity != "severe" || a.Notes != "carries an EpiPen" {
+		t.Errorf("Allergies[0] = %+v, want peanuts/severe/EpiPen note", a)
+	}
+	if len(a.SubForms) != 2 || a.SubForms[0] != "raw peanuts" || a.SubForms[1] != "peanut butter" {
+		t.Errorf("Allergies[0].SubForms = %v, want [raw peanuts, peanut butter]", a.SubForms)
+	}
+	if len(profile.Intolerances) != 1 || profile.Intolerances[0] != "lactose" {
+		t.Errorf("Intolerances = %v, want [lactose]", profile.Intolerances)
+	}
+	if len(profile.Restrictions) != 1 || profile.Restrictions[0] != "vegetarian" {
+		t.Errorf("Restrictions = %v, want [vegetarian]", profile.Restrictions)
+	}
+	if len(profile.Preferences) != 1 || profile.Preferences[0] != "dislikes cilantro" {
+		t.Errorf("Preferences = %v, want [dislikes cilantro]", profile.Preferences)
+	}
+	if profile.MedicalNotes != "low sodium" {
+		t.Errorf("MedicalNotes = %q, want 'low sodium'", profile.MedicalNotes)
+	}
+}
+
+func TestDietaryInterview_NilProvider(t *testing.T) {
+	svc := NewFamilyService(&config.Config{}, &testutil.MockFamilyRepo{}, nil)
+
+	_, _, _, err := svc.DietaryInterview(context.Background(), 5, nil)
+	if err == nil {
+		t.Fatal("expected error when AI provider is not configured")
+	}
+}
+
+func TestDietaryInterview_MemberNotFound(t *testing.T) {
+	repo := &testutil.MockFamilyRepo{
+		GetFamilyMemberByIDFunc: func(id uint) (*models.FamilyMember, error) {
+			return nil, fmt.Errorf("record not found")
+		},
+	}
+	svc := NewFamilyService(&config.Config{}, repo, &testutil.MockTextProvider{})
+
+	_, _, _, err := svc.DietaryInterview(context.Background(), 5, nil)
+	if err == nil {
+		t.Fatal("expected error when member lookup fails")
+	}
+}

--- a/internal/service/import.go
+++ b/internal/service/import.go
@@ -44,6 +44,7 @@ type ImportService struct {
 	PreviewProvider ai.TextProvider
 	CanonicalRepo   repository.CanonicalRecipeRepo
 	Policy          *ImportPolicy
+	Normalize       *NormalizeService // optional; estimates portions when imports lack them
 
 	// Test seams — nil in production, set in tests to bypass real HTTP/Firecrawl calls
 	HTTPFetchOverride      func(ctx context.Context, url string) (body []byte, statusCode int, err error)
@@ -151,14 +152,14 @@ func (s *ImportService) ImportFromURL(ctx context.Context, rawURL string, user *
 					log.Info("import from canonical cache hit")
 					go s.CanonicalRepo.IncrementHitCount(canonical.ID)
 					canonicalID := canonical.ID
-					recipeResp, _, createErr := s.createImportedRecipe(ctx, &canonical.RecipeData, user, models.RecipeTypeImportLink, rawURL, &canonicalID, nil, canonical.PromptVersion)
+					recipeResp, _, createErr := s.createImportedRecipe(ctx, &canonical.RecipeData, user, models.RecipeTypeImportLink, rawURL, "", &canonicalID, nil, canonical.PromptVersion)
 					return recipeResp, createErr
 				}
 			}
 		}
 	}
 
-	recipeDef, hashtags, method, promptVersion, err := s.extractFromURL(ctx, rawURL)
+	recipeDef, hashtags, imageURL, method, promptVersion, err := s.extractFromURL(ctx, rawURL)
 	if err != nil {
 		log.Error("extraction failed", zap.Error(err))
 		return nil, err
@@ -187,7 +188,7 @@ func (s *ImportService) ImportFromURL(ctx context.Context, rawURL string, user *
 		}
 	}
 
-	recipeResp, _, createErr := s.createImportedRecipe(ctx, recipeDef, user, models.RecipeTypeImportLink, rawURL, canonicalID, hashtags, promptVersion)
+	recipeResp, _, createErr := s.createImportedRecipe(ctx, recipeDef, user, models.RecipeTypeImportLink, rawURL, imageURL, canonicalID, hashtags, promptVersion)
 	return recipeResp, createErr
 }
 
@@ -205,7 +206,7 @@ func (s *ImportService) ImportFromCanonical(ctx context.Context, canonicalID uin
 	go s.CanonicalRepo.IncrementHitCount(canonical.ID)
 
 	cID := canonical.ID
-	resp, _, createErr := s.createImportedRecipe(ctx, &canonical.RecipeData, user, models.RecipeTypeImportLink, canonical.OriginalURL, &cID, nil, canonical.PromptVersion)
+	resp, _, createErr := s.createImportedRecipe(ctx, &canonical.RecipeData, user, models.RecipeTypeImportLink, canonical.OriginalURL, "", &cID, nil, canonical.PromptVersion)
 	return resp, createErr
 }
 
@@ -288,9 +289,10 @@ func (s *ImportService) fetchViaFirecrawl(ctx context.Context, rawURL string) (s
 }
 
 // extractFromURL fetches a URL and extracts recipe data via JSON-LD or AI fallback.
-// Returns the recipe definition, raw hashtag strings, and the extraction method used.
+// Returns the recipe definition, raw hashtag strings, the page's recipe image
+// URL (when available), the extraction method used, and the prompt version.
 // Shared by PreviewFromURL, ImportFromURL, and background refresh.
-func (s *ImportService) extractFromURL(ctx context.Context, rawURL string) (*models.RecipeDef, []string, models.ExtractionMethod, string, error) {
+func (s *ImportService) extractFromURL(ctx context.Context, rawURL string) (*models.RecipeDef, []string, string, models.ExtractionMethod, string, error) {
 	log := logger.Get().With(zap.String("url", rawURL))
 
 	// Check if this domain is known to block direct fetches
@@ -305,20 +307,20 @@ func (s *ImportService) extractFromURL(ctx context.Context, rawURL string) (*mod
 		fcHTML, fcStatus, fcErr := s.fetchViaFirecrawl(ctx, rawURL)
 		if fcErr != nil {
 			log.Warn("firecrawl fallback failed for known-blocking domain", zap.Error(fcErr))
-			return nil, nil, "", "", &ExtractionError{Code: "site_blocked", Message: "this website blocks automated access"}
+			return nil, nil, "", "", "", &ExtractionError{Code: "site_blocked", Message: "this website blocks automated access"}
 		}
 		if fcStatus == http.StatusNotFound {
-			return nil, nil, "", "", &ExtractionError{Code: "not_found", Message: "recipe page not found"}
+			return nil, nil, "", "", "", &ExtractionError{Code: "not_found", Message: "recipe page not found"}
 		}
 		html = fcHTML
 		usedFirecrawl = true
 	} else if s.HTTPFetchOverride != nil {
 		body, statusCode, err := s.HTTPFetchOverride(ctx, rawURL)
 		if err != nil {
-			return nil, nil, "", "", &ExtractionError{Code: "fetch_failed", Message: fmt.Sprintf("failed to fetch URL: %v", err)}
+			return nil, nil, "", "", "", &ExtractionError{Code: "fetch_failed", Message: fmt.Sprintf("failed to fetch URL: %v", err)}
 		}
 		if statusCode == http.StatusNotFound {
-			return nil, nil, "", "", &ExtractionError{Code: "not_found", Message: "recipe page not found"}
+			return nil, nil, "", "", "", &ExtractionError{Code: "not_found", Message: "recipe page not found"}
 		}
 		if isBotBlockStatus(statusCode) || isCloudflareChallenge(body) {
 			log.Info("direct fetch blocked, trying firecrawl", zap.Int("status", statusCode))
@@ -328,35 +330,35 @@ func (s *ImportService) extractFromURL(ctx context.Context, rawURL string) (*mod
 			fcHTML, _, fcErr := s.fetchViaFirecrawl(ctx, rawURL)
 			if fcErr != nil {
 				log.Warn("firecrawl fallback failed", zap.Error(fcErr))
-				return nil, nil, "", "", &ExtractionError{Code: "site_blocked", Message: "this website blocks automated access"}
+				return nil, nil, "", "", "", &ExtractionError{Code: "site_blocked", Message: "this website blocks automated access"}
 			}
 			html = fcHTML
 			usedFirecrawl = true
 		} else if statusCode != http.StatusOK {
-			return nil, nil, "", "", &ExtractionError{Code: "fetch_failed", Message: fmt.Sprintf("URL returned status %d", statusCode)}
+			return nil, nil, "", "", "", &ExtractionError{Code: "fetch_failed", Message: fmt.Sprintf("URL returned status %d", statusCode)}
 		} else {
 			html = string(body)
 		}
 	} else {
 		req, err := http.NewRequestWithContext(ctx, http.MethodGet, rawURL, nil)
 		if err != nil {
-			return nil, nil, "", "", &ExtractionError{Code: "fetch_failed", Message: fmt.Sprintf("failed to create request: %v", err)}
+			return nil, nil, "", "", "", &ExtractionError{Code: "fetch_failed", Message: fmt.Sprintf("failed to create request: %v", err)}
 		}
 		req.Header.Set("User-Agent", defaultUserAgent)
 
 		resp, err := safeHTTPClient.Do(req)
 		if err != nil {
-			return nil, nil, "", "", &ExtractionError{Code: "fetch_failed", Message: fmt.Sprintf("failed to fetch URL: %v", err)}
+			return nil, nil, "", "", "", &ExtractionError{Code: "fetch_failed", Message: fmt.Sprintf("failed to fetch URL: %v", err)}
 		}
 		defer resp.Body.Close()
 
 		body, err := io.ReadAll(io.LimitReader(resp.Body, 2*1024*1024))
 		if err != nil {
-			return nil, nil, "", "", &ExtractionError{Code: "fetch_failed", Message: fmt.Sprintf("failed to read URL body: %v", err)}
+			return nil, nil, "", "", "", &ExtractionError{Code: "fetch_failed", Message: fmt.Sprintf("failed to read URL body: %v", err)}
 		}
 
 		if resp.StatusCode == http.StatusNotFound {
-			return nil, nil, "", "", &ExtractionError{Code: "not_found", Message: "recipe page not found"}
+			return nil, nil, "", "", "", &ExtractionError{Code: "not_found", Message: "recipe page not found"}
 		}
 
 		if isBotBlockStatus(resp.StatusCode) || isCloudflareChallenge(body) {
@@ -367,19 +369,19 @@ func (s *ImportService) extractFromURL(ctx context.Context, rawURL string) (*mod
 			fcHTML, _, fcErr := s.fetchViaFirecrawl(ctx, rawURL)
 			if fcErr != nil {
 				log.Warn("firecrawl fallback failed", zap.Error(fcErr))
-				return nil, nil, "", "", &ExtractionError{Code: "site_blocked", Message: "this website blocks automated access"}
+				return nil, nil, "", "", "", &ExtractionError{Code: "site_blocked", Message: "this website blocks automated access"}
 			}
 			html = fcHTML
 			usedFirecrawl = true
 		} else if resp.StatusCode != http.StatusOK {
-			return nil, nil, "", "", &ExtractionError{Code: "fetch_failed", Message: fmt.Sprintf("URL returned status %d", resp.StatusCode)}
+			return nil, nil, "", "", "", &ExtractionError{Code: "fetch_failed", Message: fmt.Sprintf("URL returned status %d", resp.StatusCode)}
 		} else {
 			html = string(body)
 		}
 	}
 
 	// Phase 2: Extract recipe from HTML
-	recipeDef, hashtags, jsonLDErr := extractJSONLD(html)
+	recipeDef, hashtags, imageURL, jsonLDErr := extractJSONLD(html)
 	if jsonLDErr == nil && recipeDef != nil {
 		recipeDef.SourceURL = rawURL
 		method := models.ExtractionJSONLD
@@ -389,7 +391,7 @@ func (s *ImportService) extractFromURL(ctx context.Context, rawURL string) (*mod
 		if s.Policy != nil {
 			s.Policy.RecordOutcome(rawURL, method, true)
 		}
-		return recipeDef, hashtags, method, "", nil
+		return recipeDef, hashtags, imageURL, method, "", nil
 	}
 
 	// Fall back to AI extraction
@@ -398,10 +400,10 @@ func (s *ImportService) extractFromURL(ctx context.Context, rawURL string) (*mod
 		provider = s.TextProvider
 	}
 	if provider == nil {
-		return nil, nil, "", "", fmt.Errorf("no AI text provider configured for fallback extraction")
+		return nil, nil, "", "", "", fmt.Errorf("no AI text provider configured for fallback extraction")
 	}
 
-	result, err := provider.ExtractRecipeFromText(ctx, html, "preserve source")
+	result, err := provider.ExtractRecipeFromText(ctx, html, ai.UnitSystemPreserveSource)
 	if err != nil {
 		method := models.ExtractionHaiku
 		if usedFirecrawl {
@@ -410,11 +412,12 @@ func (s *ImportService) extractFromURL(ctx context.Context, rawURL string) (*mod
 		if s.Policy != nil {
 			s.Policy.RecordOutcome(rawURL, method, false)
 		}
-		return nil, nil, "", "", fmt.Errorf("failed to extract recipe from URL: %w", err)
+		return nil, nil, "", "", "", fmt.Errorf("failed to extract recipe from URL: %w", err)
 	}
 
 	def := recipeResultToRecipeDef(result)
 	def.SourceURL = rawURL
+	ensureUnitSystem(&def)
 	method := models.ExtractionHaiku
 	if usedFirecrawl {
 		method = models.ExtractionFirecrawlHaiku
@@ -422,7 +425,7 @@ func (s *ImportService) extractFromURL(ctx context.Context, rawURL string) (*mod
 	if s.Policy != nil {
 		s.Policy.RecordOutcome(rawURL, method, true)
 	}
-	return &def, result.Hashtags, method, result.PromptVersion, nil
+	return &def, result.Hashtags, "", method, result.PromptVersion, nil
 }
 
 // fetchAndExtractWithHTML fetches a URL once and returns both the extracted
@@ -434,7 +437,7 @@ func (s *ImportService) fetchAndExtractWithHTML(ctx context.Context, rawURL stri
 		return nil, nil, "", err
 	}
 
-	recipeDef, hashtags, method := s.extractRecipeFromHTML(html, rawURL)
+	recipeDef, hashtags, _, method := s.extractRecipeFromHTML(html, rawURL)
 	if recipeDef != nil {
 		if s.Policy != nil {
 			s.Policy.RecordOutcome(rawURL, method, true)
@@ -452,7 +455,7 @@ func (s *ImportService) fetchAndExtractWithHTML(ctx context.Context, rawURL stri
 		return nil, nil, html, nil
 	}
 
-	result, aiErr := provider.ExtractRecipeFromText(ctx, html, "preserve source")
+	result, aiErr := provider.ExtractRecipeFromText(ctx, html, ai.UnitSystemPreserveSource)
 	if aiErr != nil {
 		// AI extraction failed but HTML is available for card detection
 		return nil, nil, html, nil
@@ -460,18 +463,20 @@ func (s *ImportService) fetchAndExtractWithHTML(ctx context.Context, rawURL stri
 
 	def := recipeResultToRecipeDef(result)
 	def.SourceURL = rawURL
+	ensureUnitSystem(&def)
 	return &def, result.Hashtags, html, nil
 }
 
 // extractRecipeFromHTML attempts JSON-LD extraction from already-fetched HTML.
-// Returns nil recipe if no JSON-LD recipe found.
-func (s *ImportService) extractRecipeFromHTML(html string, rawURL string) (*models.RecipeDef, []string, models.ExtractionMethod) {
-	recipeDef, hashtags, err := extractJSONLD(html)
+// Returns nil recipe if no JSON-LD recipe found. The third return value is the
+// recipe image URL from the JSON-LD payload, when present.
+func (s *ImportService) extractRecipeFromHTML(html string, rawURL string) (*models.RecipeDef, []string, string, models.ExtractionMethod) {
+	recipeDef, hashtags, imageURL, err := extractJSONLD(html)
 	if err != nil || recipeDef == nil {
-		return nil, nil, ""
+		return nil, nil, "", ""
 	}
 	recipeDef.SourceURL = rawURL
-	return recipeDef, hashtags, models.ExtractionJSONLD
+	return recipeDef, hashtags, imageURL, models.ExtractionJSONLD
 }
 
 // fetchHTML fetches the raw HTML of a URL, using Firecrawl fallback if needed.
@@ -575,7 +580,7 @@ func (s *ImportService) ImportFromPhoto(ctx context.Context, imageData []byte, u
 	}
 
 	// Create the recipe first to get an ID for S3 upload
-	recipeResponse, recipeID, err := s.createImportedRecipe(ctx, &def, user, models.RecipeTypeImportVision, "", nil, result.Hashtags, result.PromptVersion)
+	recipeResponse, recipeID, err := s.createImportedRecipe(ctx, &def, user, models.RecipeTypeImportVision, "", "", nil, result.Hashtags, result.PromptVersion)
 	if err != nil {
 		return nil, err
 	}
@@ -616,13 +621,14 @@ func (s *ImportService) ImportFromText(ctx context.Context, text string, user *m
 	if def.UnitSystem == "" {
 		def.UnitSystem = user.Personalization.UnitSystem
 	}
-	resp, _, err := s.createImportedRecipe(ctx, &def, user, models.RecipeTypeImportCopypasta, "", nil, result.Hashtags, result.PromptVersion)
+	resp, _, err := s.createImportedRecipe(ctx, &def, user, models.RecipeTypeImportCopypasta, "", "", nil, result.Hashtags, result.PromptVersion)
 	return resp, err
 }
 
 // ImportManual creates a recipe from structured form input.
-func (s *ImportService) ImportManual(ctx context.Context, recipeDef *models.RecipeDef, user *models.User, recipeType models.RecipeType, hashtags []string) (*RecipeResponse, error) {
-	resp, _, err := s.createImportedRecipe(ctx, recipeDef, user, recipeType, "", nil, hashtags, "")
+// imageURL, when non-empty, is stored as the recipe's image.
+func (s *ImportService) ImportManual(ctx context.Context, recipeDef *models.RecipeDef, user *models.User, recipeType models.RecipeType, hashtags []string, imageURL string) (*RecipeResponse, error) {
+	resp, _, err := s.createImportedRecipe(ctx, recipeDef, user, recipeType, "", imageURL, nil, hashtags, "")
 	return resp, err
 }
 
@@ -665,7 +671,7 @@ func (s *ImportService) PreviewFromURL(ctx context.Context, rawURL string) (*mod
 		}
 	}
 
-	recipeDef, _, method, promptVersion, err := s.extractFromURL(ctx, rawURL)
+	recipeDef, _, _, method, promptVersion, err := s.extractFromURL(ctx, rawURL)
 	if err != nil {
 		log.Error("preview extraction failed", zap.Error(err))
 		return nil, nil, err
@@ -773,7 +779,7 @@ func (s *ImportService) PreviewFromURLWithMultiCheck(ctx context.Context, rawURL
 	}
 
 	// Single recipe — extract from the HTML we already fetched
-	recipeDef, _, method := s.extractRecipeFromHTML(html, rawURL)
+	recipeDef, _, _, method := s.extractRecipeFromHTML(html, rawURL)
 	if recipeDef == nil {
 		// JSON-LD failed — try AI extraction from the same HTML
 		provider := s.PreviewProvider
@@ -783,12 +789,13 @@ func (s *ImportService) PreviewFromURLWithMultiCheck(ctx context.Context, rawURL
 		if provider == nil {
 			return nil, fmt.Errorf("no AI text provider configured for fallback extraction")
 		}
-		result, aiErr := provider.ExtractRecipeFromText(ctx, html, "preserve source")
+		result, aiErr := provider.ExtractRecipeFromText(ctx, html, ai.UnitSystemPreserveSource)
 		if aiErr != nil {
 			return nil, fmt.Errorf("failed to extract recipe from URL: %w", aiErr)
 		}
 		def := recipeResultToRecipeDef(result)
 		def.SourceURL = rawURL
+		ensureUnitSystem(&def)
 		recipeDef = &def
 		method = models.ExtractionHaiku
 	}
@@ -820,13 +827,26 @@ func (s *ImportService) PreviewFromURLWithMultiCheck(ctx context.Context, rawURL
 
 // createImportedRecipe creates a recipe in the DB from a RecipeDef.
 // Returns the RecipeResponse and the raw DB recipe ID.
+// imageURL, when non-empty, is stored as the recipe's image.
 // canonicalID links the recipe to a canonical entry; nil for non-URL imports.
 // hashtags are raw tag strings to associate with the recipe.
-func (s *ImportService) createImportedRecipe(ctx context.Context, recipeDef *models.RecipeDef, user *models.User, recipeType models.RecipeType, sourcePrompt string, canonicalID *uint, hashtags []string, promptVersion string) (*RecipeResponse, uint, error) {
+func (s *ImportService) createImportedRecipe(ctx context.Context, recipeDef *models.RecipeDef, user *models.User, recipeType models.RecipeType, sourcePrompt string, imageURL string, canonicalID *uint, hashtags []string, promptVersion string) (*RecipeResponse, uint, error) {
 	log := logger.Get().With(zap.Uint("user_id", user.ID), zap.String("type", string(recipeType)))
 
 	if recipeDef.Title == "" {
 		return nil, 0, fmt.Errorf("recipe title is required")
+	}
+
+	// Estimate portions when the import lacks them (best-effort).
+	if recipeDef.Portions <= 0 && s.Normalize != nil {
+		if estimate, err := s.Normalize.EstimatePortions(ctx, recipeDef); err != nil {
+			log.Warn("failed to estimate portions for imported recipe", zap.String("title", recipeDef.Title), zap.Error(err))
+		} else if estimate != nil && estimate.Portions > 0 {
+			recipeDef.Portions = estimate.Portions
+			if recipeDef.PortionSize == "" {
+				recipeDef.PortionSize = estimate.PortionSize
+			}
+		}
 	}
 
 	recipe := &models.Recipe{
@@ -836,6 +856,7 @@ func (s *ImportService) createImportedRecipe(ctx context.Context, recipeDef *mod
 		CanonicalID:        canonicalID,
 		HasDiverged:        canonicalID == nil,
 		PromptVersion:      promptVersion,
+		ImageURL:           imageURL,
 	}
 
 	if err := s.RecipeRepo.CreateRecipe(recipe); err != nil {
@@ -907,7 +928,7 @@ func (s *ImportService) refreshStaleCanonicals() {
 		}
 
 		ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
-		recipeDef, _, method, _, err := s.extractFromURL(ctx, entry.OriginalURL)
+		recipeDef, _, _, method, _, err := s.extractFromURL(ctx, entry.OriginalURL)
 		cancel()
 		if err != nil {
 			log.Warn("failed to refresh canonical entry", zap.String("url", entry.OriginalURL), zap.Error(err))
@@ -926,7 +947,6 @@ func (s *ImportService) refreshStaleCanonicals() {
 	}
 }
 
-
 // jsonLDRecipe represents the JSON-LD Recipe schema (subset of fields we care about).
 type jsonLDRecipe struct {
 	Context      interface{} `json:"@context"`
@@ -942,8 +962,8 @@ type jsonLDRecipe struct {
 }
 
 // extractJSONLD tries to find and parse JSON-LD recipe data from HTML.
-// Returns the recipe definition and raw hashtag strings separately.
-func extractJSONLD(html string) (*models.RecipeDef, []string, error) {
+// Returns the recipe definition, raw hashtag strings, and the recipe image URL.
+func extractJSONLD(html string) (*models.RecipeDef, []string, string, error) {
 	re := regexp.MustCompile(`(?s)<script[^>]*type=["']application/ld\+json["'][^>]*>(.*?)</script>`)
 	matches := re.FindAllStringSubmatch(html, -1)
 
@@ -955,31 +975,31 @@ func extractJSONLD(html string) (*models.RecipeDef, []string, error) {
 		jsonStr := strings.TrimSpace(match[1])
 
 		// Try parsing as a single object
-		recipeDef, hashtags, err := tryParseJSONLDObject(jsonStr)
+		recipeDef, hashtags, imageURL, err := tryParseJSONLDObject(jsonStr)
 		if err == nil && recipeDef != nil {
-			return recipeDef, hashtags, nil
+			return recipeDef, hashtags, imageURL, nil
 		}
 
 		// Try parsing as an array
 		var arr []json.RawMessage
 		if err := json.Unmarshal([]byte(jsonStr), &arr); err == nil {
 			for _, item := range arr {
-				recipeDef, hashtags, err := tryParseJSONLDObject(string(item))
+				recipeDef, hashtags, imageURL, err := tryParseJSONLDObject(string(item))
 				if err == nil && recipeDef != nil {
-					return recipeDef, hashtags, nil
+					return recipeDef, hashtags, imageURL, nil
 				}
 			}
 		}
 	}
 
-	return nil, nil, fmt.Errorf("no JSON-LD recipe found")
+	return nil, nil, "", fmt.Errorf("no JSON-LD recipe found")
 }
 
 // tryParseJSONLDObject attempts to parse a JSON string as a JSON-LD Recipe.
-func tryParseJSONLDObject(jsonStr string) (*models.RecipeDef, []string, error) {
+func tryParseJSONLDObject(jsonStr string) (*models.RecipeDef, []string, string, error) {
 	var obj map[string]interface{}
 	if err := json.Unmarshal([]byte(jsonStr), &obj); err != nil {
-		return nil, nil, err
+		return nil, nil, "", err
 	}
 
 	// Check if this is a @graph container
@@ -990,23 +1010,23 @@ func tryParseJSONLDObject(jsonStr string) (*models.RecipeDef, []string, error) {
 				if err != nil {
 					continue
 				}
-				recipeDef, hashtags, err := tryParseJSONLDObject(string(itemBytes))
+				recipeDef, hashtags, imageURL, err := tryParseJSONLDObject(string(itemBytes))
 				if err == nil && recipeDef != nil {
-					return recipeDef, hashtags, nil
+					return recipeDef, hashtags, imageURL, nil
 				}
 			}
 		}
-		return nil, nil, fmt.Errorf("no recipe found in @graph")
+		return nil, nil, "", fmt.Errorf("no recipe found in @graph")
 	}
 
 	// Check @type
 	if !isRecipeType(obj["@type"]) {
-		return nil, nil, fmt.Errorf("not a Recipe type")
+		return nil, nil, "", fmt.Errorf("not a Recipe type")
 	}
 
 	var recipe jsonLDRecipe
 	if err := json.Unmarshal([]byte(jsonStr), &recipe); err != nil {
-		return nil, nil, err
+		return nil, nil, "", err
 	}
 
 	return jsonLDToRecipeDef(&recipe)
@@ -1030,18 +1050,28 @@ func isRecipeType(typeField interface{}) bool {
 }
 
 // jsonLDToRecipeDef converts a parsed JSON-LD recipe to a RecipeDef.
-// Returns the recipe definition and raw hashtag strings separately.
-func jsonLDToRecipeDef(recipe *jsonLDRecipe) (*models.RecipeDef, []string, error) {
+// Returns the recipe definition, raw hashtag strings, and the recipe image URL.
+func jsonLDToRecipeDef(recipe *jsonLDRecipe) (*models.RecipeDef, []string, string, error) {
 	if recipe.Name == "" {
-		return nil, nil, fmt.Errorf("recipe name is empty")
+		return nil, nil, "", fmt.Errorf("recipe name is empty")
 	}
 
-	// Parse ingredients
+	// Parse ingredients into structured amount/unit/name where possible,
+	// always preserving the original text for display.
 	ingredients := make(models.Ingredients, len(recipe.Ingredients))
 	for i, ingStr := range recipe.Ingredients {
-		ingredients[i] = models.Ingredient{
-			Name:         ingStr,
-			OriginalText: ingStr,
+		if amount, unit, name, ok := ParseIngredientLine(ingStr); ok {
+			ingredients[i] = models.Ingredient{
+				Name:         name,
+				Unit:         unit,
+				Amount:       amount,
+				OriginalText: ingStr,
+			}
+		} else {
+			ingredients[i] = models.Ingredient{
+				Name:         ingStr,
+				OriginalText: ingStr,
+			}
 		}
 	}
 
@@ -1062,6 +1092,8 @@ func jsonLDToRecipeDef(recipe *jsonLDRecipe) (*models.RecipeDef, []string, error
 
 	unitSystem := detectUnitSystem(recipe.Ingredients)
 
+	imageURL := parseJSONLDImage(recipe.Image)
+
 	return &models.RecipeDef{
 		Title:        recipe.Name,
 		Ingredients:  ingredients,
@@ -1070,7 +1102,47 @@ func jsonLDToRecipeDef(recipe *jsonLDRecipe) (*models.RecipeDef, []string, error
 		Portions:     portions,
 		ImagePrompt:  fmt.Sprintf("A photo of %s", recipe.Name),
 		UnitSystem:   unitSystem,
-	}, hashtags, nil
+	}, hashtags, imageURL, nil
+}
+
+// parseJSONLDImage extracts the first usable https image URL from a JSON-LD
+// image field, which can be a string, an array, or an ImageObject {url: ...}.
+func parseJSONLDImage(image interface{}) string {
+	switch v := image.(type) {
+	case string:
+		if strings.HasPrefix(v, "https://") {
+			return v
+		}
+	case []interface{}:
+		for _, item := range v {
+			if url := parseJSONLDImage(item); url != "" {
+				return url
+			}
+		}
+	case map[string]interface{}:
+		if url, ok := v["url"].(string); ok && strings.HasPrefix(url, "https://") {
+			return url
+		}
+	}
+	return ""
+}
+
+// ensureUnitSystem fills RecipeDef.UnitSystem heuristically when AI extraction
+// with the preserve-source sentinel left it empty, so ToRecipeResponse does
+// not silently mislabel metric recipes as us_customary.
+func ensureUnitSystem(def *models.RecipeDef) {
+	if def == nil || def.UnitSystem != "" {
+		return
+	}
+	lines := make([]string, 0, len(def.Ingredients))
+	for _, ing := range def.Ingredients {
+		if ing.OriginalText != "" {
+			lines = append(lines, ing.OriginalText)
+			continue
+		}
+		lines = append(lines, strings.TrimSpace(fmt.Sprintf("%v %s %s", ing.Amount, ing.Unit, ing.Name)))
+	}
+	def.UnitSystem = detectUnitSystem(lines)
 }
 
 // Compiled regexes for unit system detection.
@@ -1209,4 +1281,3 @@ func parseKeywords(keywords interface{}) []string {
 	}
 	return nil
 }
-

--- a/internal/service/import.go
+++ b/internal/service/import.go
@@ -587,7 +587,7 @@ func (s *ImportService) ImportFromPhoto(ctx context.Context, imageData []byte, u
 
 	// Upload original image to S3
 	s3Key := fmt.Sprintf("recipes/%d/images/original_import.jpg", recipeID)
-	imageURL, err := s3.UploadRecipeImageToS3(ctx, s.Cfg, imageData, s3Key)
+	imageURL, err := s3.UploadRecipeImageToS3(ctx, s.Cfg, imageData, s3Key, "image/jpeg")
 	if err != nil {
 		log.Error("failed to upload original import image", zap.Uint("recipe_id", recipeID), zap.Error(err))
 		// Non-fatal: recipe was still created

--- a/internal/service/import.go
+++ b/internal/service/import.go
@@ -114,6 +114,24 @@ var safeHTTPClient = &http.Client{
 	},
 }
 
+// canonicalEmbedding generates an embedding literal for a canonical recipe
+// from its title and ingredient names. Best-effort: returns nil when no
+// embedding provider is configured or generation fails.
+func (s *ImportService) canonicalEmbedding(ctx context.Context, recipeDef *models.RecipeDef) *string {
+	if s.RecipeService == nil || s.RecipeService.EmbedProvider == nil {
+		return nil
+	}
+
+	embedding, err := s.RecipeService.EmbedProvider.GenerateEmbedding(ctx, embeddingText(recipeDef))
+	if err != nil {
+		logger.Get().Warn("failed to generate canonical embedding", zap.String("title", recipeDef.Title), zap.Error(err))
+		return nil
+	}
+
+	literal := repository.PgvectorLiteral(embedding)
+	return &literal
+}
+
 // ImportFromURL fetches a page, tries JSON-LD extraction first, falls back to AI.
 // When a CanonicalRepo is configured, it checks the canonical cache first and
 // saves extractions for future deduplication.
@@ -159,6 +177,7 @@ func (s *ImportService) ImportFromURL(ctx context.Context, rawURL string, user *
 				FetchedAt:        now,
 				LastAccessedAt:   now,
 				PromptVersion:    promptVersion,
+				Embedding:        s.canonicalEmbedding(ctx, recipeDef),
 			}
 			if upsertErr := s.CanonicalRepo.Upsert(entry); upsertErr == nil {
 				canonicalID = &entry.ID
@@ -665,6 +684,7 @@ func (s *ImportService) PreviewFromURL(ctx context.Context, rawURL string) (*mod
 				FetchedAt:        now,
 				LastAccessedAt:   now,
 				PromptVersion:    promptVersion,
+				Embedding:        s.canonicalEmbedding(ctx, recipeDef),
 			}
 			if upsertErr := s.CanonicalRepo.Upsert(entry); upsertErr == nil {
 				canonicalID = &entry.ID
@@ -785,6 +805,7 @@ func (s *ImportService) PreviewFromURLWithMultiCheck(ctx context.Context, rawURL
 				ExtractionMethod: method,
 				FetchedAt:        now,
 				LastAccessedAt:   now,
+				Embedding:        s.canonicalEmbedding(ctx, recipeDef),
 			}
 			if upsertErr := s.CanonicalRepo.Upsert(entry); upsertErr == nil {
 				canonicalID = &entry.ID
@@ -898,6 +919,7 @@ func (s *ImportService) refreshStaleCanonicals() {
 		entry.ExtractionMethod = method
 		entry.FetchedAt = now
 		entry.LastAccessedAt = now
+		entry.Embedding = s.canonicalEmbedding(context.Background(), recipeDef)
 		if err := s.CanonicalRepo.Upsert(&entry); err != nil {
 			log.Warn("failed to upsert refreshed canonical", zap.String("url", entry.OriginalURL), zap.Error(err))
 		}

--- a/internal/service/import.go
+++ b/internal/service/import.go
@@ -940,7 +940,11 @@ func (s *ImportService) refreshStaleCanonicals() {
 		entry.ExtractionMethod = method
 		entry.FetchedAt = now
 		entry.LastAccessedAt = now
-		entry.Embedding = s.canonicalEmbedding(context.Background(), recipeDef)
+		// The extract context above is already cancelled; bound the embedding
+		// call separately so a stalled provider can't wedge the refresh loop.
+		embedCtx, embedCancel := context.WithTimeout(context.Background(), embeddingCallTimeout)
+		entry.Embedding = s.canonicalEmbedding(embedCtx, recipeDef)
+		embedCancel()
 		if err := s.CanonicalRepo.Upsert(&entry); err != nil {
 			log.Warn("failed to upsert refreshed canonical", zap.String("url", entry.OriginalURL), zap.Error(err))
 		}

--- a/internal/service/import_policy.go
+++ b/internal/service/import_policy.go
@@ -13,17 +13,17 @@ import (
 
 // DomainStats tracks extraction success/failure rates for a domain.
 type DomainStats struct {
-	Domain              string
-	TotalAttempts       int
-	JSONLDSuccesses     int
-	JSONLDFailures      int
-	DirectFetchBlocked  int
-	FirecrawlSuccesses  int
-	FirecrawlFailures   int
-	AISuccesses         int
-	AIFailures          int
-	LastAttempt         time.Time
-	LastSuccess         time.Time
+	Domain             string
+	TotalAttempts      int
+	JSONLDSuccesses    int
+	JSONLDFailures     int
+	DirectFetchBlocked int
+	FirecrawlSuccesses int
+	FirecrawlFailures  int
+	AISuccesses        int
+	AIFailures         int
+	LastAttempt        time.Time
+	LastSuccess        time.Time
 }
 
 // ImportPolicy tracks per-domain extraction outcomes and recommends strategies.

--- a/internal/service/import_policy_test.go
+++ b/internal/service/import_policy_test.go
@@ -214,7 +214,7 @@ func TestExtractFromURL_PolicyRecordsOutcome_JSONLD(t *testing.T) {
 		return []byte(jsonLDHTML()), 200, nil
 	}
 
-	_, _, method, _, err := svc.extractFromURL(context.Background(), "https://example.com/recipe")
+	_, _, _, method, _, err := svc.extractFromURL(context.Background(), "https://example.com/recipe")
 	if err != nil {
 		t.Fatalf("extractFromURL error: %v", err)
 	}
@@ -241,7 +241,7 @@ func TestExtractFromURL_PolicyRecordsBlocked(t *testing.T) {
 		return jsonLDHTML(), 200, nil
 	}
 
-	_, _, _, _, err := svc.extractFromURL(context.Background(), "https://blocked.com/recipe")
+	_, _, _, _, _, err := svc.extractFromURL(context.Background(), "https://blocked.com/recipe")
 	if err != nil {
 		t.Fatalf("extractFromURL error: %v", err)
 	}
@@ -277,7 +277,7 @@ func TestExtractFromURL_PolicySkipsDirectFetch(t *testing.T) {
 		return jsonLDHTML(), 200, nil
 	}
 
-	def, _, method, _, err := svc.extractFromURL(context.Background(), "https://blocked.com/new-recipe")
+	def, _, _, method, _, err := svc.extractFromURL(context.Background(), "https://blocked.com/new-recipe")
 	if err != nil {
 		t.Fatalf("extractFromURL error: %v", err)
 	}
@@ -310,7 +310,7 @@ func TestExtractFromURL_PolicySkipsDirectFetch_404(t *testing.T) {
 		return "<html>Not Found</html>", 404, nil
 	}
 
-	_, _, _, _, err := svc.extractFromURL(context.Background(), "https://blocked.com/deleted-recipe")
+	_, _, _, _, _, err := svc.extractFromURL(context.Background(), "https://blocked.com/deleted-recipe")
 	if err == nil {
 		t.Fatal("expected error for 404 on skip-direct domain")
 	}
@@ -332,7 +332,7 @@ func TestExtractFromURL_NilPolicyStillWorks(t *testing.T) {
 		return []byte(jsonLDHTML()), 200, nil
 	}
 
-	def, _, method, _, err := svc.extractFromURL(context.Background(), "https://example.com/recipe")
+	def, _, _, method, _, err := svc.extractFromURL(context.Background(), "https://example.com/recipe")
 	if err != nil {
 		t.Fatalf("extractFromURL error: %v", err)
 	}

--- a/internal/service/import_service_test.go
+++ b/internal/service/import_service_test.go
@@ -110,7 +110,7 @@ func TestImportManual_Success(t *testing.T) {
 		ImagePrompt:  "A photo of pancakes",
 	}
 
-	resp, err := svc.ImportManual(context.Background(), recipeDef, user, models.RecipeTypeManualEntry, nil)
+	resp, err := svc.ImportManual(context.Background(), recipeDef, user, models.RecipeTypeManualEntry, nil, "")
 	if err != nil {
 		t.Fatalf("ImportManual error: %v", err)
 	}
@@ -132,7 +132,7 @@ func TestImportManual_EmptyTitle(t *testing.T) {
 		Ingredients: models.Ingredients{{Name: "Flour"}},
 	}
 
-	_, err := svc.ImportManual(context.Background(), recipeDef, user, models.RecipeTypeManualEntry, nil)
+	_, err := svc.ImportManual(context.Background(), recipeDef, user, models.RecipeTypeManualEntry, nil, "")
 	if err == nil {
 		t.Fatal("ImportManual with empty title should return error")
 	}
@@ -151,7 +151,7 @@ func TestImportManual_WithSourceURL(t *testing.T) {
 		SourceURL:    "https://example.com/recipe",
 	}
 
-	resp, err := svc.ImportManual(context.Background(), recipeDef, user, models.RecipeTypeImportLink, nil)
+	resp, err := svc.ImportManual(context.Background(), recipeDef, user, models.RecipeTypeImportLink, nil, "")
 	if err != nil {
 		t.Fatalf("ImportManual with source URL error: %v", err)
 	}
@@ -183,7 +183,7 @@ func TestCreateImportedRecipe_AssociatesTags(t *testing.T) {
 		ImagePrompt:  "A baked thing",
 	}
 
-	resp, _, err := svc.createImportedRecipe(context.Background(), recipeDef, user, models.RecipeTypeManualEntry, "", nil, []string{"baking", "easy"}, "")
+	resp, _, err := svc.createImportedRecipe(context.Background(), recipeDef, user, models.RecipeTypeManualEntry, "", "", nil, []string{"baking", "easy"}, "")
 	if err != nil {
 		t.Fatalf("createImportedRecipe error: %v", err)
 	}
@@ -338,7 +338,7 @@ func TestCreateImportedRecipe_CreatesTree(t *testing.T) {
 		ImagePrompt:  "Salty",
 	}
 
-	_, _, err := svc.createImportedRecipe(context.Background(), recipeDef, user, models.RecipeTypeImportCopypasta, "", nil, nil, "")
+	_, _, err := svc.createImportedRecipe(context.Background(), recipeDef, user, models.RecipeTypeImportCopypasta, "", "", nil, nil, "")
 	if err != nil {
 		t.Fatalf("createImportedRecipe error: %v", err)
 	}
@@ -361,7 +361,7 @@ func TestExtractFromURL_DirectSuccess(t *testing.T) {
 		return []byte(jsonLDHTML()), 200, nil
 	}
 
-	def, _, method, _, err := svc.extractFromURL(context.Background(), "https://example.com/recipe")
+	def, _, _, method, _, err := svc.extractFromURL(context.Background(), "https://example.com/recipe")
 	if err != nil {
 		t.Fatalf("extractFromURL error: %v", err)
 	}
@@ -385,7 +385,7 @@ func TestExtractFromURL_DirectSuccess_AIFallback(t *testing.T) {
 		return []byte(plainHTML()), 200, nil
 	}
 
-	def, _, method, _, err := svc.extractFromURL(context.Background(), "https://example.com/recipe")
+	def, _, _, method, _, err := svc.extractFromURL(context.Background(), "https://example.com/recipe")
 	if err != nil {
 		t.Fatalf("extractFromURL error: %v", err)
 	}
@@ -408,7 +408,7 @@ func TestExtractFromURL_403_FirecrawlSuccess(t *testing.T) {
 		return jsonLDHTML(), 200, nil
 	}
 
-	def, _, method, _, err := svc.extractFromURL(context.Background(), "https://example.com/recipe")
+	def, _, _, method, _, err := svc.extractFromURL(context.Background(), "https://example.com/recipe")
 	if err != nil {
 		t.Fatalf("extractFromURL error: %v", err)
 	}
@@ -431,7 +431,7 @@ func TestExtractFromURL_403_FirecrawlFail(t *testing.T) {
 		return "", 0, fmt.Errorf("firecrawl error")
 	}
 
-	_, _, _, _, err := svc.extractFromURL(context.Background(), "https://example.com/recipe")
+	_, _, _, _, _, err := svc.extractFromURL(context.Background(), "https://example.com/recipe")
 	if err == nil {
 		t.Fatal("expected error when firecrawl fails")
 	}
@@ -452,7 +452,7 @@ func TestExtractFromURL_403_NoFirecrawlKey(t *testing.T) {
 		return []byte("Forbidden"), 403, nil
 	}
 
-	_, _, _, _, err := svc.extractFromURL(context.Background(), "https://example.com/recipe")
+	_, _, _, _, _, err := svc.extractFromURL(context.Background(), "https://example.com/recipe")
 	if err == nil {
 		t.Fatal("expected error when no firecrawl key")
 	}
@@ -472,7 +472,7 @@ func TestExtractFromURL_404(t *testing.T) {
 		return []byte("Not Found"), 404, nil
 	}
 
-	_, _, _, _, err := svc.extractFromURL(context.Background(), "https://example.com/recipe")
+	_, _, _, _, _, err := svc.extractFromURL(context.Background(), "https://example.com/recipe")
 	if err == nil {
 		t.Fatal("expected error on 404")
 	}
@@ -496,7 +496,7 @@ func TestExtractFromURL_CloudflareChallenge(t *testing.T) {
 		return jsonLDHTML(), 200, nil
 	}
 
-	def, _, method, _, err := svc.extractFromURL(context.Background(), "https://example.com/recipe")
+	def, _, _, method, _, err := svc.extractFromURL(context.Background(), "https://example.com/recipe")
 	if err != nil {
 		t.Fatalf("extractFromURL error: %v", err)
 	}
@@ -521,7 +521,7 @@ func TestExtractFromURL_500_NoFirecrawl(t *testing.T) {
 		return "", 0, fmt.Errorf("should not be called")
 	}
 
-	_, _, _, _, err := svc.extractFromURL(context.Background(), "https://example.com/recipe")
+	_, _, _, _, _, err := svc.extractFromURL(context.Background(), "https://example.com/recipe")
 	if err == nil {
 		t.Fatal("expected error on 500")
 	}
@@ -581,5 +581,197 @@ func TestIsCloudflareChallenge(t *testing.T) {
 				t.Errorf("isCloudflareChallenge(%q) = %v, want %v", tt.name, got, tt.want)
 			}
 		})
+	}
+}
+
+// jsonLDHTMLWithImage wraps recipe JSON-LD (including an image field) in a
+// minimal HTML page for test use.
+func jsonLDHTMLWithImage() string {
+	return `<html><head><script type="application/ld+json">
+	{"@context":"https://schema.org","@type":"Recipe","name":"Classic Pancakes",
+	"image":["https://example.com/images/pancakes.jpg"],
+	"recipeIngredient":["1 1/2 cups flour","2 eggs","a pinch of salt"],
+	"recipeInstructions":[{"@type":"HowToStep","text":"Mix"}],
+	"cookTime":"PT20M","recipeYield":"4 servings"}
+	</script></head><body></body></html>`
+}
+
+func TestImportFromURL_JSONLD_StructuredIngredientsAndImage(t *testing.T) {
+	repo := testutil.NewMockRecipeRepo()
+	svc := newTestImportService(repo, nil, nil)
+	svc.HTTPFetchOverride = func(ctx context.Context, url string) ([]byte, int, error) {
+		return []byte(jsonLDHTMLWithImage()), 200, nil
+	}
+	user := testutil.TestUser()
+
+	resp, err := svc.ImportFromURL(context.Background(), "https://example.com/recipe", user)
+	if err != nil {
+		t.Fatalf("ImportFromURL error: %v", err)
+	}
+	if resp == nil {
+		t.Fatal("ImportFromURL returned nil response")
+	}
+
+	if len(repo.Recipes) != 1 {
+		t.Fatalf("recipes in repo = %d, want 1", len(repo.Recipes))
+	}
+	var recipe *models.Recipe
+	for _, r := range repo.Recipes {
+		recipe = r
+	}
+
+	// JSON-LD image should be threaded through to Recipe.ImageURL
+	if recipe.ImageURL != "https://example.com/images/pancakes.jpg" {
+		t.Errorf("ImageURL = %q, want JSON-LD image", recipe.ImageURL)
+	}
+
+	if len(recipe.Ingredients) != 3 {
+		t.Fatalf("ingredients count = %d, want 3", len(recipe.Ingredients))
+	}
+
+	// "1 1/2 cups flour" should be structured
+	flour := recipe.Ingredients[0]
+	if flour.Amount != 1.5 || flour.Unit != "cup" || flour.Name != "flour" {
+		t.Errorf("flour = %+v, want amount=1.5 unit=cup name=flour", flour)
+	}
+	if flour.OriginalText != "1 1/2 cups flour" {
+		t.Errorf("flour OriginalText = %q, want '1 1/2 cups flour'", flour.OriginalText)
+	}
+
+	// "2 eggs" — quantity but no unit
+	eggs := recipe.Ingredients[1]
+	if eggs.Amount != 2 || eggs.Unit != "" || eggs.Name != "eggs" {
+		t.Errorf("eggs = %+v, want amount=2 unit='' name=eggs", eggs)
+	}
+
+	// "a pinch of salt" — words-only quantity stays unparsed
+	salt := recipe.Ingredients[2]
+	if salt.Name != "a pinch of salt" || salt.Amount != 0 {
+		t.Errorf("salt = %+v, want unparsed name='a pinch of salt'", salt)
+	}
+	if salt.OriginalText != "a pinch of salt" {
+		t.Errorf("salt OriginalText = %q", salt.OriginalText)
+	}
+}
+
+func TestExtractFromURL_HaikuFallback_DetectsUnitSystem(t *testing.T) {
+	repo := testutil.NewMockRecipeRepo()
+	mockPreview := &testutil.MockTextProvider{
+		ExtractRecipeFromTextFunc: func(ctx context.Context, text string, unitSystem string) (*ai.RecipeResult, error) {
+			if unitSystem != ai.UnitSystemPreserveSource {
+				t.Errorf("unitSystem = %q, want %q", unitSystem, ai.UnitSystemPreserveSource)
+			}
+			// Tool result with empty unit_system but clearly metric ingredients
+			return &ai.RecipeResult{
+				Title: "Metric Cake",
+				Ingredients: []ai.IngredientResult{
+					{Name: "flour", Unit: "g", Amount: 250, OriginalText: "250 g flour"},
+					{Name: "milk", Unit: "mL", Amount: 100, OriginalText: "100 ml milk"},
+				},
+				Instructions: []string{"Mix"},
+				ImagePrompt:  "A cake",
+			}, nil
+		},
+	}
+	svc := newTestImportService(repo, nil, mockPreview)
+	svc.HTTPFetchOverride = func(ctx context.Context, url string) ([]byte, int, error) {
+		return []byte(plainHTML()), 200, nil
+	}
+
+	def, _, _, _, _, err := svc.extractFromURL(context.Background(), "https://example.com/recipe")
+	if err != nil {
+		t.Fatalf("extractFromURL error: %v", err)
+	}
+	if def.UnitSystem != "metric" {
+		t.Errorf("UnitSystem = %q, want 'metric' (detected from ingredient text)", def.UnitSystem)
+	}
+}
+
+func TestCreateImportedRecipe_EstimatesPortionsWhenMissing(t *testing.T) {
+	repo := testutil.NewMockRecipeRepo()
+	svc := newTestImportService(repo, nil, nil)
+	svc.Normalize = NewNormalizeService(&config.Config{}, &testutil.MockTextProvider{
+		EstimatePortionsFunc: func(ctx context.Context, recipeDef interface{}) (*ai.PortionEstimate, error) {
+			return &ai.PortionEstimate{Portions: 6, PortionSize: "1 bowl", Confidence: 0.9}, nil
+		},
+	})
+	user := testutil.TestUser()
+
+	recipeDef := &models.RecipeDef{
+		Title:        "No Portions Soup",
+		Ingredients:  models.Ingredients{{Name: "Water"}},
+		Instructions: []string{"Boil"},
+		ImagePrompt:  "A soup",
+	}
+
+	_, recipeID, err := svc.createImportedRecipe(context.Background(), recipeDef, user, models.RecipeTypeImportLink, "", "", nil, nil, "")
+	if err != nil {
+		t.Fatalf("createImportedRecipe error: %v", err)
+	}
+
+	recipe := repo.Recipes[recipeID]
+	if recipe.Portions != 6 {
+		t.Errorf("Portions = %d, want 6 (estimated)", recipe.Portions)
+	}
+	if recipe.PortionSize != "1 bowl" {
+		t.Errorf("PortionSize = %q, want '1 bowl'", recipe.PortionSize)
+	}
+}
+
+func TestCreateImportedRecipe_PortionEstimateFailureContinues(t *testing.T) {
+	repo := testutil.NewMockRecipeRepo()
+	svc := newTestImportService(repo, nil, nil)
+	svc.Normalize = NewNormalizeService(&config.Config{}, &testutil.MockTextProvider{
+		EstimatePortionsFunc: func(ctx context.Context, recipeDef interface{}) (*ai.PortionEstimate, error) {
+			return nil, errors.New("AI unavailable")
+		},
+	})
+	user := testutil.TestUser()
+
+	recipeDef := &models.RecipeDef{
+		Title:        "Still Imports",
+		Ingredients:  models.Ingredients{{Name: "Water"}},
+		Instructions: []string{"Boil"},
+		ImagePrompt:  "A soup",
+	}
+
+	resp, _, err := svc.createImportedRecipe(context.Background(), recipeDef, user, models.RecipeTypeImportLink, "", "", nil, nil, "")
+	if err != nil {
+		t.Fatalf("createImportedRecipe should not fail when estimation fails: %v", err)
+	}
+	if resp == nil {
+		t.Fatal("expected recipe response despite estimation failure")
+	}
+}
+
+func TestCreateImportedRecipe_KeepsExistingPortions(t *testing.T) {
+	repo := testutil.NewMockRecipeRepo()
+	called := false
+	svc := newTestImportService(repo, nil, nil)
+	svc.Normalize = NewNormalizeService(&config.Config{}, &testutil.MockTextProvider{
+		EstimatePortionsFunc: func(ctx context.Context, recipeDef interface{}) (*ai.PortionEstimate, error) {
+			called = true
+			return &ai.PortionEstimate{Portions: 99}, nil
+		},
+	})
+	user := testutil.TestUser()
+
+	recipeDef := &models.RecipeDef{
+		Title:        "Has Portions",
+		Ingredients:  models.Ingredients{{Name: "Water"}},
+		Instructions: []string{"Boil"},
+		ImagePrompt:  "A soup",
+		Portions:     4,
+	}
+
+	_, recipeID, err := svc.createImportedRecipe(context.Background(), recipeDef, user, models.RecipeTypeImportLink, "", "", nil, nil, "")
+	if err != nil {
+		t.Fatalf("createImportedRecipe error: %v", err)
+	}
+	if called {
+		t.Error("EstimatePortions should not be called when portions are present")
+	}
+	if repo.Recipes[recipeID].Portions != 4 {
+		t.Errorf("Portions = %d, want 4 (unchanged)", repo.Recipes[recipeID].Portions)
 	}
 }

--- a/internal/service/import_test.go
+++ b/internal/service/import_test.go
@@ -266,7 +266,7 @@ func TestExtractJSONLD_ValidRecipe(t *testing.T) {
 	</script>
 	</head><body></body></html>`
 
-	def, _, err := extractJSONLD(html)
+	def, _, _, err := extractJSONLD(html)
 	if err != nil {
 		t.Fatalf("extractJSONLD valid recipe: unexpected error: %v", err)
 	}
@@ -299,7 +299,7 @@ func TestExtractJSONLD_GraphContainer(t *testing.T) {
 	</script>
 	</head><body></body></html>`
 
-	def, _, err := extractJSONLD(html)
+	def, _, _, err := extractJSONLD(html)
 	if err != nil {
 		t.Fatalf("extractJSONLD @graph: unexpected error: %v", err)
 	}
@@ -310,7 +310,7 @@ func TestExtractJSONLD_GraphContainer(t *testing.T) {
 
 func TestExtractJSONLD_NoJSONLD(t *testing.T) {
 	html := `<html><head><title>No JSON-LD</title></head><body></body></html>`
-	_, _, err := extractJSONLD(html)
+	_, _, _, err := extractJSONLD(html)
 	if err == nil {
 		t.Error("extractJSONLD with no JSON-LD should return error")
 	}
@@ -323,7 +323,7 @@ func TestExtractJSONLD_NonRecipeType(t *testing.T) {
 	</script>
 	</head><body></body></html>`
 
-	_, _, err := extractJSONLD(html)
+	_, _, _, err := extractJSONLD(html)
 	if err == nil {
 		t.Error("extractJSONLD with non-Recipe type should return error")
 	}
@@ -342,7 +342,7 @@ func TestExtractJSONLD_UsesTotalTimeAsFallback(t *testing.T) {
 	</script>
 	</head><body></body></html>`
 
-	def, _, err := extractJSONLD(html)
+	def, _, _, err := extractJSONLD(html)
 	if err != nil {
 		t.Fatalf("extractJSONLD totalTime fallback: unexpected error: %v", err)
 	}
@@ -429,7 +429,7 @@ func TestJsonLDToRecipeDef_Valid(t *testing.T) {
 		Keywords:     "italian, pasta, easy",
 	}
 
-	def, hashtags, err := jsonLDToRecipeDef(recipe)
+	def, hashtags, _, err := jsonLDToRecipeDef(recipe)
 	if err != nil {
 		t.Fatalf("jsonLDToRecipeDef valid: %v", err)
 	}
@@ -462,7 +462,7 @@ func TestJsonLDToRecipeDef_EmptyName(t *testing.T) {
 		Name:        "",
 		Ingredients: []string{"flour"},
 	}
-	_, _, err := jsonLDToRecipeDef(recipe)
+	_, _, _, err := jsonLDToRecipeDef(recipe)
 	if err == nil {
 		t.Error("jsonLDToRecipeDef with empty name should return error")
 	}
@@ -474,7 +474,7 @@ func TestJsonLDToRecipeDef_TotalTimeFallback(t *testing.T) {
 		TotalTime:   "PT1H",
 		Ingredients: []string{"water"},
 	}
-	def, _, err := jsonLDToRecipeDef(recipe)
+	def, _, _, err := jsonLDToRecipeDef(recipe)
 	if err != nil {
 		t.Fatalf("jsonLDToRecipeDef totalTime fallback: %v", err)
 	}
@@ -648,7 +648,7 @@ func TestJsonLDToRecipeDef_DetectsUnitSystem(t *testing.T) {
 		Instructions: []interface{}{"Mix"},
 	}
 
-	def, _, err := jsonLDToRecipeDef(recipe)
+	def, _, _, err := jsonLDToRecipeDef(recipe)
 	if err != nil {
 		t.Fatalf("jsonLDToRecipeDef: %v", err)
 	}
@@ -664,7 +664,7 @@ func TestJsonLDToRecipeDef_DetectsCompactMetric(t *testing.T) {
 		Instructions: []interface{}{"Mix"},
 	}
 
-	def, _, err := jsonLDToRecipeDef(recipe)
+	def, _, _, err := jsonLDToRecipeDef(recipe)
 	if err != nil {
 		t.Fatalf("jsonLDToRecipeDef compact metric: %v", err)
 	}

--- a/internal/service/ingredient_parse.go
+++ b/internal/service/ingredient_parse.go
@@ -162,11 +162,16 @@ func parseNumberToken(tok string) (float64, bool) {
 				return 0, false
 			}
 			right := tok[idx+len(sep):]
-			if frac, fracOK := parseFractionToken(right); fracOK {
-				return low + frac, true // mixed number, e.g. "1-1/2"
+			// A fractional right side is a mixed number only when the left
+			// side is a whole integer ("1-1/2" = 1.5). With a fractional
+			// left side it is a range ("1/2-3/4") and the low value is kept.
+			if isWholeIntegerToken(tok[:idx]) {
+				if frac, fracOK := parseFractionToken(right); fracOK {
+					return low + frac, true // mixed number, e.g. "1-1/2"
+				}
 			}
 			if _, highOK := parseNumberToken(right); highOK {
-				return low, true // range, e.g. "1-2" — use the low value
+				return low, true // range, e.g. "1-2" or "1/2-3/4" — use the low value
 			}
 			return 0, false
 		}
@@ -192,6 +197,20 @@ func parseNumberToken(tok string) (float64, bool) {
 		return 0, false
 	}
 	return v, true
+}
+
+// isWholeIntegerToken reports whether a token is a plain whole integer
+// (digits only — no fraction slash, decimal point, or unicode fraction).
+func isWholeIntegerToken(tok string) bool {
+	if tok == "" {
+		return false
+	}
+	for _, r := range tok {
+		if r < '0' || r > '9' {
+			return false
+		}
+	}
+	return true
 }
 
 // parseFractionToken parses a token that is purely a fraction: "1/2" or "½".

--- a/internal/service/ingredient_parse.go
+++ b/internal/service/ingredient_parse.go
@@ -1,0 +1,251 @@
+package service
+
+import (
+	"strconv"
+	"strings"
+)
+
+// unicodeFractions maps single-rune vulgar fractions to their decimal values.
+var unicodeFractions = map[rune]float64{
+	'½': 1.0 / 2,
+	'⅓': 1.0 / 3,
+	'⅔': 2.0 / 3,
+	'¼': 1.0 / 4,
+	'¾': 3.0 / 4,
+	'⅕': 1.0 / 5,
+	'⅖': 2.0 / 5,
+	'⅗': 3.0 / 5,
+	'⅘': 4.0 / 5,
+	'⅙': 1.0 / 6,
+	'⅚': 5.0 / 6,
+	'⅐': 1.0 / 7,
+	'⅛': 1.0 / 8,
+	'⅜': 3.0 / 8,
+	'⅝': 5.0 / 8,
+	'⅞': 7.0 / 8,
+	'⅑': 1.0 / 9,
+	'⅒': 1.0 / 10,
+}
+
+// unitAliases maps lowercase unit spellings (plurals, abbreviations, long
+// forms) to the canonical unit enum used by the create_recipe Claude tool
+// schema: pieces, tsp, tbsp, fl oz, cup, pt, qt, gal, oz, lb, mL, L, mg, g,
+// kg, pinch, dash, drop, bushel.
+// "T"/"t" are handled case-sensitively before this table is consulted.
+var unitAliases = map[string]string{
+	// volume — US customary
+	"tsp": "tsp", "tsps": "tsp", "teaspoon": "tsp", "teaspoons": "tsp",
+	"tbsp": "tbsp", "tbsps": "tbsp", "tbs": "tbsp", "tbl": "tbsp", "tblsp": "tbsp",
+	"tablespoon": "tbsp", "tablespoons": "tbsp",
+	"cup": "cup", "cups": "cup", "c": "cup",
+	"pt": "pt", "pts": "pt", "pint": "pt", "pints": "pt",
+	"qt": "qt", "qts": "qt", "quart": "qt", "quarts": "qt",
+	"gal": "gal", "gals": "gal", "gallon": "gal", "gallons": "gal",
+	"floz": "fl oz",
+	// weight — US customary
+	"oz": "oz", "ozs": "oz", "ounce": "oz", "ounces": "oz",
+	"lb": "lb", "lbs": "lb", "pound": "lb", "pounds": "lb",
+	// metric volume
+	"ml": "mL", "mls": "mL", "milliliter": "mL", "milliliters": "mL",
+	"millilitre": "mL", "millilitres": "mL", "cc": "mL",
+	"l": "L", "liter": "L", "liters": "L", "litre": "L", "litres": "L",
+	// metric weight
+	"mg": "mg", "mgs": "mg", "milligram": "mg", "milligrams": "mg",
+	"g": "g", "gram": "g", "grams": "g", "gr": "g",
+	"kg": "kg", "kgs": "kg", "kilogram": "kg", "kilograms": "kg", "kilo": "kg", "kilos": "kg",
+	// small measures
+	"pinch": "pinch", "pinches": "pinch",
+	"dash": "dash", "dashes": "dash",
+	"drop": "drop", "drops": "drop",
+	"bushel": "bushel", "bushels": "bushel",
+	// countable descriptors — collapse to the canonical "pieces"
+	"piece": "pieces", "pieces": "pieces", "pc": "pieces", "pcs": "pieces",
+	"clove": "pieces", "cloves": "pieces",
+	"can": "pieces", "cans": "pieces",
+	"slice": "pieces", "slices": "pieces",
+	"stick": "pieces", "sticks": "pieces",
+	"stalk": "pieces", "stalks": "pieces",
+	"sprig": "pieces", "sprigs": "pieces",
+	"head": "pieces", "heads": "pieces",
+	"bunch": "pieces", "bunches": "pieces",
+	"package": "pieces", "packages": "pieces", "pkg": "pieces", "pkgs": "pieces",
+	"ear": "pieces", "ears": "pieces",
+	"fillet": "pieces", "fillets": "pieces",
+}
+
+// ParseIngredientLine deterministically parses a free-form ingredient line
+// (e.g. "1 1/2 cups all-purpose flour") into a structured amount, canonical
+// unit, and name. It handles integer, decimal, ASCII-fraction, and
+// unicode-fraction quantities, mixed numbers, and ranges (the low value is
+// used). The unit is optional; when no known unit token follows the quantity,
+// unit is returned empty. Lines without a leading numeric quantity (e.g.
+// "a pinch of salt") return ok=false and should keep their original text.
+func ParseIngredientLine(s string) (amount float64, unit string, name string, ok bool) {
+	tokens := strings.Fields(strings.TrimSpace(s))
+	if len(tokens) == 0 {
+		return 0, "", "", false
+	}
+
+	amount, consumed, ok := parseQuantity(tokens)
+	if !ok || amount <= 0 {
+		return 0, "", "", false
+	}
+	rest := tokens[consumed:]
+
+	// Optional unit token (possibly two tokens for "fl oz" variants).
+	if len(rest) > 0 {
+		if u, n := matchUnit(rest); n > 0 {
+			unit = u
+			rest = rest[n:]
+		}
+	}
+
+	name = strings.Join(rest, " ")
+	name = strings.TrimSpace(strings.TrimPrefix(name, "of "))
+	if name == "" {
+		return 0, "", "", false
+	}
+	return amount, unit, name, true
+}
+
+// parseQuantity parses a leading quantity from the token stream, returning the
+// value and the number of tokens consumed. It handles plain numbers, ASCII and
+// unicode fractions, mixed numbers ("1 1/2", "1½"), and ranges ("1-2",
+// "1 to 2") where the low value is kept.
+func parseQuantity(tokens []string) (float64, int, bool) {
+	first, ok := parseNumberToken(tokens[0])
+	if !ok {
+		return 0, 0, false
+	}
+	consumed := 1
+
+	// Mixed number across tokens: "1 1/2", "1 ½"
+	if len(tokens) > consumed {
+		if frac, fracOK := parseFractionToken(tokens[consumed]); fracOK {
+			first += frac
+			consumed++
+		}
+	}
+
+	// Range across tokens: "1 - 2", "1 to 2" — keep the low value.
+	if len(tokens) > consumed+1 && isRangeSeparator(tokens[consumed]) {
+		if _, highOK := parseNumberToken(tokens[consumed+1]); highOK {
+			consumed += 2
+		}
+	}
+
+	return first, consumed, true
+}
+
+// isRangeSeparator reports whether a token separates the low and high values
+// of a quantity range.
+func isRangeSeparator(tok string) bool {
+	switch tok {
+	case "-", "–", "—", "to":
+		return true
+	}
+	return false
+}
+
+// parseNumberToken parses a single token as a number: "2", "1.5", "1/2", "½",
+// "1½", "1-2" (range — low value), "1-1/2" (mixed — 1.5).
+func parseNumberToken(tok string) (float64, bool) {
+	if tok == "" {
+		return 0, false
+	}
+
+	// Hyphenated token: mixed number ("1-1/2") or range ("1-2").
+	for _, sep := range []string{"-", "–", "—"} {
+		if idx := strings.Index(tok, sep); idx > 0 && idx < len(tok)-len(sep) {
+			low, lowOK := parseNumberToken(tok[:idx])
+			if !lowOK {
+				return 0, false
+			}
+			right := tok[idx+len(sep):]
+			if frac, fracOK := parseFractionToken(right); fracOK {
+				return low + frac, true // mixed number, e.g. "1-1/2"
+			}
+			if _, highOK := parseNumberToken(right); highOK {
+				return low, true // range, e.g. "1-2" — use the low value
+			}
+			return 0, false
+		}
+	}
+
+	if frac, ok := parseFractionToken(tok); ok {
+		return frac, true
+	}
+
+	// Integer prefix with attached unicode fraction: "1½"
+	runes := []rune(tok)
+	if len(runes) > 1 {
+		if frac, ok := unicodeFractions[runes[len(runes)-1]]; ok {
+			if whole, err := strconv.ParseFloat(string(runes[:len(runes)-1]), 64); err == nil {
+				return whole + frac, true
+			}
+			return 0, false
+		}
+	}
+
+	v, err := strconv.ParseFloat(tok, 64)
+	if err != nil || v < 0 {
+		return 0, false
+	}
+	return v, true
+}
+
+// parseFractionToken parses a token that is purely a fraction: "1/2" or "½".
+func parseFractionToken(tok string) (float64, bool) {
+	runes := []rune(tok)
+	if len(runes) == 1 {
+		if v, ok := unicodeFractions[runes[0]]; ok {
+			return v, true
+		}
+	}
+	parts := strings.Split(tok, "/")
+	if len(parts) != 2 {
+		return 0, false
+	}
+	num, err1 := strconv.ParseFloat(parts[0], 64)
+	den, err2 := strconv.ParseFloat(parts[1], 64)
+	if err1 != nil || err2 != nil || den == 0 {
+		return 0, false
+	}
+	return num / den, true
+}
+
+// matchUnit matches the leading token(s) against the unit alias table and
+// returns the canonical unit plus the number of tokens consumed (0 if no
+// match). "T" and "t" are matched case-sensitively (tablespoon vs teaspoon);
+// everything else is case-insensitive with trailing periods/commas stripped.
+func matchUnit(tokens []string) (string, int) {
+	tok := strings.TrimRight(tokens[0], ".,")
+	if tok == "" {
+		return "", 0
+	}
+
+	// Case-sensitive single-letter abbreviations.
+	switch tok {
+	case "T":
+		return "tbsp", 1
+	case "t":
+		return "tsp", 1
+	}
+
+	lower := strings.ToLower(tok)
+
+	// Two-token "fl oz" variants: "fl oz", "fl. oz.", "fluid ounce(s)".
+	if (lower == "fl" || lower == "fluid") && len(tokens) > 1 {
+		next := strings.ToLower(strings.TrimRight(tokens[1], ".,"))
+		switch next {
+		case "oz", "ozs", "ounce", "ounces":
+			return "fl oz", 2
+		}
+		return "", 0
+	}
+
+	if canonical, ok := unitAliases[lower]; ok {
+		return canonical, 1
+	}
+	return "", 0
+}

--- a/internal/service/ingredient_parse_test.go
+++ b/internal/service/ingredient_parse_test.go
@@ -1,0 +1,93 @@
+package service
+
+import (
+	"math"
+	"testing"
+)
+
+func almostEqual(a, b float64) bool {
+	return math.Abs(a-b) < 1e-6
+}
+
+func TestParseIngredientLine(t *testing.T) {
+	tests := []struct {
+		name       string
+		input      string
+		wantAmount float64
+		wantUnit   string
+		wantName   string
+		wantOK     bool
+	}{
+		// integers and decimals
+		{"integer with cups", "2 cups flour", 2, "cup", "flour", true},
+		{"decimal amount", "1.5 cups sugar", 1.5, "cup", "sugar", true},
+		{"integer no unit", "3 eggs", 3, "", "eggs", true},
+		// ASCII fractions
+		{"ascii fraction", "1/2 cup butter", 0.5, "cup", "butter", true},
+		{"ascii fraction tsp", "3/4 tsp salt", 0.75, "tsp", "salt", true},
+		// unicode fractions
+		{"unicode half", "½ cup milk", 0.5, "cup", "milk", true},
+		{"unicode quarter", "¼ tsp nutmeg", 0.25, "tsp", "nutmeg", true},
+		{"unicode third", "⅓ cup honey", 1.0 / 3, "cup", "honey", true},
+		{"unicode eighth", "⅛ tsp cayenne", 0.125, "tsp", "cayenne", true},
+		// mixed numbers
+		{"mixed number spaced", "1 1/2 cups flour", 1.5, "cup", "flour", true},
+		{"mixed number attached unicode", "1½ cups flour", 1.5, "cup", "flour", true},
+		{"mixed number spaced unicode", "2 ¾ cups broth", 2.75, "cup", "broth", true},
+		{"mixed number hyphenated", "1-1/2 cups flour", 1.5, "cup", "flour", true},
+		// ranges — low value wins
+		{"hyphen range", "1-2 tbsp olive oil", 1, "tbsp", "olive oil", true},
+		{"spaced hyphen range", "2 - 3 cups stock", 2, "cup", "stock", true},
+		{"to range", "1 to 2 tsp vanilla", 1, "tsp", "vanilla", true},
+		// unit aliases
+		{"tablespoon long form", "2 tablespoons butter", 2, "tbsp", "butter", true},
+		{"teaspoon long form", "1 teaspoon vanilla", 1, "tsp", "vanilla", true},
+		{"uppercase T is tbsp", "1 T sugar", 1, "tbsp", "sugar", true},
+		{"lowercase t is tsp", "1 t sugar", 1, "tsp", "sugar", true},
+		{"c with period", "2 c. flour", 2, "cup", "flour", true},
+		{"ounces", "8 ounces cream cheese", 8, "oz", "cream cheese", true},
+		{"pounds lbs", "2 lbs chicken thighs", 2, "lb", "chicken thighs", true},
+		{"grams compact", "250 g flour", 250, "g", "flour", true},
+		{"kilograms", "1 kg potatoes", 1, "kg", "potatoes", true},
+		{"milliliters", "100 ml milk", 100, "mL", "milk", true},
+		{"liters", "1 liter water", 1, "L", "water", true},
+		{"fl oz two tokens", "4 fl oz heavy cream", 4, "fl oz", "heavy cream", true},
+		{"fluid ounces", "8 fluid ounces water", 8, "fl oz", "water", true},
+		{"pinch", "1 pinch saffron", 1, "pinch", "saffron", true},
+		{"cloves map to pieces", "2 cloves garlic", 2, "pieces", "garlic", true},
+		{"can maps to pieces", "1 can black beans", 1, "pieces", "black beans", true},
+		{"slices map to pieces", "4 slices bacon", 4, "pieces", "bacon", true},
+		// "of" stripping
+		{"of after unit", "2 cups of flour", 2, "cup", "flour", true},
+		{"pinch of", "1 pinch of salt", 1, "pinch", "salt", true},
+		// no unit, descriptive words stay in name
+		{"descriptive no unit", "2 large eggs", 2, "", "large eggs", true},
+		// unparseable — words-only quantities stay unparsed
+		{"words only quantity", "a pinch of salt", 0, "", "", false},
+		{"no quantity at all", "salt to taste", 0, "", "", false},
+		{"empty string", "", 0, "", "", false},
+		{"only a number", "2", 0, "", "", false},
+		{"unit but no name", "2 cups", 0, "", "", false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			amount, unit, name, ok := ParseIngredientLine(tt.input)
+			if ok != tt.wantOK {
+				t.Fatalf("ParseIngredientLine(%q) ok = %v, want %v", tt.input, ok, tt.wantOK)
+			}
+			if !tt.wantOK {
+				return
+			}
+			if !almostEqual(amount, tt.wantAmount) {
+				t.Errorf("ParseIngredientLine(%q) amount = %v, want %v", tt.input, amount, tt.wantAmount)
+			}
+			if unit != tt.wantUnit {
+				t.Errorf("ParseIngredientLine(%q) unit = %q, want %q", tt.input, unit, tt.wantUnit)
+			}
+			if name != tt.wantName {
+				t.Errorf("ParseIngredientLine(%q) name = %q, want %q", tt.input, name, tt.wantName)
+			}
+		})
+	}
+}

--- a/internal/service/ingredient_parse_test.go
+++ b/internal/service/ingredient_parse_test.go
@@ -39,6 +39,9 @@ func TestParseIngredientLine(t *testing.T) {
 		{"hyphen range", "1-2 tbsp olive oil", 1, "tbsp", "olive oil", true},
 		{"spaced hyphen range", "2 - 3 cups stock", 2, "cup", "stock", true},
 		{"to range", "1 to 2 tsp vanilla", 1, "tsp", "vanilla", true},
+		{"fraction-to-fraction range", "1/2-3/4 cup butter", 0.5, "cup", "butter", true},
+		{"unicode fraction range", "½-¾ cup sugar", 0.5, "cup", "sugar", true},
+		{"decimal-led hyphen range", "1.5-2 cups stock", 1.5, "cup", "stock", true},
 		// unit aliases
 		{"tablespoon long form", "2 tablespoons butter", 2, "tbsp", "butter", true},
 		{"teaspoon long form", "1 teaspoon vanilla", 1, "tsp", "vanilla", true},

--- a/internal/service/multi_recipe.go
+++ b/internal/service/multi_recipe.go
@@ -17,25 +17,25 @@ import (
 
 // MultiRecipeCard is a lightweight preview of one recipe found on a multi-recipe page.
 type MultiRecipeCard struct {
-	Title            string              `json:"title"`
-	ImageURL         string              `json:"image_url,omitempty"`
-	Description      string              `json:"description,omitempty"`
-	SourceURL        string              `json:"source_url"`
-	ExtractionStatus string              `json:"extraction_status"` // "pending", "extracting", "done", "failed"
-	RecipeDef        *models.RecipeDef   `json:"recipe,omitempty"`  // populated when done
-	Hashtags         []string            `json:"hashtags,omitempty"`
+	Title            string            `json:"title"`
+	ImageURL         string            `json:"image_url,omitempty"`
+	Description      string            `json:"description,omitempty"`
+	SourceURL        string            `json:"source_url"`
+	ExtractionStatus string            `json:"extraction_status"` // "pending", "extracting", "done", "failed"
+	RecipeDef        *models.RecipeDef `json:"recipe,omitempty"`  // populated when done
+	Hashtags         []string          `json:"hashtags,omitempty"`
 }
 
 // MultiRecipeEntry tracks the resolution state of a multi-recipe URL.
 type MultiRecipeEntry struct {
-	mu          sync.RWMutex
-	ID          string            `json:"multi_id"`
-	SourceURL   string            `json:"source_url"`
-	Status      string            `json:"status"` // "resolving", "resolved", "failed"
-	Cards       []MultiRecipeCard `json:"recipes"`
-	DetectedAt  time.Time         `json:"detected_at"`
-	ResolvedAt  *time.Time        `json:"resolved_at,omitempty"`
-	pageHTML    string            // stored for extraction, not serialized
+	mu         sync.RWMutex
+	ID         string            `json:"multi_id"`
+	SourceURL  string            `json:"source_url"`
+	Status     string            `json:"status"` // "resolving", "resolved", "failed"
+	Cards      []MultiRecipeCard `json:"recipes"`
+	DetectedAt time.Time         `json:"detected_at"`
+	ResolvedAt *time.Time        `json:"resolved_at,omitempty"`
+	pageHTML   string            // stored for extraction, not serialized
 }
 
 func (e *MultiRecipeEntry) GetCards() []MultiRecipeCard {
@@ -505,7 +505,7 @@ func (r *MultiRecipeResolver) extractSingleCard(entry *MultiRecipeEntry, idx int
 
 	// Pass the stripped text with a constraint to extract only this recipe by title
 	extractionInput := fmt.Sprintf("Extract ONLY the recipe titled %q from the following page. Ignore all other recipes.\n\n%s", title, pageText)
-	result, err := provider.ExtractRecipeFromText(ctx, extractionInput, "preserve source")
+	result, err := provider.ExtractRecipeFromText(ctx, extractionInput, ai.UnitSystemPreserveSource)
 	if err != nil {
 		log.Error("failed to extract individual recipe", zap.Error(err))
 		entry.mu.Lock()
@@ -516,6 +516,7 @@ func (r *MultiRecipeResolver) extractSingleCard(entry *MultiRecipeEntry, idx int
 
 	def := recipeResultToRecipeDef(result)
 	def.SourceURL = sourceURL
+	ensureUnitSystem(&def)
 
 	entry.mu.Lock()
 	entry.Cards[idx].ExtractionStatus = "done"
@@ -568,4 +569,3 @@ func (r *MultiRecipeResolver) extractSingleCard(entry *MultiRecipeEntry, idx int
 
 	log.Info("individual recipe extracted successfully")
 }
-

--- a/internal/service/multi_recipe.go
+++ b/internal/service/multi_recipe.go
@@ -78,6 +78,17 @@ func NewMultiRecipeRegistry() *MultiRecipeRegistry {
 	return r
 }
 
+// shouldEvictEntry reports whether a registry entry in the given state is
+// eligible for eviction at time now. Entries still resolving are never
+// evicted; terminal entries (resolved/failed) are evicted once older than
+// the TTL.
+func shouldEvictEntry(status string, detectedAt time.Time, now time.Time) bool {
+	if status != "resolved" && status != "failed" {
+		return false
+	}
+	return now.Sub(detectedAt) > registryEvictionTTL
+}
+
 // evictionLoop periodically removes resolved/failed entries older than the TTL.
 func (r *MultiRecipeRegistry) evictionLoop() {
 	ticker := time.NewTicker(5 * time.Minute)
@@ -92,7 +103,7 @@ func (r *MultiRecipeRegistry) evictionLoop() {
 			status := entry.Status
 			detected := entry.DetectedAt
 			entry.mu.RUnlock()
-			if (status == "resolved" || status == "failed") && time.Since(detected) > registryEvictionTTL {
+			if shouldEvictEntry(status, detected, time.Now()) {
 				toEvict = append(toEvict, url)
 			}
 		}

--- a/internal/service/multi_recipe_resolver_test.go
+++ b/internal/service/multi_recipe_resolver_test.go
@@ -1,0 +1,400 @@
+package service
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/windoze95/saltybytes-api/internal/ai"
+	"github.com/windoze95/saltybytes-api/internal/models"
+	"github.com/windoze95/saltybytes-api/internal/testutil"
+)
+
+// upsertRecorder is a thread-safe capture of canonical-recipe upserts; the
+// resolver extracts cards on up to 3 concurrent goroutines.
+type upsertRecorder struct {
+	mu      sync.Mutex
+	entries []models.CanonicalRecipe
+}
+
+func (u *upsertRecorder) record(entry *models.CanonicalRecipe) error {
+	u.mu.Lock()
+	defer u.mu.Unlock()
+	u.entries = append(u.entries, *entry)
+	return nil
+}
+
+func (u *upsertRecorder) snapshot() []models.CanonicalRecipe {
+	u.mu.Lock()
+	defer u.mu.Unlock()
+	out := make([]models.CanonicalRecipe, len(u.entries))
+	copy(out, u.entries)
+	return out
+}
+
+// multiRecipeHTML returns a page with the given JSON-LD recipe titles.
+func multiRecipeHTML(titles ...string) string {
+	var b strings.Builder
+	b.WriteString("<html><head>")
+	for _, title := range titles {
+		fmt.Fprintf(&b, `<script type="application/ld+json">{"@type":"Recipe","name":%q}</script>`, title)
+	}
+	b.WriteString("</head><body><h1>Roundup</h1></body></html>")
+	return b.String()
+}
+
+// newResolverForTest wires a resolver whose import service uses the given
+// preview provider and canonical repo.
+func newResolverForTest(preview ai.TextProvider, canonicalRepo *testutil.MockCanonicalRecipeRepo) *MultiRecipeResolver {
+	svc := newTestImportService(testutil.NewMockRecipeRepo(), nil, preview)
+	if canonicalRepo != nil {
+		svc.CanonicalRepo = canonicalRepo
+	}
+	return NewMultiRecipeResolver(NewMultiRecipeRegistry(), svc)
+}
+
+// waitResolved polls the entry until background extraction finishes.
+func waitResolved(t *testing.T, entry *MultiRecipeEntry) {
+	t.Helper()
+	deadline := time.Now().Add(3 * time.Second)
+	for time.Now().Before(deadline) {
+		if entry.GetStatus() == "resolved" {
+			return
+		}
+		time.Sleep(5 * time.Millisecond)
+	}
+	t.Fatalf("entry never resolved; status = %q", entry.GetStatus())
+}
+
+func TestResolveFromHTML_JSONLDMultiRecipe(t *testing.T) {
+	var detectionCalled atomic.Bool
+	var extractInputs sync.Map
+	preview := &testutil.MockTextProvider{
+		CookingQAFunc: func(ctx context.Context, question string, recipeContext string) (string, error) {
+			detectionCalled.Store(true)
+			return "SINGLE", nil
+		},
+		ExtractRecipeFromTextFunc: func(ctx context.Context, text string, unitSystem string) (*ai.RecipeResult, error) {
+			extractInputs.Store(text, true)
+			if unitSystem != ai.UnitSystemPreserveSource {
+				t.Errorf("ExtractRecipeFromText unitSystem = %q, want preserve-source sentinel", unitSystem)
+			}
+			return testutil.TestRecipeResult(), nil
+		},
+	}
+	recorder := &upsertRecorder{}
+	resolver := newResolverForTest(preview, &testutil.MockCanonicalRecipeRepo{UpsertFunc: recorder.record})
+
+	html := multiRecipeHTML("Pancakes", "Waffles")
+	entry := resolver.ResolveFromHTML(context.Background(), "https://example.com/breakfast", html)
+	if entry == nil {
+		t.Fatal("ResolveFromHTML returned nil for a multi-recipe page")
+	}
+	if detectionCalled.Load() {
+		t.Error("AI detection ran even though JSON-LD already found multiple recipes")
+	}
+
+	waitResolved(t, entry)
+
+	cards := entry.GetCards()
+	if len(cards) != 2 {
+		t.Fatalf("entry has %d cards, want 2", len(cards))
+	}
+	for i, card := range cards {
+		if card.ExtractionStatus != "done" {
+			t.Errorf("card[%d].ExtractionStatus = %q, want 'done'", i, card.ExtractionStatus)
+		}
+		if card.RecipeDef == nil {
+			t.Errorf("card[%d].RecipeDef is nil after extraction", i)
+			continue
+		}
+		if card.RecipeDef.SourceURL != "https://example.com/breakfast" {
+			t.Errorf("card[%d].RecipeDef.SourceURL = %q, want the page URL", i, card.RecipeDef.SourceURL)
+		}
+		if len(card.Hashtags) == 0 {
+			t.Errorf("card[%d].Hashtags empty, want hashtags from the extraction result", i)
+		}
+	}
+	if entry.ResolvedAt == nil {
+		t.Error("entry.ResolvedAt not set after resolution")
+	}
+
+	// Each card's extraction prompt must target its own title.
+	for _, title := range []string{"Pancakes", "Waffles"} {
+		found := false
+		extractInputs.Range(func(key, _ interface{}) bool {
+			if strings.Contains(key.(string), fmt.Sprintf("%q", title)) {
+				found = true
+				return false
+			}
+			return true
+		})
+		if !found {
+			t.Errorf("no extraction input constrained to title %q", title)
+		}
+	}
+
+	// Both extractions cached under distinct canonical keys.
+	upserts := recorder.snapshot()
+	if len(upserts) != 2 {
+		t.Fatalf("canonical upserts = %d, want 2", len(upserts))
+	}
+	if upserts[0].NormalizedURL == upserts[1].NormalizedURL {
+		t.Errorf("both cards cached under the same canonical key %q", upserts[0].NormalizedURL)
+	}
+	for i, up := range upserts {
+		if !strings.Contains(up.OriginalURL, "_recipe=") {
+			t.Errorf("upsert[%d].OriginalURL = %q, want a _recipe= slug param", i, up.OriginalURL)
+		}
+		if up.ExtractionMethod != models.ExtractionHaiku {
+			t.Errorf("upsert[%d].ExtractionMethod = %q, want haiku", i, up.ExtractionMethod)
+		}
+	}
+}
+
+func TestResolveFromHTML_SingleRecipeNotMulti(t *testing.T) {
+	preview := &testutil.MockTextProvider{
+		CookingQAFunc: func(ctx context.Context, question string, recipeContext string) (string, error) {
+			return "SINGLE", nil
+		},
+	}
+	resolver := newResolverForTest(preview, nil)
+
+	entry := resolver.ResolveFromHTML(context.Background(), "https://example.com/one", multiRecipeHTML("Lone Recipe"))
+	if entry != nil {
+		t.Errorf("ResolveFromHTML = %+v, want nil for a single-recipe page", entry)
+	}
+	if tracked := resolver.Registry.Get("https://example.com/one"); tracked != nil {
+		t.Error("single-recipe URL should not be registered")
+	}
+}
+
+func TestResolveFromHTML_AIFallbackDetection(t *testing.T) {
+	preview := &testutil.MockTextProvider{
+		CookingQAFunc: func(ctx context.Context, question string, recipeContext string) (string, error) {
+			// Includes noise lines the detector must filter out.
+			return "Slow Cooker Chili\n\nok\nWhite Chicken Chili\nVegetarian Chili", nil
+		},
+		ExtractRecipeFromTextFunc: func(ctx context.Context, text string, unitSystem string) (*ai.RecipeResult, error) {
+			return testutil.TestRecipeResult(), nil
+		},
+	}
+	resolver := newResolverForTest(preview, nil)
+
+	html := `<html><body><h1>15 Chili Recipes</h1><p>No JSON-LD here.</p></body></html>`
+	entry := resolver.ResolveFromHTML(context.Background(), "https://example.com/chili-roundup", html)
+	if entry == nil {
+		t.Fatal("ResolveFromHTML returned nil; AI fallback should have detected multiple recipes")
+	}
+
+	waitResolved(t, entry)
+
+	cards := entry.GetCards()
+	if len(cards) != 3 {
+		t.Fatalf("entry has %d cards, want 3 (noise filtered)", len(cards))
+	}
+	wantTitles := []string{"Slow Cooker Chili", "White Chicken Chili", "Vegetarian Chili"}
+	for i, want := range wantTitles {
+		if cards[i].Title != want {
+			t.Errorf("card[%d].Title = %q, want %q", i, cards[i].Title, want)
+		}
+		if cards[i].ExtractionStatus != "done" {
+			t.Errorf("card[%d].ExtractionStatus = %q, want 'done'", i, cards[i].ExtractionStatus)
+		}
+	}
+}
+
+func TestResolveFromHTML_AlreadyRegisteredSkipsReextraction(t *testing.T) {
+	var extractCalls atomic.Int32
+	preview := &testutil.MockTextProvider{
+		ExtractRecipeFromTextFunc: func(ctx context.Context, text string, unitSystem string) (*ai.RecipeResult, error) {
+			extractCalls.Add(1)
+			return testutil.TestRecipeResult(), nil
+		},
+	}
+	resolver := newResolverForTest(preview, nil)
+
+	existing, _ := resolver.Registry.Register("https://example.com/breakfast")
+
+	entry := resolver.ResolveFromHTML(context.Background(), "https://example.com/breakfast", multiRecipeHTML("Pancakes", "Waffles"))
+	if entry != existing {
+		t.Error("ResolveFromHTML should return the already-registered entry")
+	}
+	// No new extraction work was started for the duplicate resolve.
+	time.Sleep(50 * time.Millisecond)
+	if n := extractCalls.Load(); n != 0 {
+		t.Errorf("extraction ran %d times for an already-registered URL, want 0", n)
+	}
+}
+
+func TestResolveFromHTML_ExtractionFailureMarksCardFailed(t *testing.T) {
+	preview := &testutil.MockTextProvider{
+		ExtractRecipeFromTextFunc: func(ctx context.Context, text string, unitSystem string) (*ai.RecipeResult, error) {
+			if strings.Contains(text, `"Waffles"`) {
+				return nil, errors.New("model exploded")
+			}
+			return testutil.TestRecipeResult(), nil
+		},
+	}
+	resolver := newResolverForTest(preview, nil)
+
+	entry := resolver.ResolveFromHTML(context.Background(), "https://example.com/breakfast", multiRecipeHTML("Pancakes", "Waffles"))
+	if entry == nil {
+		t.Fatal("ResolveFromHTML returned nil")
+	}
+	waitResolved(t, entry)
+
+	byTitle := map[string]MultiRecipeCard{}
+	for _, c := range entry.GetCards() {
+		byTitle[c.Title] = c
+	}
+	if got := byTitle["Pancakes"].ExtractionStatus; got != "done" {
+		t.Errorf("Pancakes status = %q, want 'done'", got)
+	}
+	if got := byTitle["Waffles"].ExtractionStatus; got != "failed" {
+		t.Errorf("Waffles status = %q, want 'failed'", got)
+	}
+	if byTitle["Waffles"].RecipeDef != nil {
+		t.Error("failed card should not carry a RecipeDef")
+	}
+}
+
+func TestResolveFromHTML_NoProviderMarksAllCardsFailed(t *testing.T) {
+	// JSON-LD detection needs no AI, but extraction does; with no provider
+	// every card must fail without panicking and the entry still resolves.
+	resolver := newResolverForTest(nil, nil)
+
+	entry := resolver.ResolveFromHTML(context.Background(), "https://example.com/breakfast", multiRecipeHTML("Pancakes", "Waffles"))
+	if entry == nil {
+		t.Fatal("ResolveFromHTML returned nil")
+	}
+	waitResolved(t, entry)
+
+	for i, card := range entry.GetCards() {
+		if card.ExtractionStatus != "failed" {
+			t.Errorf("card[%d].ExtractionStatus = %q, want 'failed' with no provider", i, card.ExtractionStatus)
+		}
+	}
+}
+
+func TestExtractAllRecipes_CanonicalKeysSurviveSlugCollisions(t *testing.T) {
+	preview := &testutil.MockTextProvider{
+		ExtractRecipeFromTextFunc: func(ctx context.Context, text string, unitSystem string) (*ai.RecipeResult, error) {
+			return testutil.TestRecipeResult(), nil
+		},
+	}
+	recorder := &upsertRecorder{}
+	resolver := newResolverForTest(preview, &testutil.MockCanonicalRecipeRepo{UpsertFunc: recorder.record})
+
+	// "Best Brownies!" and "Best Brownies?" slugify identically; the
+	// non-ASCII titles slugify to empty strings. All four must still get
+	// distinct canonical cache keys.
+	html := multiRecipeHTML("Best Brownies!", "Best Brownies?", "クッキー", "ケーキ")
+	entry := resolver.ResolveFromHTML(context.Background(), "https://example.com/sweets?page=2", html)
+	if entry == nil {
+		t.Fatal("ResolveFromHTML returned nil")
+	}
+	waitResolved(t, entry)
+
+	upserts := recorder.snapshot()
+	if len(upserts) != 4 {
+		t.Fatalf("canonical upserts = %d, want 4", len(upserts))
+	}
+	seen := make(map[string]string)
+	for _, up := range upserts {
+		if prev, dup := seen[up.NormalizedURL]; dup {
+			t.Errorf("canonical key collision: %q used by %q and %q", up.NormalizedURL, prev, up.OriginalURL)
+		}
+		seen[up.NormalizedURL] = up.OriginalURL
+		// Source URL already has a query string, so the slug must be
+		// appended with '&', not a second '?'.
+		if strings.Count(up.OriginalURL, "?") != 1 {
+			t.Errorf("OriginalURL %q malformed; want exactly one '?'", up.OriginalURL)
+		}
+	}
+}
+
+func TestResolveFromURL_FetchesAndResolves(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		fmt.Fprint(w, multiRecipeHTML("Pancakes", "Waffles", "Crepes"))
+	}))
+	defer server.Close()
+
+	preview := &testutil.MockTextProvider{
+		ExtractRecipeFromTextFunc: func(ctx context.Context, text string, unitSystem string) (*ai.RecipeResult, error) {
+			return testutil.TestRecipeResult(), nil
+		},
+	}
+	resolver := newResolverForTest(preview, nil)
+
+	pageURL := server.URL + "/breakfast-roundup"
+	entry := resolver.ResolveFromURL(context.Background(), pageURL)
+	if entry == nil {
+		t.Fatal("ResolveFromURL returned nil for a multi-recipe page")
+	}
+	if entry.SourceURL != pageURL {
+		t.Errorf("entry.SourceURL = %q, want %q", entry.SourceURL, pageURL)
+	}
+	waitResolved(t, entry)
+	if got := len(entry.GetCards()); got != 3 {
+		t.Errorf("entry has %d cards, want 3", got)
+	}
+}
+
+func TestResolveFromURL_AlreadyTrackedSkipsFetch(t *testing.T) {
+	var fetches atomic.Int32
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		fetches.Add(1)
+		fmt.Fprint(w, multiRecipeHTML("Pancakes", "Waffles"))
+	}))
+	defer server.Close()
+
+	resolver := newResolverForTest(nil, nil)
+	pageURL := server.URL + "/tracked"
+	existing, _ := resolver.Registry.Register(pageURL)
+
+	entry := resolver.ResolveFromURL(context.Background(), pageURL)
+	if entry != existing {
+		t.Error("ResolveFromURL should return the tracked entry")
+	}
+	if n := fetches.Load(); n != 0 {
+		t.Errorf("ResolveFromURL fetched %d times for a tracked URL, want 0", n)
+	}
+}
+
+func TestResolveFromURL_FetchFailureReturnsNil(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		http.NotFound(w, r)
+	}))
+	defer server.Close()
+
+	resolver := newResolverForTest(nil, nil)
+	if entry := resolver.ResolveFromURL(context.Background(), server.URL+"/missing"); entry != nil {
+		t.Errorf("ResolveFromURL = %+v, want nil on fetch failure", entry)
+	}
+}
+
+func TestResolveFromURL_SingleRecipePageReturnsNil(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		fmt.Fprint(w, multiRecipeHTML("Lone Recipe"))
+	}))
+	defer server.Close()
+
+	preview := &testutil.MockTextProvider{
+		CookingQAFunc: func(ctx context.Context, question string, recipeContext string) (string, error) {
+			return "SINGLE", nil
+		},
+	}
+	resolver := newResolverForTest(preview, nil)
+
+	if entry := resolver.ResolveFromURL(context.Background(), server.URL+"/single"); entry != nil {
+		t.Errorf("ResolveFromURL = %+v, want nil for a single-recipe page", entry)
+	}
+}

--- a/internal/service/multi_recipe_test.go
+++ b/internal/service/multi_recipe_test.go
@@ -1,0 +1,492 @@
+package service
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/windoze95/saltybytes-api/internal/testutil"
+)
+
+// --- extractAllJSONLDRecipes ---
+
+func TestExtractAllJSONLDRecipes_MultipleScriptBlocks(t *testing.T) {
+	html := `<html><head>
+	<script type="application/ld+json">{"@type":"Recipe","name":"Pancakes","description":"Fluffy","image":"https://img.example.com/p.jpg"}</script>
+	<script type="application/ld+json">{"@type":"Recipe","name":"Waffles"}</script>
+	</head><body></body></html>`
+
+	cards := extractAllJSONLDRecipes(html, "https://example.com/breakfast")
+	if len(cards) != 2 {
+		t.Fatalf("extractAllJSONLDRecipes returned %d cards, want 2", len(cards))
+	}
+	if cards[0].Title != "Pancakes" || cards[1].Title != "Waffles" {
+		t.Errorf("card titles = %q, %q; want Pancakes, Waffles", cards[0].Title, cards[1].Title)
+	}
+	if cards[0].ImageURL != "https://img.example.com/p.jpg" {
+		t.Errorf("card[0].ImageURL = %q, want the JSON-LD image", cards[0].ImageURL)
+	}
+	if cards[0].Description != "Fluffy" {
+		t.Errorf("card[0].Description = %q, want 'Fluffy'", cards[0].Description)
+	}
+	for i, c := range cards {
+		if c.SourceURL != "https://example.com/breakfast" {
+			t.Errorf("card[%d].SourceURL = %q, want the page URL", i, c.SourceURL)
+		}
+		if c.ExtractionStatus != "pending" {
+			t.Errorf("card[%d].ExtractionStatus = %q, want 'pending'", i, c.ExtractionStatus)
+		}
+	}
+}
+
+func TestExtractAllJSONLDRecipes_DeduplicatesByTitle(t *testing.T) {
+	html := `<script type="application/ld+json">{"@type":"Recipe","name":"Chili"}</script>
+	<script type="application/ld+json">{"@type":"Recipe","name":"Chili"}</script>`
+
+	cards := extractAllJSONLDRecipes(html, "https://example.com")
+	if len(cards) != 1 {
+		t.Fatalf("extractAllJSONLDRecipes returned %d cards, want 1 after dedupe", len(cards))
+	}
+}
+
+func TestExtractAllJSONLDRecipes_NoJSONLD(t *testing.T) {
+	html := `<html><body><h1>Just an article</h1></body></html>`
+	if cards := extractAllJSONLDRecipes(html, "https://example.com"); len(cards) != 0 {
+		t.Errorf("extractAllJSONLDRecipes returned %d cards, want 0", len(cards))
+	}
+}
+
+func TestExtractAllJSONLDRecipes_SkipsNonRecipeBlocks(t *testing.T) {
+	html := `<script type="application/ld+json">{"@type":"Article","name":"Top 10 Dinners"}</script>
+	<script type="application/ld+json">{"@type":"Recipe","name":"Lasagna"}</script>`
+
+	cards := extractAllJSONLDRecipes(html, "https://example.com")
+	if len(cards) != 1 || cards[0].Title != "Lasagna" {
+		t.Fatalf("extractAllJSONLDRecipes cards = %+v, want only Lasagna", cards)
+	}
+}
+
+// --- findAllRecipesInJSONLD ---
+
+func TestFindAllRecipesInJSONLD_GraphContainer(t *testing.T) {
+	jsonStr := `{"@context":"https://schema.org","@graph":[
+		{"@type":"WebPage","name":"Page"},
+		{"@type":"Recipe","name":"Tacos","description":"Crunchy"},
+		{"@type":"Recipe","name":"Salsa"}
+	]}`
+
+	recipes := findAllRecipesInJSONLD(jsonStr)
+	if len(recipes) != 2 {
+		t.Fatalf("findAllRecipesInJSONLD returned %d recipes, want 2", len(recipes))
+	}
+	if recipes[0].Title != "Tacos" || recipes[1].Title != "Salsa" {
+		t.Errorf("titles = %q, %q; want Tacos, Salsa", recipes[0].Title, recipes[1].Title)
+	}
+	if recipes[0].Description != "Crunchy" {
+		t.Errorf("description = %q, want 'Crunchy'", recipes[0].Description)
+	}
+}
+
+func TestFindAllRecipesInJSONLD_TopLevelArray(t *testing.T) {
+	jsonStr := `[
+		{"@type":"Recipe","name":"Soup"},
+		{"@type":"BreadcrumbList"},
+		{"@type":"Recipe","name":"Salad"}
+	]`
+
+	recipes := findAllRecipesInJSONLD(jsonStr)
+	if len(recipes) != 2 {
+		t.Fatalf("findAllRecipesInJSONLD returned %d recipes, want 2", len(recipes))
+	}
+}
+
+func TestFindAllRecipesInJSONLD_NestedGraphInArray(t *testing.T) {
+	jsonStr := `[{"@graph":[{"@type":"Recipe","name":"Stew"}]},{"@type":"Recipe","name":"Pie"}]`
+
+	recipes := findAllRecipesInJSONLD(jsonStr)
+	if len(recipes) != 2 {
+		t.Fatalf("findAllRecipesInJSONLD returned %d recipes, want 2 (nested @graph + sibling)", len(recipes))
+	}
+}
+
+func TestFindAllRecipesInJSONLD_TypeArray(t *testing.T) {
+	jsonStr := `{"@type":["Recipe","NewsArticle"],"name":"Fusion Bowl"}`
+
+	recipes := findAllRecipesInJSONLD(jsonStr)
+	if len(recipes) != 1 || recipes[0].Title != "Fusion Bowl" {
+		t.Fatalf("findAllRecipesInJSONLD = %+v, want one recipe 'Fusion Bowl'", recipes)
+	}
+}
+
+func TestFindAllRecipesInJSONLD_ImageVariants(t *testing.T) {
+	cases := []struct {
+		name    string
+		jsonStr string
+		want    string
+	}{
+		{"string image", `{"@type":"Recipe","name":"A","image":"https://x/img.jpg"}`, "https://x/img.jpg"},
+		{"string array image", `{"@type":"Recipe","name":"A","image":["https://x/1.jpg","https://x/2.jpg"]}`, "https://x/1.jpg"},
+		{"object array image", `{"@type":"Recipe","name":"A","image":[{"@type":"ImageObject","url":"https://x/obj.jpg"}]}`, "https://x/obj.jpg"},
+		{"object image", `{"@type":"Recipe","name":"A","image":{"@type":"ImageObject","url":"https://x/single.jpg"}}`, "https://x/single.jpg"},
+		{"missing image", `{"@type":"Recipe","name":"A"}`, ""},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			recipes := findAllRecipesInJSONLD(tc.jsonStr)
+			if len(recipes) != 1 {
+				t.Fatalf("got %d recipes, want 1", len(recipes))
+			}
+			if recipes[0].ImageURL != tc.want {
+				t.Errorf("ImageURL = %q, want %q", recipes[0].ImageURL, tc.want)
+			}
+		})
+	}
+}
+
+func TestFindAllRecipesInJSONLD_InvalidAndEmptyInputs(t *testing.T) {
+	cases := []struct {
+		name    string
+		jsonStr string
+	}{
+		{"invalid json", `{not json`},
+		{"recipe without name", `{"@type":"Recipe"}`},
+		{"non-recipe object", `{"@type":"Person","name":"Chef"}`},
+		{"empty string", ``},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if recipes := findAllRecipesInJSONLD(tc.jsonStr); len(recipes) != 0 {
+				t.Errorf("findAllRecipesInJSONLD(%q) = %+v, want none", tc.jsonStr, recipes)
+			}
+		})
+	}
+}
+
+// --- stripHTMLToText ---
+
+func TestStripHTMLToText_RemovesScriptsAndStyles(t *testing.T) {
+	html := `<html><head>
+	<script>var hidden = "secret-js";</script>
+	<style>.hidden { color: red; }</style>
+	<noscript>enable-js-note</noscript>
+	</head><body>
+	<nav>Home | About</nav>
+	<header>Site Header</header>
+	<svg><path d="M0 0"/></svg>
+	<p>Visible recipe text</p>
+	<footer>Copyright Notice</footer>
+	</body></html>`
+
+	text := stripHTMLToText(html)
+
+	for _, hidden := range []string{"secret-js", "color: red", "enable-js-note", "Home | About", "Site Header", "Copyright Notice", "M0 0"} {
+		if strings.Contains(text, hidden) {
+			t.Errorf("stripHTMLToText output contains %q, should be stripped", hidden)
+		}
+	}
+	if !strings.Contains(text, "Visible recipe text") {
+		t.Errorf("stripHTMLToText output = %q, want it to contain visible text", text)
+	}
+}
+
+func TestStripHTMLToText_RemovesComments(t *testing.T) {
+	text := stripHTMLToText(`<p>before</p><!-- hidden comment --><p>after</p>`)
+	if strings.Contains(text, "hidden comment") {
+		t.Errorf("stripHTMLToText kept comment content: %q", text)
+	}
+	if !strings.Contains(text, "before") || !strings.Contains(text, "after") {
+		t.Errorf("stripHTMLToText lost visible text: %q", text)
+	}
+}
+
+func TestStripHTMLToText_DecodesEntities(t *testing.T) {
+	text := stripHTMLToText(`<p>Mac &amp; Cheese &lt;3 &quot;best&quot; mom&#39;s&nbsp;recipe &gt;</p>`)
+	want := `Mac & Cheese <3 "best" mom's recipe >`
+	if !strings.Contains(text, want) {
+		t.Errorf("stripHTMLToText = %q, want it to contain %q", text, want)
+	}
+}
+
+func TestStripHTMLToText_BlockTagsBecomeNewlines(t *testing.T) {
+	text := stripHTMLToText(`<h1>Title</h1><p>One</p><li>Two</li>`)
+	lines := strings.Split(text, "\n")
+	var nonEmpty []string
+	for _, l := range lines {
+		if strings.TrimSpace(l) != "" {
+			nonEmpty = append(nonEmpty, strings.TrimSpace(l))
+		}
+	}
+	if len(nonEmpty) != 3 {
+		t.Fatalf("stripHTMLToText produced %d lines %v, want 3 (block tags preserved as newlines)", len(nonEmpty), nonEmpty)
+	}
+}
+
+func TestStripHTMLToText_CollapsesWhitespace(t *testing.T) {
+	text := stripHTMLToText("<p>a    \t   b</p>\n\n\n\n\n<p>c</p>")
+	if strings.Contains(text, "  ") {
+		t.Errorf("stripHTMLToText left runs of spaces: %q", text)
+	}
+	if strings.Contains(text, "\n\n\n") {
+		t.Errorf("stripHTMLToText left 3+ consecutive newlines: %q", text)
+	}
+	if got := stripHTMLToText("   <p>  trimmed  </p>   "); strings.HasPrefix(got, " ") || strings.HasSuffix(got, " ") {
+		t.Errorf("stripHTMLToText output not trimmed: %q", got)
+	}
+}
+
+// --- detectMultipleRecipesFromHTML ---
+
+func TestDetectMultipleRecipes_NilProvider(t *testing.T) {
+	cards := detectMultipleRecipesFromHTML(context.Background(), nil, "<p>page</p>", "https://example.com")
+	if cards != nil {
+		t.Errorf("detectMultipleRecipesFromHTML with nil provider = %+v, want nil", cards)
+	}
+}
+
+func TestDetectMultipleRecipes_SingleResponse(t *testing.T) {
+	provider := &testutil.MockTextProvider{
+		CookingQAFunc: func(ctx context.Context, question string, recipeContext string) (string, error) {
+			return "SINGLE", nil
+		},
+	}
+	cards := detectMultipleRecipesFromHTML(context.Background(), provider, "<p>one recipe</p>", "https://example.com")
+	if cards != nil {
+		t.Errorf("detectMultipleRecipesFromHTML = %+v, want nil for SINGLE response", cards)
+	}
+}
+
+func TestDetectMultipleRecipes_ProviderError(t *testing.T) {
+	provider := &testutil.MockTextProvider{
+		CookingQAFunc: func(ctx context.Context, question string, recipeContext string) (string, error) {
+			return "", errors.New("ai unavailable")
+		},
+	}
+	cards := detectMultipleRecipesFromHTML(context.Background(), provider, "<p>page</p>", "https://example.com")
+	if cards != nil {
+		t.Errorf("detectMultipleRecipesFromHTML = %+v, want nil on provider error", cards)
+	}
+}
+
+func TestDetectMultipleRecipes_FiltersNoisyLinesAndDuplicates(t *testing.T) {
+	longLine := strings.Repeat("x", 201)
+	provider := &testutil.MockTextProvider{
+		CookingQAFunc: func(ctx context.Context, question string, recipeContext string) (string, error) {
+			return strings.Join([]string{
+				"Pumpkin Soup",
+				"",             // empty — skipped
+				"  ",           // whitespace — skipped
+				"ab",           // too short — skipped
+				longLine,       // too long — skipped
+				"SINGLE",       // literal SINGLE mid-list — skipped
+				"Pumpkin Soup", // duplicate — skipped
+				"Apple Crumble",
+			}, "\n"), nil
+		},
+	}
+
+	cards := detectMultipleRecipesFromHTML(context.Background(), provider, "<p>page</p>", "https://example.com/desserts")
+	if len(cards) != 2 {
+		t.Fatalf("detectMultipleRecipesFromHTML returned %d cards, want 2 after filtering", len(cards))
+	}
+	if cards[0].Title != "Pumpkin Soup" || cards[1].Title != "Apple Crumble" {
+		t.Errorf("card titles = %q, %q", cards[0].Title, cards[1].Title)
+	}
+	for i, c := range cards {
+		if c.SourceURL != "https://example.com/desserts" || c.ExtractionStatus != "pending" {
+			t.Errorf("card[%d] = %+v, want pending card pointing at source URL", i, c)
+		}
+	}
+}
+
+func TestDetectMultipleRecipes_CapsAtTwentyCards(t *testing.T) {
+	var titles []string
+	for i := 0; i < 30; i++ {
+		titles = append(titles, fmt.Sprintf("Recipe Number %d", i))
+	}
+	provider := &testutil.MockTextProvider{
+		CookingQAFunc: func(ctx context.Context, question string, recipeContext string) (string, error) {
+			return strings.Join(titles, "\n"), nil
+		},
+	}
+
+	cards := detectMultipleRecipesFromHTML(context.Background(), provider, "<p>page</p>", "https://example.com")
+	if len(cards) != 20 {
+		t.Errorf("detectMultipleRecipesFromHTML returned %d cards, want cap of 20", len(cards))
+	}
+}
+
+func TestDetectMultipleRecipes_OneTitleIsNotMulti(t *testing.T) {
+	provider := &testutil.MockTextProvider{
+		CookingQAFunc: func(ctx context.Context, question string, recipeContext string) (string, error) {
+			return "Just One Recipe", nil
+		},
+	}
+	cards := detectMultipleRecipesFromHTML(context.Background(), provider, "<p>page</p>", "https://example.com")
+	if cards != nil {
+		t.Errorf("detectMultipleRecipesFromHTML = %+v, want nil when only one title detected", cards)
+	}
+}
+
+func TestDetectMultipleRecipes_StripsAndTruncatesPromptInput(t *testing.T) {
+	// Build HTML well above the 15k detection budget; the prompt must carry
+	// stripped text, not raw HTML, and stay bounded.
+	html := "<script>var noise='should-not-appear';</script>" +
+		"<p>" + strings.Repeat("filler words for the page body ", 2000) + "</p>"
+
+	var gotQuestion string
+	provider := &testutil.MockTextProvider{
+		CookingQAFunc: func(ctx context.Context, question string, recipeContext string) (string, error) {
+			gotQuestion = question
+			return "SINGLE", nil
+		},
+	}
+
+	detectMultipleRecipesFromHTML(context.Background(), provider, html, "https://example.com")
+
+	if strings.Contains(gotQuestion, "should-not-appear") {
+		t.Error("detection prompt contains script content; HTML was not stripped")
+	}
+	if strings.Contains(gotQuestion, "<p>") {
+		t.Error("detection prompt contains raw HTML tags")
+	}
+	// Prompt = fixed instructions + at most 15k of page text.
+	if len(gotQuestion) > 16_000 {
+		t.Errorf("detection prompt length = %d, want page text truncated to ~15k", len(gotQuestion))
+	}
+}
+
+// --- MultiRecipeRegistry ---
+
+func TestRegistryRegister_NewEntry(t *testing.T) {
+	r := NewMultiRecipeRegistry()
+
+	entry, isNew := r.Register("https://example.com/roundup")
+	if !isNew {
+		t.Fatal("Register of an unseen URL should report isNew=true")
+	}
+	if entry.Status != "resolving" {
+		t.Errorf("new entry Status = %q, want 'resolving'", entry.Status)
+	}
+	if entry.SourceURL != "https://example.com/roundup" {
+		t.Errorf("new entry SourceURL = %q", entry.SourceURL)
+	}
+	if !strings.HasPrefix(entry.ID, "multi_") {
+		t.Errorf("new entry ID = %q, want 'multi_' prefix", entry.ID)
+	}
+	if entry.DetectedAt.IsZero() {
+		t.Error("new entry DetectedAt is zero")
+	}
+}
+
+func TestRegistryRegister_ExistingEntryReturned(t *testing.T) {
+	r := NewMultiRecipeRegistry()
+
+	first, _ := r.Register("https://example.com/roundup")
+	second, isNew := r.Register("https://example.com/roundup")
+	if isNew {
+		t.Error("Register of a tracked URL should report isNew=false")
+	}
+	if first != second {
+		t.Error("Register should return the existing entry for a tracked URL")
+	}
+}
+
+func TestRegistryRegister_UniqueIDs(t *testing.T) {
+	r := NewMultiRecipeRegistry()
+
+	a, _ := r.Register("https://example.com/a")
+	b, _ := r.Register("https://example.com/b")
+	if a.ID == b.ID {
+		t.Errorf("two registered entries share ID %q; counter should make them unique", a.ID)
+	}
+}
+
+func TestRegistryGet_UntrackedURL(t *testing.T) {
+	r := NewMultiRecipeRegistry()
+	if entry := r.Get("https://example.com/unknown"); entry != nil {
+		t.Errorf("Get(untracked) = %+v, want nil", entry)
+	}
+}
+
+func TestRegistryGetByID(t *testing.T) {
+	r := NewMultiRecipeRegistry()
+	entry, _ := r.Register("https://example.com/roundup")
+
+	if got := r.GetByID(entry.ID); got != entry {
+		t.Errorf("GetByID(%q) = %+v, want the registered entry", entry.ID, got)
+	}
+	if got := r.GetByID("multi_nope_42"); got != nil {
+		t.Errorf("GetByID(unknown) = %+v, want nil", got)
+	}
+}
+
+// --- eviction decision (pure; the loop itself is time-driven and not spawned here) ---
+
+func TestShouldEvictEntry(t *testing.T) {
+	now := time.Now()
+	old := now.Add(-registryEvictionTTL - time.Minute)
+	fresh := now.Add(-time.Minute)
+
+	cases := []struct {
+		name       string
+		status     string
+		detectedAt time.Time
+		want       bool
+	}{
+		{"resolved and stale", "resolved", old, true},
+		{"failed and stale", "failed", old, true},
+		{"resolving never evicted even when stale", "resolving", old, false},
+		{"resolved but fresh", "resolved", fresh, false},
+		{"failed but fresh", "failed", fresh, false},
+		{"exactly at TTL boundary not evicted", "resolved", now.Add(-registryEvictionTTL), false},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := shouldEvictEntry(tc.status, tc.detectedAt, now); got != tc.want {
+				t.Errorf("shouldEvictEntry(%q, %v ago) = %v, want %v", tc.status, now.Sub(tc.detectedAt), got, tc.want)
+			}
+		})
+	}
+}
+
+// --- MultiRecipeEntry accessors ---
+
+func TestEntryGetCards_DeepCopiesRecipeDef(t *testing.T) {
+	def := testutil.TestRecipeDef()
+	entry := &MultiRecipeEntry{
+		Status: "resolved",
+		Cards: []MultiRecipeCard{
+			{Title: "Pancakes", RecipeDef: &def, ExtractionStatus: "done"},
+		},
+	}
+
+	cards := entry.GetCards()
+	if len(cards) != 1 {
+		t.Fatalf("GetCards returned %d cards, want 1", len(cards))
+	}
+	if cards[0].RecipeDef == entry.Cards[0].RecipeDef {
+		t.Error("GetCards returned the same RecipeDef pointer; want a deep copy")
+	}
+	if cards[0].RecipeDef.Title != def.Title {
+		t.Errorf("copied RecipeDef.Title = %q, want %q", cards[0].RecipeDef.Title, def.Title)
+	}
+
+	// Mutating the copy must not leak back into the entry.
+	cards[0].RecipeDef.Title = "Mutated"
+	if entry.Cards[0].RecipeDef.Title == "Mutated" {
+		t.Error("mutating a GetCards copy changed the entry's card")
+	}
+}
+
+func TestEntryGetStatus(t *testing.T) {
+	entry := &MultiRecipeEntry{Status: "resolving"}
+	if got := entry.GetStatus(); got != "resolving" {
+		t.Errorf("GetStatus = %q, want 'resolving'", got)
+	}
+}

--- a/internal/service/recipe.go
+++ b/internal/service/recipe.go
@@ -261,8 +261,11 @@ func (s *RecipeService) DeleteRecipe(ctx context.Context, recipeID uint) error {
 		return fmt.Errorf("failed to delete recipe: %w", err)
 	}
 
-	// Best-effort S3 image cleanup.
-	if s3Key := s3.S3KeyFromURL(imageURL); s3Key != "" {
+	// Best-effort S3 image cleanup. The key is scoped to this recipe's own
+	// "recipes/<id>/" prefix: ImageURL can be client-supplied (manual import)
+	// or scraped (JSON-LD), so a key derived from it must never be allowed to
+	// reference another recipe's objects.
+	if s3Key := s3.RecipeImageKeyFromURL(imageURL, recipeID); s3Key != "" {
 		if err := deleteImageFromS3(ctx, s.Cfg, s3Key); err != nil {
 			logger.Get().Warn("failed to delete recipe image from S3",
 				zap.Uint("recipe_id", recipeID),
@@ -324,8 +327,10 @@ func uploadRecipeImage(ctx context.Context, recipeID uint, oldImageURL string, i
 		return "", errors.New("failed to upload image to S3: " + err.Error())
 	}
 
-	// Best-effort cleanup of the previous image object behind the old URL.
-	if oldKey := s3.S3KeyFromURL(oldImageURL); oldKey != "" && oldKey != s3Key {
+	// Best-effort cleanup of the previous image object behind the old URL,
+	// scoped to this recipe's own prefix (the stored URL may be
+	// client-supplied or external and must not name another recipe's object).
+	if oldKey := s3.RecipeImageKeyFromURL(oldImageURL, recipeID); oldKey != "" && oldKey != s3Key {
 		if delErr := deleteImageFromS3(ctx, cfg, oldKey); delErr != nil {
 			logger.Get().Warn("failed to delete previous recipe image from S3",
 				zap.Uint("recipe_id", recipeID),

--- a/internal/service/recipe.go
+++ b/internal/service/recipe.go
@@ -42,8 +42,8 @@ type RecipeResponse struct {
 	SourceURL       string             `json:"sourceUrl,omitempty"`
 	CreatedAt       string             `json:"createdAt"`
 	UpdatedAt       string             `json:"updatedAt"`
-	UnitSystem      string  `json:"unitSystem"`
-	Status          string  `json:"status"`
+	UnitSystem      string             `json:"unitSystem"`
+	Status          string             `json:"status"`
 	// Additional detail fields
 	ParentRecipeID *string `json:"parentRecipeId,omitempty"`
 }

--- a/internal/service/recipe.go
+++ b/internal/service/recipe.go
@@ -305,11 +305,16 @@ func (s *RecipeService) GetRecipeTree(recipeID uint) (*TreeResponse, error) {
 		return nil, fmt.Errorf("failed to get tree nodes: %w", err)
 	}
 
+	if treeWithNodes.Nodes == nil {
+		treeWithNodes.Nodes = []models.RecipeNode{}
+	}
+
 	return &TreeResponse{
-		TreeID:     treeWithNodes.ID,
-		RecipeID:   treeWithNodes.RecipeID,
-		RootNodeID: treeWithNodes.RootNodeID,
-		Nodes:      treeWithNodes.Nodes,
+		TreeID:       treeWithNodes.ID,
+		RecipeID:     treeWithNodes.RecipeID,
+		RootNodeID:   treeWithNodes.RootNodeID,
+		ActiveNodeID: activeNodeID(treeWithNodes.Nodes),
+		Nodes:        treeWithNodes.Nodes,
 	}, nil
 }
 
@@ -355,12 +360,25 @@ func (s *RecipeService) SwitchToNode(recipeID uint, nodeID uint) error {
 	return nil
 }
 
-// TreeResponse is the response object for recipe tree operations.
+// TreeResponse is the response object for recipe tree operations. Nodes is a
+// flat array; clients rebuild the tree structure from each node's parent_id.
 type TreeResponse struct {
-	TreeID     uint                `json:"tree_id"`
-	RecipeID   uint                `json:"recipe_id"`
-	RootNodeID *uint               `json:"root_node_id"`
-	Nodes      []models.RecipeNode `json:"nodes"`
+	TreeID       uint                `json:"tree_id"`
+	RecipeID     uint                `json:"recipe_id"`
+	RootNodeID   *uint               `json:"root_node_id"`
+	ActiveNodeID *uint               `json:"active_node_id"`
+	Nodes        []models.RecipeNode `json:"nodes"`
+}
+
+// activeNodeID returns the ID of the active node in a flat node list, or nil.
+func activeNodeID(nodes []models.RecipeNode) *uint {
+	for i := range nodes {
+		if nodes[i].IsActive {
+			id := nodes[i].ID
+			return &id
+		}
+	}
+	return nil
 }
 
 // effectiveRecipeDef resolves the effective RecipeDef for a recipe, using the

--- a/internal/service/recipe.go
+++ b/internal/service/recipe.go
@@ -22,14 +22,10 @@ type RecipeService struct {
 	Repo          repository.RecipeRepo
 	TextProvider  ai.TextProvider
 	ImageProvider ai.ImageProvider
-	// Optional: set these to enable embedding generation on recipe create/update.
+	// Optional: set these to enable embedding generation on recipe
+	// create/update and semantic search over a user's recipes.
 	EmbedProvider ai.EmbeddingProvider
-	VectorRepo    VectorUpdater
-}
-
-// VectorUpdater is the subset of VectorRepository needed by RecipeService.
-type VectorUpdater interface {
-	UpdateEmbedding(recipeID uint, embedding []float32) error
+	VectorRepo    repository.VectorRepo
 }
 
 // RecipeResponse is the response object for recipe-related operations.
@@ -76,27 +72,39 @@ func NewRecipeService(cfg *config.Config, repo repository.RecipeRepo, textProvid
 	}
 }
 
-// generateAndStoreEmbedding creates a vector embedding for a recipe and persists it.
-// This is best-effort: failures are logged but do not block recipe operations.
-func (s *RecipeService) generateAndStoreEmbedding(ctx context.Context, recipeID uint, recipeDef *models.RecipeDef) {
-	if s.EmbedProvider == nil || s.VectorRepo == nil {
-		return
-	}
-
+// embeddingText builds the text used to embed a recipe: its title followed by
+// its ingredient names.
+func embeddingText(recipeDef *models.RecipeDef) string {
 	text := recipeDef.Title
 	for _, ing := range recipeDef.Ingredients {
 		text += " " + ing.Name
 	}
+	return text
+}
 
-	embedding, err := s.EmbedProvider.GenerateEmbedding(ctx, text)
+// generateAndStoreRecipeEmbedding creates a vector embedding for a recipe and
+// persists it. This is best-effort: failures are logged but do not block
+// recipe operations.
+func generateAndStoreRecipeEmbedding(ctx context.Context, embedProvider ai.EmbeddingProvider, vectorRepo repository.VectorRepo, recipeID uint, recipeDef *models.RecipeDef) {
+	if embedProvider == nil || vectorRepo == nil {
+		return
+	}
+
+	embedding, err := embedProvider.GenerateEmbedding(ctx, embeddingText(recipeDef))
 	if err != nil {
 		logger.Get().Warn("failed to generate recipe embedding", zap.Uint("recipe_id", recipeID), zap.Error(err))
 		return
 	}
 
-	if err := s.VectorRepo.UpdateEmbedding(recipeID, embedding); err != nil {
+	if err := vectorRepo.UpdateEmbedding(recipeID, embedding); err != nil {
 		logger.Get().Warn("failed to store recipe embedding", zap.Uint("recipe_id", recipeID), zap.Error(err))
 	}
+}
+
+// generateAndStoreEmbedding creates a vector embedding for a recipe and persists it.
+// This is best-effort: failures are logged but do not block recipe operations.
+func (s *RecipeService) generateAndStoreEmbedding(ctx context.Context, recipeID uint, recipeDef *models.RecipeDef) {
+	generateAndStoreRecipeEmbedding(ctx, s.EmbedProvider, s.VectorRepo, recipeID, recipeDef)
 }
 
 // GetUserRecipes returns a paginated list of recipes for a user.
@@ -106,30 +114,113 @@ func (s *RecipeService) GetUserRecipes(userID uint, page, pageSize int) ([]Recip
 		return nil, 0, fmt.Errorf("failed to get user recipes: %w", err)
 	}
 
+	return s.ToRecipeListItems(recipes), total, nil
+}
+
+// ToRecipeListItem converts a Recipe to the lightweight RecipeListItem DTO.
+func (s *RecipeService) ToRecipeListItem(r *models.Recipe) RecipeListItem {
+	effectiveDef := effectiveRecipeDef(r)
+
+	tags := make([]string, 0, len(r.Hashtags))
+	for _, t := range r.Hashtags {
+		tags = append(tags, t.Hashtag)
+	}
+
+	return RecipeListItem{
+		ID:              fmt.Sprintf("%d", r.ID),
+		Title:           effectiveDef.Title,
+		OwnerID:         fmt.Sprintf("%d", r.CreatedByID),
+		ImageURL:        r.ImageURL,
+		CookTimeMinutes: effectiveDef.CookTime,
+		Tags:            tags,
+		SourceURL:       effectiveDef.SourceURL,
+		Status:          r.Status,
+		CreatedAt:       r.CreatedAt.Format("2006-01-02T15:04:05Z"),
+		UpdatedAt:       r.UpdatedAt.Format("2006-01-02T15:04:05Z"),
+	}
+}
+
+// ToRecipeListItems converts a slice of Recipes to RecipeListItem DTOs.
+// Always returns a non-nil slice so JSON serializes as [] rather than null.
+func (s *RecipeService) ToRecipeListItems(recipes []models.Recipe) []RecipeListItem {
 	items := make([]RecipeListItem, len(recipes))
-	for i, r := range recipes {
-		effectiveDef := effectiveRecipeDef(&r)
+	for i := range recipes {
+		items[i] = s.ToRecipeListItem(&recipes[i])
+	}
+	return items
+}
 
-		tags := make([]string, 0, len(r.Hashtags))
-		for _, t := range r.Hashtags {
-			tags = append(tags, t.Hashtag)
-		}
+// userSearchCandidateCap bounds how many candidates each search strategy
+// (vector, ILIKE) contributes before merging and paginating.
+const userSearchCandidateCap = 100
 
-		items[i] = RecipeListItem{
-			ID:              fmt.Sprintf("%d", r.ID),
-			Title:           effectiveDef.Title,
-			OwnerID:         fmt.Sprintf("%d", r.CreatedByID),
-			ImageURL:        r.ImageURL,
-			CookTimeMinutes: effectiveDef.CookTime,
-			Tags:            tags,
-			SourceURL:       effectiveDef.SourceURL,
-			Status:          r.Status,
-			CreatedAt:       r.CreatedAt.Format("2006-01-02T15:04:05Z"),
-			UpdatedAt:       r.UpdatedAt.Format("2006-01-02T15:04:05Z"),
+// SearchUserRecipes performs a semantic search over the user's own recipes,
+// merged with an ILIKE title fallback for recipes lacking embeddings. Results
+// are deduped by ID (vector-rank first) and paginated in memory. If embedding
+// generation fails, it falls back to a pure ILIKE title search.
+func (s *RecipeService) SearchUserRecipes(ctx context.Context, userID uint, query string, page, pageSize int) ([]RecipeListItem, int64, error) {
+	if s.VectorRepo == nil {
+		return nil, 0, errors.New("vector repository not configured")
+	}
+
+	var vectorHits []models.Recipe
+	vectorOK := false
+	if s.EmbedProvider != nil {
+		embedding, err := s.EmbedProvider.GenerateEmbedding(ctx, query)
+		if err != nil {
+			logger.Get().Warn("failed to embed search query, falling back to title search",
+				zap.Uint("user_id", userID), zap.Error(err))
+		} else {
+			hits, searchErr := s.VectorRepo.SearchUserRecipesByEmbedding(userID, repository.PgvectorLiteral(embedding), userSearchCandidateCap)
+			if searchErr != nil {
+				logger.Get().Warn("vector search failed, falling back to title search",
+					zap.Uint("user_id", userID), zap.Error(searchErr))
+			} else {
+				vectorHits = hits
+				vectorOK = true
+			}
 		}
 	}
 
-	return items, total, nil
+	// When the vector search succeeded, the ILIKE pass only needs to cover
+	// recipes lacking embeddings; otherwise it is the sole search strategy.
+	titleHits, err := s.VectorRepo.SearchUserRecipesByTitle(userID, query, vectorOK, userSearchCandidateCap)
+	if err != nil {
+		if !vectorOK {
+			return nil, 0, fmt.Errorf("failed to search user recipes: %w", err)
+		}
+		logger.Get().Warn("title fallback search failed", zap.Uint("user_id", userID), zap.Error(err))
+	}
+
+	// Dedupe by ID, preserving vector-rank-first order.
+	seen := make(map[uint]bool, len(vectorHits)+len(titleHits))
+	merged := make([]models.Recipe, 0, len(vectorHits)+len(titleHits))
+	for _, r := range vectorHits {
+		if !seen[r.ID] {
+			seen[r.ID] = true
+			merged = append(merged, r)
+		}
+	}
+	for _, r := range titleHits {
+		if !seen[r.ID] {
+			seen[r.ID] = true
+			merged = append(merged, r)
+		}
+	}
+
+	total := int64(len(merged))
+
+	// Paginate the merged result.
+	start := (page - 1) * pageSize
+	if start >= len(merged) {
+		return []RecipeListItem{}, total, nil
+	}
+	end := start + pageSize
+	if end > len(merged) {
+		end = len(merged)
+	}
+
+	return s.ToRecipeListItems(merged[start:end]), total, nil
 }
 
 // GetRecipeByID fetches a recipe by its ID.

--- a/internal/service/recipe.go
+++ b/internal/service/recipe.go
@@ -237,17 +237,38 @@ func (s *RecipeService) GetRecipeByID(recipeID uint) (*RecipeResponse, error) {
 	return recipeResponse, nil
 }
 
-// DeleteRecipe deletes a recipe by its ID.
+// uploadImageToS3 and deleteImageFromS3 are indirections over the s3 package
+// so tests can stub out network calls.
+var (
+	uploadImageToS3   = s3.UploadRecipeImageToS3
+	deleteImageFromS3 = s3.DeleteRecipeImageFromS3
+)
+
+// DeleteRecipe deletes a recipe by its ID, along with its tree/nodes and S3
+// image. S3 cleanup is best-effort: the row is already gone by then, so a
+// failed S3 delete is logged but does not fail the request.
 func (s *RecipeService) DeleteRecipe(ctx context.Context, recipeID uint) error {
-	// Delete the recipe from the database
+	// Capture the image URL before the row is deleted so the S3 object can be
+	// cleaned up afterwards. Image keys are timestamp-versioned, so the key
+	// must be derived from the stored URL rather than regenerated.
+	var imageURL string
+	if recipe, err := s.Repo.GetRecipeByID(recipeID); err == nil {
+		imageURL = recipe.ImageURL
+	}
+
+	// Delete the recipe (and its tree + nodes) from the database.
 	if err := s.Repo.DeleteRecipe(recipeID); err != nil {
 		return fmt.Errorf("failed to delete recipe: %w", err)
 	}
 
-	// Delete the recipe image from S3
-	s3Key := s3.GenerateS3Key(recipeID)
-	if err := s3.DeleteRecipeImageFromS3(ctx, s.Cfg, s3Key); err != nil {
-		return fmt.Errorf("failed to delete recipe image from S3: %w", err)
+	// Best-effort S3 image cleanup.
+	if s3Key := s3.S3KeyFromURL(imageURL); s3Key != "" {
+		if err := deleteImageFromS3(ctx, s.Cfg, s3Key); err != nil {
+			logger.Get().Warn("failed to delete recipe image from S3",
+				zap.Uint("recipe_id", recipeID),
+				zap.String("s3_key", s3Key),
+				zap.Error(err))
+		}
 	}
 
 	return nil
@@ -292,12 +313,25 @@ func validateRecipeCoreFields(recipe *models.Recipe) error {
 	return nil
 }
 
-// uploadRecipeImage uploads the recipe image to S3 and returns the new image URL.
-func uploadRecipeImage(ctx context.Context, recipeID uint, imageBytes []byte, cfg *config.Config) (string, error) {
+// uploadRecipeImage uploads a generated recipe image (DALL-E PNG bytes) to S3
+// under a timestamp-versioned key and returns the new image URL. After a
+// successful upload, the previous image object (derived from oldImageURL) is
+// deleted best-effort so stale objects don't accumulate.
+func uploadRecipeImage(ctx context.Context, recipeID uint, oldImageURL string, imageBytes []byte, cfg *config.Config) (string, error) {
 	s3Key := s3.GenerateS3Key(recipeID)
-	imageURL, err := s3.UploadRecipeImageToS3(ctx, cfg, imageBytes, s3Key)
+	imageURL, err := uploadImageToS3(ctx, cfg, imageBytes, s3Key, "image/png")
 	if err != nil {
 		return "", errors.New("failed to upload image to S3: " + err.Error())
+	}
+
+	// Best-effort cleanup of the previous image object behind the old URL.
+	if oldKey := s3.S3KeyFromURL(oldImageURL); oldKey != "" && oldKey != s3Key {
+		if delErr := deleteImageFromS3(ctx, cfg, oldKey); delErr != nil {
+			logger.Get().Warn("failed to delete previous recipe image from S3",
+				zap.Uint("recipe_id", recipeID),
+				zap.String("s3_key", oldKey),
+				zap.Error(delErr))
+		}
 	}
 
 	return imageURL, nil

--- a/internal/service/recipeChat.go
+++ b/internal/service/recipeChat.go
@@ -83,7 +83,7 @@ func (s *RecipeService) FinishGenerateRecipe(recipe *models.Recipe, user *models
 					return
 				}
 
-				imageURL, uploadErr := uploadRecipeImage(ctx, recipe.ID, imageBytes, s.Cfg)
+				imageURL, uploadErr := uploadRecipeImage(ctx, recipe.ID, recipe.ImageURL, imageBytes, s.Cfg)
 				if uploadErr != nil {
 					imageErrChan <- uploadErr
 					return
@@ -298,7 +298,7 @@ func (s *RecipeService) finishStreamedRecipe(ctx context.Context, recipe *models
 				log.Error("background image generation failed", zap.Error(err))
 				return
 			}
-			imageURL, err := uploadRecipeImage(imgCtx, recipe.ID, imageBytes, s.Cfg)
+			imageURL, err := uploadRecipeImage(imgCtx, recipe.ID, recipe.ImageURL, imageBytes, s.Cfg)
 			if err != nil {
 				log.Error("background image upload failed", zap.Error(err))
 				return

--- a/internal/service/recipeChat.go
+++ b/internal/service/recipeChat.go
@@ -202,7 +202,7 @@ func (s *RecipeService) StreamGenerateRecipe(ctx context.Context, user *models.U
 	ai.TrySendEvent(ctx, events, ai.StreamEvent{Type: ai.StreamEventStarted, RecipeID: recipe.ID})
 
 	// Type-assert to get streaming capability
-	anthropicProvider, ok := s.TextProvider.(*ai.AnthropicProvider)
+	streamProvider, ok := s.TextProvider.(ai.StreamingTextProvider)
 	if !ok {
 		// Fall back to non-streaming generation
 		log.Info("provider does not support streaming, falling back to sync generation")
@@ -230,7 +230,7 @@ func (s *RecipeService) StreamGenerateRecipe(ctx context.Context, user *models.U
 		CookingContext: user.Personalization.CookingContextPrompt(),
 	}
 
-	result, err := anthropicProvider.StreamGenerateRecipe(ctx, req, events)
+	result, err := streamProvider.StreamGenerateRecipe(ctx, req, events)
 	if err != nil {
 		log.Error("streaming recipe generation failed", zap.Uint("recipe_id", recipe.ID), zap.Error(err))
 		s.Repo.UpdateRecipeStatus(recipe.ID, "failed")

--- a/internal/service/recipeChat.go
+++ b/internal/service/recipeChat.go
@@ -9,6 +9,7 @@ import (
 	"github.com/windoze95/saltybytes-api/internal/ai"
 	"github.com/windoze95/saltybytes-api/internal/logger"
 	"github.com/windoze95/saltybytes-api/internal/models"
+	"github.com/windoze95/saltybytes-api/internal/util"
 	"go.uber.org/zap"
 )
 
@@ -41,11 +42,15 @@ func (s *RecipeService) InitGenerateRecipe(user *models.User, userPrompt string,
 
 // FinishGenerateRecipe finishes generating a recipe with chat.
 func (s *RecipeService) FinishGenerateRecipe(recipe *models.Recipe, user *models.User, userPrompt string, genImage bool) {
+	defer util.RecoverPanic("finish generate recipe")
+
 	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Minute)
 	defer cancel()
 
-	recipeErrChan := make(chan error)
-	imageErrChan := make(chan error, 1) // buffered to prevent goroutine leak when genImage is false
+	// Both channels are buffered so the worker goroutines' single send never
+	// blocks (and leaks the goroutine) when the parent returns on ctx.Done().
+	recipeErrChan := make(chan error, 1)
+	imageErrChan := make(chan error, 1)
 
 	req := ai.RecipeRequest{
 		UserPrompt:     userPrompt,
@@ -56,6 +61,8 @@ func (s *RecipeService) FinishGenerateRecipe(recipe *models.Recipe, user *models
 
 	// Goroutine to handle recipe generation
 	go func(ctx context.Context, recipeErrChan chan<- error, imageErrChan chan<- error) {
+		defer util.RecoverPanic("generate recipe worker")
+
 		result, err := s.TextProvider.GenerateRecipe(ctx, req)
 		if err != nil {
 			recipeErrChan <- err
@@ -76,6 +83,8 @@ func (s *RecipeService) FinishGenerateRecipe(recipe *models.Recipe, user *models
 
 		// Goroutine to handle image generation and upload
 		go func(ctx context.Context, imageErrChan chan<- error) {
+			defer util.RecoverPanic("generate recipe image worker")
+
 			if genImage && result.ImagePrompt != "" {
 				imageBytes, imgErr := s.ImageProvider.GenerateImage(ctx, result.ImagePrompt)
 				if imgErr != nil {
@@ -291,6 +300,8 @@ func (s *RecipeService) finishStreamedRecipe(ctx context.Context, recipe *models
 	// Image generation runs in background — SSE closes after complete
 	if genImage && result.ImagePrompt != "" {
 		go func() {
+			defer util.RecoverPanic("streamed recipe background image")
+
 			imgCtx, cancel := context.WithTimeout(context.Background(), 2*time.Minute)
 			defer cancel()
 			imageBytes, err := s.ImageProvider.GenerateImage(imgCtx, result.ImagePrompt)

--- a/internal/service/recipeFork.go
+++ b/internal/service/recipeFork.go
@@ -108,7 +108,7 @@ func (s *RecipeService) FinishGenerateRecipeWithFork(recipe *models.Recipe, sour
 					return
 				}
 
-				imageURL, uploadErr := uploadRecipeImage(ctx, recipe.ID, imageBytes, s.Cfg)
+				imageURL, uploadErr := uploadRecipeImage(ctx, recipe.ID, recipe.ImageURL, imageBytes, s.Cfg)
 				if uploadErr != nil {
 					imageErrChan <- uploadErr
 					return

--- a/internal/service/recipeFork.go
+++ b/internal/service/recipeFork.go
@@ -9,6 +9,7 @@ import (
 	"github.com/windoze95/saltybytes-api/internal/ai"
 	"github.com/windoze95/saltybytes-api/internal/logger"
 	"github.com/windoze95/saltybytes-api/internal/models"
+	"github.com/windoze95/saltybytes-api/internal/util"
 	"go.uber.org/zap"
 )
 
@@ -48,11 +49,15 @@ func (s *RecipeService) InitGenerateRecipeWithFork(user *models.User, forkedReci
 // FinishGenerateRecipeWithFork finishes generating a recipe with fork.
 // sourceRecipe is the original recipe being forked (used for AI conversation context).
 func (s *RecipeService) FinishGenerateRecipeWithFork(recipe *models.Recipe, sourceRecipe *models.Recipe, user *models.User, userPrompt string, genImage bool) {
+	defer util.RecoverPanic("finish generate recipe with fork")
+
 	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Minute)
 	defer cancel()
 
-	recipeErrChan := make(chan error)
-	imageErrChan := make(chan error, 1) // buffered to prevent goroutine leak when genImage is false
+	// Both channels are buffered so the worker goroutines' single send never
+	// blocks (and leaks the goroutine) when the parent returns on ctx.Done().
+	recipeErrChan := make(chan error, 1)
+	imageErrChan := make(chan error, 1)
 
 	// Resolve effective RecipeDef from canonical for fork context (read-only)
 	effectiveDef := effectiveRecipeDef(sourceRecipe)
@@ -81,6 +86,8 @@ func (s *RecipeService) FinishGenerateRecipeWithFork(recipe *models.Recipe, sour
 
 	// Goroutine to handle recipe generation
 	go func(ctx context.Context, recipeErrChan chan<- error, imageErrChan chan<- error) {
+		defer util.RecoverPanic("fork recipe worker")
+
 		result, err := s.TextProvider.ForkRecipe(ctx, req)
 		if err != nil {
 			recipeErrChan <- err
@@ -101,6 +108,8 @@ func (s *RecipeService) FinishGenerateRecipeWithFork(recipe *models.Recipe, sour
 
 		// Goroutine to handle image generation and upload
 		go func(ctx context.Context, imageErrChan chan<- error) {
+			defer util.RecoverPanic("fork recipe image worker")
+
 			if genImage && result.ImagePrompt != "" {
 				imageBytes, imgErr := s.ImageProvider.GenerateImage(ctx, result.ImagePrompt)
 				if imgErr != nil {

--- a/internal/service/recipeRegen.go
+++ b/internal/service/recipeRegen.go
@@ -11,6 +11,7 @@ import (
 	"github.com/windoze95/saltybytes-api/internal/ai"
 	"github.com/windoze95/saltybytes-api/internal/logger"
 	"github.com/windoze95/saltybytes-api/internal/models"
+	"github.com/windoze95/saltybytes-api/internal/util"
 	"go.uber.org/zap"
 )
 
@@ -37,6 +38,8 @@ func (s *RecipeService) InitRegenerateRecipe(user *models.User, recipeID uint, u
 
 // FinishRegenerateRecipe finishes regenerating a recipe.
 func (s *RecipeService) FinishRegenerateRecipe(recipe *models.Recipe, user *models.User, userPrompt string, genImage bool) {
+	defer util.RecoverPanic("finish regenerate recipe")
+
 	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Minute)
 	defer cancel()
 
@@ -45,8 +48,10 @@ func (s *RecipeService) FinishRegenerateRecipe(recipe *models.Recipe, user *mode
 		logger.Get().Error("failed to materialize canonical before regen", zap.Uint("recipe_id", recipe.ID), zap.Error(err))
 	}
 
-	recipeErrChan := make(chan error)
-	imageErrChan := make(chan error, 1) // buffered to prevent goroutine leak when genImage is false
+	// Both channels are buffered so the worker goroutines' single send never
+	// blocks (and leaks the goroutine) when the parent returns on ctx.Done().
+	recipeErrChan := make(chan error, 1)
+	imageErrChan := make(chan error, 1)
 
 	// Load conversation context from tree nodes
 	var existingHistory []ai.Message
@@ -72,6 +77,8 @@ func (s *RecipeService) FinishRegenerateRecipe(recipe *models.Recipe, user *mode
 
 	// Goroutine to handle recipe generation
 	go func(ctx context.Context, recipeErrChan chan<- error, imageErrChan chan<- error) {
+		defer util.RecoverPanic("regenerate recipe worker")
+
 		result, err := s.TextProvider.RegenerateRecipe(ctx, req)
 		if err != nil {
 			recipeErrChan <- err
@@ -92,6 +99,8 @@ func (s *RecipeService) FinishRegenerateRecipe(recipe *models.Recipe, user *mode
 
 		// Goroutine to handle image generation and upload
 		go func(ctx context.Context, imageErrChan chan<- error) {
+			defer util.RecoverPanic("regenerate recipe image worker")
+
 			if genImage && result.ImagePrompt != "" {
 				imageBytes, imgErr := s.ImageProvider.GenerateImage(ctx, result.ImagePrompt)
 				if imgErr != nil {

--- a/internal/service/recipeRegen.go
+++ b/internal/service/recipeRegen.go
@@ -99,7 +99,7 @@ func (s *RecipeService) FinishRegenerateRecipe(recipe *models.Recipe, user *mode
 					return
 				}
 
-				imageURL, uploadErr := uploadRecipeImage(ctx, recipe.ID, imageBytes, s.Cfg)
+				imageURL, uploadErr := uploadRecipeImage(ctx, recipe.ID, recipe.ImageURL, imageBytes, s.Cfg)
 				if uploadErr != nil {
 					imageErrChan <- uploadErr
 					return

--- a/internal/service/recipe_chat_test.go
+++ b/internal/service/recipe_chat_test.go
@@ -1,0 +1,794 @@
+package service
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/windoze95/saltybytes-api/internal/ai"
+	"github.com/windoze95/saltybytes-api/internal/config"
+	"github.com/windoze95/saltybytes-api/internal/models"
+	"github.com/windoze95/saltybytes-api/internal/repository"
+	"github.com/windoze95/saltybytes-api/internal/testutil"
+)
+
+// newGenRecipeService builds a RecipeService with the given AI providers and
+// embedding deps wired in (any may be nil for "not configured").
+func newGenRecipeService(repo repository.RecipeRepo, text ai.TextProvider, image ai.ImageProvider, embed ai.EmbeddingProvider, vector repository.VectorRepo) *RecipeService {
+	return &RecipeService{
+		Cfg:           &config.Config{},
+		Repo:          repo,
+		TextProvider:  text,
+		ImageProvider: image,
+		EmbedProvider: embed,
+		VectorRepo:    vector,
+	}
+}
+
+// gatedTextProvider returns a MockTextProvider whose GenerateRecipe blocks
+// until the test finishes, so Init* tests can assert on placeholder state
+// without racing the background finish goroutine.
+func gatedTextProvider(t *testing.T) (*testutil.MockTextProvider, chan struct{}) {
+	t.Helper()
+	gate := make(chan struct{})
+	entered := make(chan struct{})
+	t.Cleanup(func() { close(gate) })
+	provider := &testutil.MockTextProvider{
+		GenerateRecipeFunc: func(ctx context.Context, req ai.RecipeRequest) (*ai.RecipeResult, error) {
+			close(entered)
+			<-gate
+			return nil, errors.New("aborted by test teardown")
+		},
+	}
+	return provider, entered
+}
+
+// waitForCondition polls cond until it returns true or the timeout elapses.
+func waitForCondition(t *testing.T, timeout time.Duration, cond func() bool, msg string) {
+	t.Helper()
+	deadline := time.Now().Add(timeout)
+	for time.Now().Before(deadline) {
+		if cond() {
+			return
+		}
+		time.Sleep(5 * time.Millisecond)
+	}
+	t.Fatal(msg)
+}
+
+// drainEvents closes and drains a stream event channel into a slice.
+func drainEvents(events chan ai.StreamEvent) []ai.StreamEvent {
+	close(events)
+	var out []ai.StreamEvent
+	for e := range events {
+		out = append(out, e)
+	}
+	return out
+}
+
+// findEvent returns the first event of the given type, or nil.
+func findEvent(events []ai.StreamEvent, eventType ai.StreamEventType) *ai.StreamEvent {
+	for i := range events {
+		if events[i].Type == eventType {
+			return &events[i]
+		}
+	}
+	return nil
+}
+
+// --- InitGenerateRecipe ---
+
+func TestInitGenerateRecipe_CreatesGeneratingPlaceholder(t *testing.T) {
+	repo := testutil.NewMockRecipeRepo()
+	user := testutil.TestUser()
+	provider, entered := gatedTextProvider(t)
+
+	svc := newGenRecipeService(repo, provider, &testutil.MockImageProvider{}, nil, nil)
+	resp, err := svc.InitGenerateRecipe(user, "make pancakes", false)
+	if err != nil {
+		t.Fatalf("InitGenerateRecipe() error = %v", err)
+	}
+
+	if resp.ID != "1" {
+		t.Errorf("response ID = %q, want '1'", resp.ID)
+	}
+	if resp.Status != "generating" {
+		t.Errorf("response Status = %q, want 'generating'", resp.Status)
+	}
+
+	stored := repo.RecipeSnapshot(1)
+	if stored == nil {
+		t.Fatal("placeholder recipe should exist in the repo")
+	}
+	if stored.Status != "generating" {
+		t.Errorf("stored Status = %q, want 'generating'", stored.Status)
+	}
+	if stored.PersonalizationUID != user.Personalization.UID {
+		t.Errorf("stored PersonalizationUID = %v, want %v", stored.PersonalizationUID, user.Personalization.UID)
+	}
+
+	// The async finish goroutine must actually start.
+	select {
+	case <-entered:
+	case <-time.After(2 * time.Second):
+		t.Fatal("FinishGenerateRecipe goroutine never called the text provider")
+	}
+}
+
+func TestInitGenerateRecipe_NilPersonalization(t *testing.T) {
+	repo := testutil.NewMockRecipeRepo()
+	user := testutil.TestUser()
+	user.Personalization = &models.Personalization{} // ID == 0
+
+	svc := newGenRecipeService(repo, &testutil.MockTextProvider{}, &testutil.MockImageProvider{}, nil, nil)
+	if _, err := svc.InitGenerateRecipe(user, "make pancakes", false); err == nil {
+		t.Fatal("InitGenerateRecipe() error = nil, want error for missing personalization")
+	}
+	if len(repo.Recipes) != 0 {
+		t.Errorf("no recipe should be created, got %d", len(repo.Recipes))
+	}
+}
+
+func TestInitGenerateRecipe_CreateRecipeError(t *testing.T) {
+	repo := testutil.NewMockRecipeRepo()
+	repo.CreateRecipeErr = errors.New("db down")
+
+	svc := newGenRecipeService(repo, &testutil.MockTextProvider{}, &testutil.MockImageProvider{}, nil, nil)
+	if _, err := svc.InitGenerateRecipe(testutil.TestUser(), "make pancakes", false); err == nil {
+		t.Fatal("InitGenerateRecipe() error = nil, want error when the repo create fails")
+	}
+}
+
+// --- FinishGenerateRecipe ---
+
+// seedGeneratingRecipe creates a placeholder recipe through the repo the same
+// way InitGenerateRecipe does.
+func seedGeneratingRecipe(t *testing.T, repo *testutil.MockRecipeRepo, user *models.User) *models.Recipe {
+	t.Helper()
+	recipe := &models.Recipe{
+		CreatedBy:          user,
+		CreatedByID:        user.ID,
+		PersonalizationUID: user.Personalization.UID,
+		Status:             "generating",
+	}
+	if err := repo.CreateRecipe(recipe); err != nil {
+		t.Fatalf("CreateRecipe() error = %v", err)
+	}
+	return recipe
+}
+
+func TestFinishGenerateRecipe_HappyPathWithImage(t *testing.T) {
+	repo := testutil.NewMockRecipeRepo()
+	user := testutil.TestUser()
+	recipe := seedGeneratingRecipe(t, repo, user)
+
+	var gotReq ai.RecipeRequest
+	result := testutil.TestRecipeResult()
+	result.UnitSystem = "metric"
+	result.PromptVersion = "pv-123"
+	text := &testutil.MockTextProvider{
+		GenerateRecipeFunc: func(ctx context.Context, req ai.RecipeRequest) (*ai.RecipeResult, error) {
+			gotReq = req
+			return result, nil
+		},
+	}
+
+	var imagePrompt string
+	image := &testutil.MockImageProvider{
+		GenerateImageFunc: func(ctx context.Context, prompt string) ([]byte, error) {
+			imagePrompt = prompt
+			return []byte("png-bytes"), nil
+		},
+	}
+	var gotKey, gotContentType string
+	newURL := "https://bucket.s3.us-east-2.amazonaws.com/recipes/1/images/recipe_image_1_1700000001.png"
+	stubS3Upload(t, &gotKey, &gotContentType, newURL, nil)
+	stubS3Delete(t, nil)
+
+	vector := &testutil.MockVectorRepo{}
+	embed := &testutil.MockEmbeddingProvider{
+		GenerateEmbeddingFunc: func(ctx context.Context, text string) ([]float32, error) {
+			return []float32{0.1, 0.2}, nil
+		},
+	}
+
+	svc := newGenRecipeService(repo, text, image, embed, vector)
+	svc.FinishGenerateRecipe(recipe, user, "make pancakes", true)
+
+	// Request carried the user's personalization.
+	if gotReq.UserPrompt != "make pancakes" {
+		t.Errorf("req.UserPrompt = %q", gotReq.UserPrompt)
+	}
+	if gotReq.UnitSystem != "US Customary" {
+		t.Errorf("req.UnitSystem = %q, want 'US Customary'", gotReq.UnitSystem)
+	}
+	if gotReq.Requirements != "No peanuts" {
+		t.Errorf("req.Requirements = %q, want 'No peanuts'", gotReq.Requirements)
+	}
+
+	stored := repo.RecipeSnapshot(recipe.ID)
+	if stored == nil {
+		t.Fatal("recipe should still exist")
+	}
+	if stored.Title != "Classic Pancakes" {
+		t.Errorf("persisted Title = %q, want 'Classic Pancakes'", stored.Title)
+	}
+	if stored.UnitSystem != "metric" {
+		t.Errorf("persisted UnitSystem = %q, want 'metric' (from tool result)", stored.UnitSystem)
+	}
+	if stored.Status != "ready" {
+		t.Errorf("Status = %q, want 'ready'", stored.Status)
+	}
+	if recipe.PromptVersion != "pv-123" {
+		t.Errorf("PromptVersion = %q, want 'pv-123'", recipe.PromptVersion)
+	}
+
+	// Tree initialized with the chat root node.
+	tree, err := repo.GetTreeByRecipeID(recipe.ID)
+	if err != nil {
+		t.Fatalf("GetTreeByRecipeID() error = %v", err)
+	}
+	root, err := repo.GetActiveNode(tree.ID)
+	if err != nil {
+		t.Fatalf("GetActiveNode() error = %v", err)
+	}
+	if root.Type != models.RecipeTypeChat {
+		t.Errorf("root node Type = %q, want %q", root.Type, models.RecipeTypeChat)
+	}
+	if root.Prompt != "make pancakes" {
+		t.Errorf("root node Prompt = %q", root.Prompt)
+	}
+	if root.BranchName != "original" {
+		t.Errorf("root node BranchName = %q, want 'original'", root.BranchName)
+	}
+	if root.Response == nil || root.Response.Title != "Classic Pancakes" {
+		t.Error("root node Response should carry the generated def")
+	}
+
+	// Embedding attempted.
+	if len(vector.UpdateEmbeddingCalls) != 1 || vector.UpdateEmbeddingCalls[0] != recipe.ID {
+		t.Errorf("UpdateEmbeddingCalls = %v, want [%d]", vector.UpdateEmbeddingCalls, recipe.ID)
+	}
+
+	// Image generated and persisted.
+	if imagePrompt != result.ImagePrompt {
+		t.Errorf("image prompt = %q, want %q", imagePrompt, result.ImagePrompt)
+	}
+	updates := repo.ImageURLUpdates()
+	if len(updates) != 1 || updates[0].ImageURL != newURL {
+		t.Errorf("ImageURLUpdates = %v, want one update to %q", updates, newURL)
+	}
+	if gotContentType != "image/png" {
+		t.Errorf("upload content type = %q, want 'image/png'", gotContentType)
+	}
+
+	// Tags associated.
+	if len(repo.Tags) != 3 {
+		t.Errorf("tags created = %d, want 3", len(repo.Tags))
+	}
+}
+
+func TestFinishGenerateRecipe_UnitSystemFallbackToPersonalization(t *testing.T) {
+	repo := testutil.NewMockRecipeRepo()
+	user := testutil.TestUser()
+	recipe := seedGeneratingRecipe(t, repo, user)
+
+	result := testutil.TestRecipeResult()
+	result.UnitSystem = "" // tool result omitted unit_system
+	text := &testutil.MockTextProvider{
+		GenerateRecipeFunc: func(ctx context.Context, req ai.RecipeRequest) (*ai.RecipeResult, error) {
+			return result, nil
+		},
+	}
+
+	svc := newGenRecipeService(repo, text, &testutil.MockImageProvider{}, nil, nil)
+	svc.FinishGenerateRecipe(recipe, user, "make pancakes", false)
+
+	stored := repo.RecipeSnapshot(recipe.ID)
+	if stored == nil {
+		t.Fatal("recipe should still exist")
+	}
+	if stored.UnitSystem != "us_customary" {
+		t.Errorf("persisted UnitSystem = %q, want personalization fallback 'us_customary'", stored.UnitSystem)
+	}
+}
+
+func TestFinishGenerateRecipe_AIFailureMarksFailedAndDeletes(t *testing.T) {
+	repo := testutil.NewMockRecipeRepo()
+	user := testutil.TestUser()
+	recipe := seedGeneratingRecipe(t, repo, user)
+
+	text := &testutil.MockTextProvider{
+		GenerateRecipeFunc: func(ctx context.Context, req ai.RecipeRequest) (*ai.RecipeResult, error) {
+			return nil, errors.New("claude unavailable")
+		},
+	}
+
+	svc := newGenRecipeService(repo, text, &testutil.MockImageProvider{}, nil, nil)
+	svc.FinishGenerateRecipe(recipe, user, "make pancakes", true)
+
+	if repo.RecipeSnapshot(recipe.ID) != nil {
+		t.Error("recipe should be deleted after a generation failure")
+	}
+	statuses := repo.StatusUpdates()
+	if len(statuses) != 1 || statuses[0].Status != "failed" {
+		t.Errorf("StatusUpdates = %v, want a single 'failed' update", statuses)
+	}
+}
+
+func TestFinishGenerateRecipe_ValidationFailureDeletes(t *testing.T) {
+	repo := testutil.NewMockRecipeRepo()
+	user := testutil.TestUser()
+	recipe := seedGeneratingRecipe(t, repo, user)
+
+	result := testutil.TestRecipeResult()
+	result.Title = "" // fails validateRecipeCoreFields
+	text := &testutil.MockTextProvider{
+		GenerateRecipeFunc: func(ctx context.Context, req ai.RecipeRequest) (*ai.RecipeResult, error) {
+			return result, nil
+		},
+	}
+
+	svc := newGenRecipeService(repo, text, &testutil.MockImageProvider{}, nil, nil)
+	svc.FinishGenerateRecipe(recipe, user, "make pancakes", false)
+
+	if repo.RecipeSnapshot(recipe.ID) != nil {
+		t.Error("recipe should be deleted after a validation failure")
+	}
+	statuses := repo.StatusUpdates()
+	if len(statuses) != 1 || statuses[0].Status != "failed" {
+		t.Errorf("StatusUpdates = %v, want a single 'failed' update", statuses)
+	}
+}
+
+func TestFinishGenerateRecipe_PersistFailureDeletes(t *testing.T) {
+	repo := testutil.NewMockRecipeRepo()
+	repo.UpdateRecipeDefErr = errors.New("db down")
+	user := testutil.TestUser()
+	recipe := seedGeneratingRecipe(t, repo, user)
+
+	text := &testutil.MockTextProvider{
+		GenerateRecipeFunc: func(ctx context.Context, req ai.RecipeRequest) (*ai.RecipeResult, error) {
+			return testutil.TestRecipeResult(), nil
+		},
+	}
+
+	svc := newGenRecipeService(repo, text, &testutil.MockImageProvider{}, nil, nil)
+	svc.FinishGenerateRecipe(recipe, user, "make pancakes", false)
+
+	if repo.RecipeSnapshot(recipe.ID) != nil {
+		t.Error("recipe should be deleted when persisting the def fails")
+	}
+}
+
+func TestFinishGenerateRecipe_NoImageWhenGenImageFalse(t *testing.T) {
+	repo := testutil.NewMockRecipeRepo()
+	user := testutil.TestUser()
+	recipe := seedGeneratingRecipe(t, repo, user)
+
+	imageCalled := false
+	image := &testutil.MockImageProvider{
+		GenerateImageFunc: func(ctx context.Context, prompt string) ([]byte, error) {
+			imageCalled = true
+			return []byte("png"), nil
+		},
+	}
+	text := &testutil.MockTextProvider{
+		GenerateRecipeFunc: func(ctx context.Context, req ai.RecipeRequest) (*ai.RecipeResult, error) {
+			return testutil.TestRecipeResult(), nil
+		},
+	}
+
+	svc := newGenRecipeService(repo, text, image, nil, nil)
+	svc.FinishGenerateRecipe(recipe, user, "make pancakes", false)
+
+	if imageCalled {
+		t.Error("image provider should not be called when genImage is false")
+	}
+	if updates := repo.ImageURLUpdates(); len(updates) != 0 {
+		t.Errorf("ImageURLUpdates = %v, want none", updates)
+	}
+	stored := repo.RecipeSnapshot(recipe.ID)
+	if stored == nil || stored.Status != "ready" {
+		t.Error("recipe should still finish as ready")
+	}
+}
+
+func TestFinishGenerateRecipe_ImageFailureNonFatal(t *testing.T) {
+	repo := testutil.NewMockRecipeRepo()
+	user := testutil.TestUser()
+	recipe := seedGeneratingRecipe(t, repo, user)
+
+	image := &testutil.MockImageProvider{
+		GenerateImageFunc: func(ctx context.Context, prompt string) ([]byte, error) {
+			return nil, errors.New("dall-e unavailable")
+		},
+	}
+	text := &testutil.MockTextProvider{
+		GenerateRecipeFunc: func(ctx context.Context, req ai.RecipeRequest) (*ai.RecipeResult, error) {
+			return testutil.TestRecipeResult(), nil
+		},
+	}
+
+	svc := newGenRecipeService(repo, text, image, nil, nil)
+	svc.FinishGenerateRecipe(recipe, user, "make pancakes", true)
+
+	stored := repo.RecipeSnapshot(recipe.ID)
+	if stored == nil {
+		t.Fatal("recipe must survive an image generation failure")
+	}
+	if stored.Status != "ready" {
+		t.Errorf("Status = %q, want 'ready' (image failure is non-fatal)", stored.Status)
+	}
+	if updates := repo.ImageURLUpdates(); len(updates) != 0 {
+		t.Errorf("ImageURLUpdates = %v, want none", updates)
+	}
+}
+
+func TestFinishGenerateRecipe_TreeCreateFailureNonFatal(t *testing.T) {
+	repo := testutil.NewMockRecipeRepo()
+	repo.CreateRecipeTreeErr = errors.New("db down")
+	user := testutil.TestUser()
+	recipe := seedGeneratingRecipe(t, repo, user)
+
+	text := &testutil.MockTextProvider{
+		GenerateRecipeFunc: func(ctx context.Context, req ai.RecipeRequest) (*ai.RecipeResult, error) {
+			return testutil.TestRecipeResult(), nil
+		},
+	}
+
+	svc := newGenRecipeService(repo, text, &testutil.MockImageProvider{}, nil, nil)
+	svc.FinishGenerateRecipe(recipe, user, "make pancakes", false)
+
+	stored := repo.RecipeSnapshot(recipe.ID)
+	if stored == nil || stored.Status != "ready" {
+		t.Error("recipe should be ready even when tree creation fails (supplementary)")
+	}
+}
+
+func TestFinishGenerateRecipe_EmbeddingFailureNonFatal(t *testing.T) {
+	repo := testutil.NewMockRecipeRepo()
+	user := testutil.TestUser()
+	recipe := seedGeneratingRecipe(t, repo, user)
+
+	text := &testutil.MockTextProvider{
+		GenerateRecipeFunc: func(ctx context.Context, req ai.RecipeRequest) (*ai.RecipeResult, error) {
+			return testutil.TestRecipeResult(), nil
+		},
+	}
+	embed := &testutil.MockEmbeddingProvider{
+		GenerateEmbeddingFunc: func(ctx context.Context, text string) ([]float32, error) {
+			return nil, errors.New("embedding api down")
+		},
+	}
+	vector := &testutil.MockVectorRepo{}
+
+	svc := newGenRecipeService(repo, text, &testutil.MockImageProvider{}, embed, vector)
+	svc.FinishGenerateRecipe(recipe, user, "make pancakes", false)
+
+	stored := repo.RecipeSnapshot(recipe.ID)
+	if stored == nil || stored.Status != "ready" {
+		t.Error("recipe should be ready even when embedding generation fails")
+	}
+	if len(vector.UpdateEmbeddingCalls) != 0 {
+		t.Errorf("UpdateEmbeddingCalls = %v, want none after embed failure", vector.UpdateEmbeddingCalls)
+	}
+}
+
+// --- StreamGenerateRecipe / finishStreamedRecipe ---
+
+func TestStreamGenerateRecipe_HappyPathStreaming(t *testing.T) {
+	repo := testutil.NewMockRecipeRepo()
+	user := testutil.TestUser()
+
+	result := testutil.TestRecipeResult()
+	result.UnitSystem = "metric"
+	provider := &testutil.MockStreamingTextProvider{
+		StreamGenerateRecipeFunc: func(ctx context.Context, req ai.RecipeRequest, events chan<- ai.StreamEvent) (*ai.RecipeResult, error) {
+			ai.TrySendEvent(ctx, events, ai.StreamEvent{Type: ai.StreamEventGenerating})
+			ai.TrySendEvent(ctx, events, ai.StreamEvent{Type: ai.StreamEventProgress, TokensSoFar: 128})
+			return result, nil
+		},
+	}
+	vector := &testutil.MockVectorRepo{}
+	embed := &testutil.MockEmbeddingProvider{
+		GenerateEmbeddingFunc: func(ctx context.Context, text string) ([]float32, error) {
+			return []float32{0.5}, nil
+		},
+	}
+
+	svc := newGenRecipeService(repo, provider, &testutil.MockImageProvider{}, embed, vector)
+	events := make(chan ai.StreamEvent, 32)
+	svc.StreamGenerateRecipe(context.Background(), user, "make pancakes", false, events)
+	got := drainEvents(events)
+
+	if len(got) == 0 || got[0].Type != ai.StreamEventStarted {
+		t.Fatalf("first event = %+v, want recipe.started", got)
+	}
+	recipeID := got[0].RecipeID
+	if recipeID == 0 {
+		t.Error("started event should carry the placeholder recipe ID")
+	}
+	if findEvent(got, ai.StreamEventProgress) == nil {
+		t.Error("expected the provider's progress event to pass through")
+	}
+	complete := findEvent(got, ai.StreamEventComplete)
+	if complete == nil {
+		t.Fatalf("no complete event, got %+v", got)
+	}
+	if got[len(got)-1].Type != ai.StreamEventComplete {
+		t.Errorf("last event = %q, want recipe.complete", got[len(got)-1].Type)
+	}
+	if complete.Result == nil || complete.Result.Title != "Classic Pancakes" {
+		t.Errorf("complete.Result = %+v, want the generated recipe", complete.Result)
+	}
+	if complete.Result.UnitSystem != "metric" {
+		t.Errorf("complete.Result.UnitSystem = %q, want 'metric'", complete.Result.UnitSystem)
+	}
+
+	stored := repo.RecipeSnapshot(recipeID)
+	if stored == nil {
+		t.Fatal("recipe should be persisted")
+	}
+	if stored.Title != "Classic Pancakes" || stored.Status != "ready" {
+		t.Errorf("stored recipe = title %q status %q, want persisted+ready", stored.Title, stored.Status)
+	}
+	if _, err := repo.GetTreeByRecipeID(recipeID); err != nil {
+		t.Errorf("tree should be created for the streamed recipe: %v", err)
+	}
+	if len(vector.UpdateEmbeddingCalls) != 1 {
+		t.Errorf("UpdateEmbeddingCalls = %v, want one embedding attempt", vector.UpdateEmbeddingCalls)
+	}
+}
+
+func TestStreamGenerateRecipe_StreamFailureDeletesRecipe(t *testing.T) {
+	repo := testutil.NewMockRecipeRepo()
+	user := testutil.TestUser()
+
+	provider := &testutil.MockStreamingTextProvider{
+		StreamGenerateRecipeFunc: func(ctx context.Context, req ai.RecipeRequest, events chan<- ai.StreamEvent) (*ai.RecipeResult, error) {
+			// The real provider emits the error event itself before returning.
+			ai.TrySendEvent(ctx, events, ai.StreamEvent{Type: ai.StreamEventError, Error: "overloaded", ErrorKind: "rate_limit"})
+			return nil, errors.New("overloaded")
+		},
+	}
+
+	svc := newGenRecipeService(repo, provider, &testutil.MockImageProvider{}, nil, nil)
+	events := make(chan ai.StreamEvent, 32)
+	svc.StreamGenerateRecipe(context.Background(), user, "make pancakes", false, events)
+	got := drainEvents(events)
+
+	if len(got) == 0 || got[0].Type != ai.StreamEventStarted {
+		t.Fatalf("first event = %+v, want recipe.started", got)
+	}
+	recipeID := got[0].RecipeID
+	if findEvent(got, ai.StreamEventComplete) != nil {
+		t.Error("no complete event should be emitted on stream failure")
+	}
+	if repo.RecipeSnapshot(recipeID) != nil {
+		t.Error("placeholder recipe should be deleted after a premature stream failure")
+	}
+	statuses := repo.StatusUpdates()
+	if len(statuses) != 1 || statuses[0].Status != "failed" {
+		t.Errorf("StatusUpdates = %v, want a single 'failed' update", statuses)
+	}
+}
+
+func TestStreamGenerateRecipe_FallbackToSyncProvider(t *testing.T) {
+	repo := testutil.NewMockRecipeRepo()
+	user := testutil.TestUser()
+
+	syncCalled := false
+	// Plain MockTextProvider does not implement ai.StreamingTextProvider,
+	// forcing the sync fallback path.
+	provider := &testutil.MockTextProvider{
+		GenerateRecipeFunc: func(ctx context.Context, req ai.RecipeRequest) (*ai.RecipeResult, error) {
+			syncCalled = true
+			return testutil.TestRecipeResult(), nil
+		},
+	}
+
+	svc := newGenRecipeService(repo, provider, &testutil.MockImageProvider{}, nil, nil)
+	events := make(chan ai.StreamEvent, 32)
+	svc.StreamGenerateRecipe(context.Background(), user, "make pancakes", false, events)
+	got := drainEvents(events)
+
+	if !syncCalled {
+		t.Fatal("sync GenerateRecipe should be used when the provider cannot stream")
+	}
+	complete := findEvent(got, ai.StreamEventComplete)
+	if complete == nil {
+		t.Fatalf("no complete event in fallback path, got %+v", got)
+	}
+	stored := repo.RecipeSnapshot(complete.RecipeID)
+	if stored == nil || stored.Status != "ready" {
+		t.Error("fallback-generated recipe should be persisted and ready")
+	}
+}
+
+func TestStreamGenerateRecipe_FallbackSyncFailure(t *testing.T) {
+	repo := testutil.NewMockRecipeRepo()
+	user := testutil.TestUser()
+
+	provider := &testutil.MockTextProvider{
+		GenerateRecipeFunc: func(ctx context.Context, req ai.RecipeRequest) (*ai.RecipeResult, error) {
+			return nil, errors.New("claude unavailable")
+		},
+	}
+
+	svc := newGenRecipeService(repo, provider, &testutil.MockImageProvider{}, nil, nil)
+	events := make(chan ai.StreamEvent, 32)
+	svc.StreamGenerateRecipe(context.Background(), user, "make pancakes", false, events)
+	got := drainEvents(events)
+
+	errEvent := findEvent(got, ai.StreamEventError)
+	if errEvent == nil {
+		t.Fatalf("no error event, got %+v", got)
+	}
+	if errEvent.RecipeID == 0 {
+		t.Error("error event should reference the placeholder recipe")
+	}
+	if repo.RecipeSnapshot(errEvent.RecipeID) != nil {
+		t.Error("placeholder recipe should be deleted after sync fallback failure")
+	}
+}
+
+func TestStreamGenerateRecipe_NilPersonalization(t *testing.T) {
+	repo := testutil.NewMockRecipeRepo()
+	user := testutil.TestUser()
+	user.Personalization = &models.Personalization{}
+
+	svc := newGenRecipeService(repo, &testutil.MockStreamingTextProvider{}, &testutil.MockImageProvider{}, nil, nil)
+	events := make(chan ai.StreamEvent, 32)
+	svc.StreamGenerateRecipe(context.Background(), user, "make pancakes", false, events)
+	got := drainEvents(events)
+
+	if len(got) != 1 || got[0].Type != ai.StreamEventError {
+		t.Fatalf("events = %+v, want a single error event", got)
+	}
+	if got[0].ErrorKind != "content_quality" {
+		t.Errorf("ErrorKind = %q, want 'content_quality'", got[0].ErrorKind)
+	}
+	if len(repo.Recipes) != 0 {
+		t.Error("no placeholder recipe should be created")
+	}
+}
+
+func TestStreamGenerateRecipe_CreateRecipeError(t *testing.T) {
+	repo := testutil.NewMockRecipeRepo()
+	repo.CreateRecipeErr = errors.New("db down")
+
+	svc := newGenRecipeService(repo, &testutil.MockStreamingTextProvider{}, &testutil.MockImageProvider{}, nil, nil)
+	events := make(chan ai.StreamEvent, 32)
+	svc.StreamGenerateRecipe(context.Background(), testutil.TestUser(), "make pancakes", false, events)
+	got := drainEvents(events)
+
+	if len(got) != 1 || got[0].Type != ai.StreamEventError {
+		t.Fatalf("events = %+v, want a single error event (no started)", got)
+	}
+}
+
+func TestFinishStreamedRecipe_ValidationFailure(t *testing.T) {
+	repo := testutil.NewMockRecipeRepo()
+	user := testutil.TestUser()
+
+	result := testutil.TestRecipeResult()
+	result.ImagePrompt = "" // fails validateRecipeCoreFields
+	provider := &testutil.MockStreamingTextProvider{
+		StreamGenerateRecipeFunc: func(ctx context.Context, req ai.RecipeRequest, events chan<- ai.StreamEvent) (*ai.RecipeResult, error) {
+			return result, nil
+		},
+	}
+
+	svc := newGenRecipeService(repo, provider, &testutil.MockImageProvider{}, nil, nil)
+	events := make(chan ai.StreamEvent, 32)
+	svc.StreamGenerateRecipe(context.Background(), user, "make pancakes", false, events)
+	got := drainEvents(events)
+
+	errEvent := findEvent(got, ai.StreamEventError)
+	if errEvent == nil {
+		t.Fatalf("no error event, got %+v", got)
+	}
+	if errEvent.ErrorKind != "content_quality" {
+		t.Errorf("ErrorKind = %q, want 'content_quality'", errEvent.ErrorKind)
+	}
+	if repo.RecipeSnapshot(errEvent.RecipeID) != nil {
+		t.Error("recipe should be deleted after streamed validation failure")
+	}
+}
+
+func TestFinishStreamedRecipe_PersistFailureKeepsRecipeMarkedFailed(t *testing.T) {
+	repo := testutil.NewMockRecipeRepo()
+	repo.UpdateRecipeDefErr = errors.New("db down")
+	user := testutil.TestUser()
+
+	provider := &testutil.MockStreamingTextProvider{
+		StreamGenerateRecipeFunc: func(ctx context.Context, req ai.RecipeRequest, events chan<- ai.StreamEvent) (*ai.RecipeResult, error) {
+			return testutil.TestRecipeResult(), nil
+		},
+	}
+
+	svc := newGenRecipeService(repo, provider, &testutil.MockImageProvider{}, nil, nil)
+	events := make(chan ai.StreamEvent, 32)
+	svc.StreamGenerateRecipe(context.Background(), user, "make pancakes", false, events)
+	got := drainEvents(events)
+
+	errEvent := findEvent(got, ai.StreamEventError)
+	if errEvent == nil {
+		t.Fatalf("no error event, got %+v", got)
+	}
+	stored := repo.RecipeSnapshot(errEvent.RecipeID)
+	if stored == nil {
+		t.Fatal("recipe row should NOT be deleted on a persist failure")
+	}
+	if stored.Status != "failed" {
+		t.Errorf("Status = %q, want 'failed'", stored.Status)
+	}
+}
+
+func TestFinishStreamedRecipe_UnitSystemFallbackToPersonalization(t *testing.T) {
+	repo := testutil.NewMockRecipeRepo()
+	user := testutil.TestUser()
+
+	result := testutil.TestRecipeResult()
+	result.UnitSystem = ""
+	provider := &testutil.MockStreamingTextProvider{
+		StreamGenerateRecipeFunc: func(ctx context.Context, req ai.RecipeRequest, events chan<- ai.StreamEvent) (*ai.RecipeResult, error) {
+			return result, nil
+		},
+	}
+
+	svc := newGenRecipeService(repo, provider, &testutil.MockImageProvider{}, nil, nil)
+	events := make(chan ai.StreamEvent, 32)
+	svc.StreamGenerateRecipe(context.Background(), user, "make pancakes", false, events)
+	got := drainEvents(events)
+
+	complete := findEvent(got, ai.StreamEventComplete)
+	if complete == nil {
+		t.Fatalf("no complete event, got %+v", got)
+	}
+	if complete.Result.UnitSystem != "us_customary" {
+		t.Errorf("complete.Result.UnitSystem = %q, want personalization fallback 'us_customary'", complete.Result.UnitSystem)
+	}
+	stored := repo.RecipeSnapshot(complete.RecipeID)
+	if stored == nil || stored.UnitSystem != "us_customary" {
+		t.Error("persisted def should carry the fallback unit system")
+	}
+}
+
+func TestFinishStreamedRecipe_BackgroundImageGeneration(t *testing.T) {
+	repo := testutil.NewMockRecipeRepo()
+	user := testutil.TestUser()
+
+	provider := &testutil.MockStreamingTextProvider{
+		StreamGenerateRecipeFunc: func(ctx context.Context, req ai.RecipeRequest, events chan<- ai.StreamEvent) (*ai.RecipeResult, error) {
+			return testutil.TestRecipeResult(), nil
+		},
+	}
+	image := &testutil.MockImageProvider{
+		GenerateImageFunc: func(ctx context.Context, prompt string) ([]byte, error) {
+			return []byte("png"), nil
+		},
+	}
+	var gotKey, gotContentType string
+	newURL := "https://bucket.s3.us-east-2.amazonaws.com/recipes/1/images/recipe_image_1_1700000002.png"
+	stubS3Upload(t, &gotKey, &gotContentType, newURL, nil)
+	stubS3Delete(t, nil)
+
+	svc := newGenRecipeService(repo, provider, image, nil, nil)
+	events := make(chan ai.StreamEvent, 32)
+	svc.StreamGenerateRecipe(context.Background(), user, "make pancakes", true, events)
+	got := drainEvents(events)
+
+	complete := findEvent(got, ai.StreamEventComplete)
+	if complete == nil {
+		t.Fatalf("no complete event, got %+v", got)
+	}
+
+	// Image generation runs in the background after the complete event.
+	waitForCondition(t, 2*time.Second, func() bool {
+		updates := repo.ImageURLUpdates()
+		return len(updates) == 1 && updates[0].ImageURL == newURL
+	}, "background image generation never updated the recipe image URL")
+}

--- a/internal/service/recipe_delete_test.go
+++ b/internal/service/recipe_delete_test.go
@@ -59,6 +59,45 @@ func TestDeleteRecipe_S3FailureStillSucceeds(t *testing.T) {
 	}
 }
 
+func TestDeleteRecipe_ForeignImageURLNeverDeletesOtherRecipesObject(t *testing.T) {
+	repo := testutil.NewMockRecipeRepo()
+	recipe := testutil.TestRecipe()
+	// A stored ImageURL pointing at ANOTHER recipe's S3 object (e.g. supplied
+	// via manual import image_url) must never be used as a delete key.
+	recipe.ImageURL = "https://bucket.s3.us-east-2.amazonaws.com/recipes/999/images/recipe_image_999_1700000000.png"
+	repo.Recipes[recipe.ID] = recipe
+
+	deletedKeys := stubS3Delete(t, nil)
+
+	svc := newTestRecipeService(repo)
+	if err := svc.DeleteRecipe(context.Background(), recipe.ID); err != nil {
+		t.Fatalf("DeleteRecipe() error = %v", err)
+	}
+
+	if len(*deletedKeys) != 0 {
+		t.Errorf("S3 delete keys = %v, want none for a key outside this recipe's own prefix", *deletedKeys)
+	}
+}
+
+func TestDeleteRecipe_ExternalImageURLSkipsS3Delete(t *testing.T) {
+	repo := testutil.NewMockRecipeRepo()
+	recipe := testutil.TestRecipe()
+	// JSON-LD imports store the page's external image URL; it is not ours to delete.
+	recipe.ImageURL = "https://example.com/photos/bread.jpg"
+	repo.Recipes[recipe.ID] = recipe
+
+	deletedKeys := stubS3Delete(t, nil)
+
+	svc := newTestRecipeService(repo)
+	if err := svc.DeleteRecipe(context.Background(), recipe.ID); err != nil {
+		t.Fatalf("DeleteRecipe() error = %v", err)
+	}
+
+	if len(*deletedKeys) != 0 {
+		t.Errorf("S3 delete keys = %v, want none for an external image URL", *deletedKeys)
+	}
+}
+
 func TestDeleteRecipe_CleansUpTreeAndNodes(t *testing.T) {
 	repo := testutil.NewMockRecipeRepo()
 	recipe := testutil.TestRecipe()

--- a/internal/service/recipe_delete_test.go
+++ b/internal/service/recipe_delete_test.go
@@ -1,0 +1,182 @@
+package service
+
+import (
+	"context"
+	"errors"
+	"regexp"
+	"testing"
+
+	"github.com/windoze95/saltybytes-api/internal/config"
+	"github.com/windoze95/saltybytes-api/internal/models"
+	"github.com/windoze95/saltybytes-api/internal/testutil"
+)
+
+// stubS3Delete replaces the package-level S3 delete indirection for the test,
+// restoring it afterwards. It returns a pointer to the keys it was called with.
+func stubS3Delete(t *testing.T, err error) *[]string {
+	t.Helper()
+	var keys []string
+	orig := deleteImageFromS3
+	deleteImageFromS3 = func(_ context.Context, _ *config.Config, s3Key string) error {
+		keys = append(keys, s3Key)
+		return err
+	}
+	t.Cleanup(func() { deleteImageFromS3 = orig })
+	return &keys
+}
+
+// stubS3Upload replaces the package-level S3 upload indirection for the test,
+// restoring it afterwards.
+func stubS3Upload(t *testing.T, gotKey, gotContentType *string, returnURL string, err error) {
+	t.Helper()
+	orig := uploadImageToS3
+	uploadImageToS3 = func(_ context.Context, _ *config.Config, _ []byte, s3Key string, contentType string) (string, error) {
+		*gotKey = s3Key
+		*gotContentType = contentType
+		return returnURL, err
+	}
+	t.Cleanup(func() { uploadImageToS3 = orig })
+}
+
+func TestDeleteRecipe_S3FailureStillSucceeds(t *testing.T) {
+	repo := testutil.NewMockRecipeRepo()
+	recipe := testutil.TestRecipe()
+	recipe.ImageURL = "https://bucket.s3.us-east-2.amazonaws.com/recipes/1/images/recipe_image_1_1700000000.png"
+	repo.Recipes[recipe.ID] = recipe
+
+	deletedKeys := stubS3Delete(t, errors.New("s3 unavailable"))
+
+	svc := newTestRecipeService(repo)
+	if err := svc.DeleteRecipe(context.Background(), recipe.ID); err != nil {
+		t.Fatalf("DeleteRecipe() error = %v, want nil (S3 failure must be best-effort)", err)
+	}
+
+	if _, ok := repo.Recipes[recipe.ID]; ok {
+		t.Error("recipe should have been deleted from the repo")
+	}
+	if len(*deletedKeys) != 1 || (*deletedKeys)[0] != "recipes/1/images/recipe_image_1_1700000000.png" {
+		t.Errorf("S3 delete keys = %v, want the key derived from the recipe's ImageURL", *deletedKeys)
+	}
+}
+
+func TestDeleteRecipe_CleansUpTreeAndNodes(t *testing.T) {
+	repo := testutil.NewMockRecipeRepo()
+	recipe := testutil.TestRecipe()
+	recipe.ImageURL = ""
+	repo.Recipes[recipe.ID] = recipe
+
+	def := testutil.TestRecipeDef()
+	rootNode := &models.RecipeNode{
+		Prompt:      "make pancakes",
+		Response:    &def,
+		Type:        models.RecipeTypeChat,
+		BranchName:  "original",
+		CreatedByID: recipe.CreatedByID,
+		IsActive:    true,
+	}
+	tree, err := repo.CreateRecipeTree(recipe.ID, rootNode)
+	if err != nil {
+		t.Fatalf("CreateRecipeTree() error = %v", err)
+	}
+	childNode := &models.RecipeNode{
+		TreeID:      tree.ID,
+		ParentID:    &rootNode.ID,
+		Prompt:      "make them fluffier",
+		Response:    &def,
+		Type:        models.RecipeTypeRegenChat,
+		CreatedByID: recipe.CreatedByID,
+	}
+	if err := repo.AddNodeToTree(childNode, true); err != nil {
+		t.Fatalf("AddNodeToTree() error = %v", err)
+	}
+
+	deletedKeys := stubS3Delete(t, nil)
+
+	svc := newTestRecipeService(repo)
+	if err := svc.DeleteRecipe(context.Background(), recipe.ID); err != nil {
+		t.Fatalf("DeleteRecipe() error = %v", err)
+	}
+
+	if len(repo.Trees) != 0 {
+		t.Errorf("trees remaining after delete = %d, want 0", len(repo.Trees))
+	}
+	if len(repo.Nodes) != 0 {
+		t.Errorf("nodes remaining after delete = %d, want 0", len(repo.Nodes))
+	}
+	if len(*deletedKeys) != 0 {
+		t.Errorf("S3 delete should not be called for a recipe with no image, got keys %v", *deletedKeys)
+	}
+}
+
+func TestDeleteRecipe_RepoErrorFails(t *testing.T) {
+	repo := testutil.NewMockRecipeRepo()
+	recipe := testutil.TestRecipe()
+	repo.Recipes[recipe.ID] = recipe
+	repo.DeleteRecipeErr = errors.New("db down")
+
+	deletedKeys := stubS3Delete(t, nil)
+
+	svc := newTestRecipeService(repo)
+	if err := svc.DeleteRecipe(context.Background(), recipe.ID); err == nil {
+		t.Fatal("DeleteRecipe() error = nil, want error when the repo delete fails")
+	}
+	if len(*deletedKeys) != 0 {
+		t.Errorf("S3 delete should not run when the repo delete fails, got keys %v", *deletedKeys)
+	}
+}
+
+func TestUploadRecipeImage_VersionedPNGKeyAndOldObjectCleanup(t *testing.T) {
+	var gotKey, gotContentType string
+	newURL := "https://bucket.s3.us-east-2.amazonaws.com/recipes/1/images/recipe_image_1_1700000001.png"
+	stubS3Upload(t, &gotKey, &gotContentType, newURL, nil)
+	deletedKeys := stubS3Delete(t, nil)
+
+	oldURL := "https://bucket.s3.us-east-2.amazonaws.com/recipes/1/images/recipe_image_1.jpg"
+	url, err := uploadRecipeImage(context.Background(), 1, oldURL, []byte("png-bytes"), &config.Config{})
+	if err != nil {
+		t.Fatalf("uploadRecipeImage() error = %v", err)
+	}
+	if url != newURL {
+		t.Errorf("uploadRecipeImage() url = %q, want %q", url, newURL)
+	}
+
+	keyPattern := regexp.MustCompile(`^recipes/1/images/recipe_image_1_\d+\.png$`)
+	if !keyPattern.MatchString(gotKey) {
+		t.Errorf("upload key = %q, want match for %q", gotKey, keyPattern)
+	}
+	if gotContentType != "image/png" {
+		t.Errorf("upload content type = %q, want %q", gotContentType, "image/png")
+	}
+	if len(*deletedKeys) != 1 || (*deletedKeys)[0] != "recipes/1/images/recipe_image_1.jpg" {
+		t.Errorf("old object delete keys = %v, want the legacy key derived from the old URL", *deletedKeys)
+	}
+}
+
+func TestUploadRecipeImage_OldObjectDeleteFailureNonFatal(t *testing.T) {
+	var gotKey, gotContentType string
+	newURL := "https://bucket.s3.us-east-2.amazonaws.com/recipes/2/images/recipe_image_2_1700000002.png"
+	stubS3Upload(t, &gotKey, &gotContentType, newURL, nil)
+	stubS3Delete(t, errors.New("s3 unavailable"))
+
+	oldURL := "https://bucket.s3.us-east-2.amazonaws.com/recipes/2/images/recipe_image_2_1600000000.png"
+	url, err := uploadRecipeImage(context.Background(), 2, oldURL, []byte("png-bytes"), &config.Config{})
+	if err != nil {
+		t.Fatalf("uploadRecipeImage() error = %v, want nil (old-object cleanup is best-effort)", err)
+	}
+	if url != newURL {
+		t.Errorf("uploadRecipeImage() url = %q, want %q", url, newURL)
+	}
+}
+
+func TestUploadRecipeImage_NoOldImageSkipsDelete(t *testing.T) {
+	var gotKey, gotContentType string
+	stubS3Upload(t, &gotKey, &gotContentType, "https://bucket.s3.us-east-2.amazonaws.com/new.png", nil)
+	deletedKeys := stubS3Delete(t, nil)
+
+	if _, err := uploadRecipeImage(context.Background(), 3, "", []byte("png-bytes"), &config.Config{}); err != nil {
+		t.Fatalf("uploadRecipeImage() error = %v", err)
+	}
+	if len(*deletedKeys) != 0 {
+		t.Errorf("no old image: delete should not be called, got keys %v", *deletedKeys)
+	}
+}

--- a/internal/service/recipe_fork_test.go
+++ b/internal/service/recipe_fork_test.go
@@ -1,0 +1,339 @@
+package service
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/windoze95/saltybytes-api/internal/ai"
+	"github.com/windoze95/saltybytes-api/internal/models"
+	"github.com/windoze95/saltybytes-api/internal/testutil"
+	"gorm.io/gorm"
+)
+
+// forkUser returns a user distinct from the source recipe's owner.
+func forkUser() *models.User {
+	user := testutil.TestUser()
+	user.ID = 2
+	user.Personalization.UserID = 2
+	return user
+}
+
+// seedForkSource seeds a source recipe owned by user 1 with a tree whose root
+// node is active, and returns the source recipe.
+func seedForkSource(t *testing.T, repo *testutil.MockRecipeRepo) *models.Recipe {
+	t.Helper()
+	def := testutil.TestRecipeDef()
+	source := &models.Recipe{
+		Model:       gorm.Model{ID: 1},
+		RecipeDef:   def,
+		CreatedByID: 1,
+	}
+	repo.Recipes[source.ID] = source
+	repo.NextID = 2
+
+	rootNode := &models.RecipeNode{
+		Prompt:      "make pancakes",
+		Response:    &def,
+		Summary:     "Initial pancake recipe",
+		Type:        models.RecipeTypeChat,
+		BranchName:  "original",
+		CreatedByID: source.CreatedByID,
+		IsActive:    true,
+	}
+	if _, err := repo.CreateRecipeTree(source.ID, rootNode); err != nil {
+		t.Fatalf("CreateRecipeTree() error = %v", err)
+	}
+	return source
+}
+
+// seedForkPlaceholder creates the new (forked) recipe the way
+// InitGenerateRecipeWithFork does.
+func seedForkPlaceholder(t *testing.T, repo *testutil.MockRecipeRepo, user *models.User, source *models.Recipe) *models.Recipe {
+	t.Helper()
+	recipe := &models.Recipe{
+		CreatedBy:          user,
+		CreatedByID:        user.ID,
+		ForkedFrom:         source,
+		PersonalizationUID: user.Personalization.UID,
+		Status:             "generating",
+	}
+	if err := repo.CreateRecipe(recipe); err != nil {
+		t.Fatalf("CreateRecipe() error = %v", err)
+	}
+	return recipe
+}
+
+// --- InitGenerateRecipeWithFork ---
+
+func TestInitGenerateRecipeWithFork_NilPersonalization(t *testing.T) {
+	repo := testutil.NewMockRecipeRepo()
+	user := forkUser()
+	user.Personalization = &models.Personalization{}
+
+	svc := newGenRecipeService(repo, &testutil.MockTextProvider{}, &testutil.MockImageProvider{}, nil, nil)
+	if _, err := svc.InitGenerateRecipeWithFork(user, 1, "make it vegan", false); err == nil {
+		t.Fatal("InitGenerateRecipeWithFork() error = nil, want error for missing personalization")
+	}
+}
+
+func TestInitGenerateRecipeWithFork_SourceNotFound(t *testing.T) {
+	repo := testutil.NewMockRecipeRepo()
+
+	svc := newGenRecipeService(repo, &testutil.MockTextProvider{}, &testutil.MockImageProvider{}, nil, nil)
+	if _, err := svc.InitGenerateRecipeWithFork(forkUser(), 999, "make it vegan", false); err == nil {
+		t.Fatal("InitGenerateRecipeWithFork() error = nil, want error for missing source recipe")
+	}
+}
+
+func TestInitGenerateRecipeWithFork_CreatesGeneratingPlaceholder(t *testing.T) {
+	repo := testutil.NewMockRecipeRepo()
+	source := seedForkSource(t, repo)
+	user := forkUser()
+
+	gate := make(chan struct{})
+	entered := make(chan struct{})
+	t.Cleanup(func() { close(gate) })
+	provider := &testutil.MockTextProvider{
+		ForkRecipeFunc: func(ctx context.Context, req ai.ForkRequest) (*ai.RecipeResult, error) {
+			close(entered)
+			<-gate
+			return nil, errors.New("aborted by test teardown")
+		},
+	}
+
+	svc := newGenRecipeService(repo, provider, &testutil.MockImageProvider{}, nil, nil)
+	resp, err := svc.InitGenerateRecipeWithFork(user, source.ID, "make it vegan", false)
+	if err != nil {
+		t.Fatalf("InitGenerateRecipeWithFork() error = %v", err)
+	}
+	if resp.Status != "generating" {
+		t.Errorf("response Status = %q, want 'generating'", resp.Status)
+	}
+
+	stored := repo.RecipeSnapshot(2)
+	if stored == nil {
+		t.Fatal("forked placeholder recipe should exist with ID 2")
+	}
+	if stored.Status != "generating" {
+		t.Errorf("stored Status = %q, want 'generating'", stored.Status)
+	}
+	if stored.ForkedFrom == nil || stored.ForkedFrom.ID != source.ID {
+		t.Error("placeholder should reference the forked source recipe")
+	}
+
+	select {
+	case <-entered:
+	case <-time.After(2 * time.Second):
+		t.Fatal("FinishGenerateRecipeWithFork goroutine never called the text provider")
+	}
+}
+
+// --- FinishGenerateRecipeWithFork ---
+
+func TestFinishGenerateRecipeWithFork_HappyPath(t *testing.T) {
+	repo := testutil.NewMockRecipeRepo()
+	source := seedForkSource(t, repo)
+	sourceDefJSON, _ := json.Marshal(source.RecipeDef)
+	user := forkUser()
+	recipe := seedForkPlaceholder(t, repo, user, source)
+	sourceNodesBefore := len(repo.Nodes)
+
+	var gotReq ai.ForkRequest
+	result := testutil.TestRecipeResult()
+	result.Title = "Vegan Pancakes"
+	result.PromptVersion = "pv-fork-1"
+	result.Summary = "Forked vegan"
+	provider := &testutil.MockTextProvider{
+		ForkRecipeFunc: func(ctx context.Context, req ai.ForkRequest) (*ai.RecipeResult, error) {
+			gotReq = req
+			return result, nil
+		},
+	}
+	vector := &testutil.MockVectorRepo{}
+	embed := &testutil.MockEmbeddingProvider{
+		GenerateEmbeddingFunc: func(ctx context.Context, text string) ([]float32, error) {
+			return []float32{0.7}, nil
+		},
+	}
+
+	svc := newGenRecipeService(repo, provider, &testutil.MockImageProvider{}, embed, vector)
+	svc.FinishGenerateRecipeWithFork(recipe, source, user, "make it vegan", false)
+
+	// Conversation context comes from the source recipe's tree.
+	wantHistory := []ai.Message{
+		{Role: "user", Content: "make pancakes"},
+		{Role: "assistant", Content: string(sourceDefJSON)},
+	}
+	if len(gotReq.ExistingHistory) != 2 ||
+		gotReq.ExistingHistory[0] != wantHistory[0] ||
+		gotReq.ExistingHistory[1] != wantHistory[1] {
+		t.Errorf("ExistingHistory = %+v, want %+v", gotReq.ExistingHistory, wantHistory)
+	}
+	if gotReq.UserPrompt != "make it vegan" {
+		t.Errorf("UserPrompt = %q", gotReq.UserPrompt)
+	}
+
+	// New recipe is owned by the forker and persisted as ready.
+	stored := repo.RecipeSnapshot(recipe.ID)
+	if stored == nil {
+		t.Fatal("forked recipe should exist")
+	}
+	if stored.CreatedByID != user.ID {
+		t.Errorf("forked recipe CreatedByID = %d, want forker %d", stored.CreatedByID, user.ID)
+	}
+	if stored.Title != "Vegan Pancakes" || stored.Status != "ready" {
+		t.Errorf("forked recipe = title %q status %q, want persisted+ready", stored.Title, stored.Status)
+	}
+	if recipe.PromptVersion != "pv-fork-1" {
+		t.Errorf("PromptVersion = %q, want 'pv-fork-1'", recipe.PromptVersion)
+	}
+
+	// New tree initialized for the fork, rooted at a fork node owned by the forker.
+	tree, err := repo.GetTreeByRecipeID(recipe.ID)
+	if err != nil {
+		t.Fatalf("forked recipe should have its own tree: %v", err)
+	}
+	root, err := repo.GetActiveNode(tree.ID)
+	if err != nil {
+		t.Fatalf("GetActiveNode() error = %v", err)
+	}
+	if root.Type != models.RecipeTypeFork {
+		t.Errorf("root node Type = %q, want %q", root.Type, models.RecipeTypeFork)
+	}
+	if root.BranchName != "original" {
+		t.Errorf("root node BranchName = %q, want 'original'", root.BranchName)
+	}
+	if root.CreatedByID != user.ID {
+		t.Errorf("root node CreatedByID = %d, want forker %d", root.CreatedByID, user.ID)
+	}
+
+	// Embedding generated for the new recipe.
+	if len(vector.UpdateEmbeddingCalls) != 1 || vector.UpdateEmbeddingCalls[0] != recipe.ID {
+		t.Errorf("UpdateEmbeddingCalls = %v, want [%d]", vector.UpdateEmbeddingCalls, recipe.ID)
+	}
+
+	// Source recipe untouched: same def, no extra nodes in its tree.
+	storedSource := repo.RecipeSnapshot(source.ID)
+	if storedSource.Title != "Classic Pancakes" {
+		t.Errorf("source Title = %q, fork must not mutate the source", storedSource.Title)
+	}
+	sourceTree, _ := repo.GetTreeByRecipeID(source.ID)
+	sourceNodes := 0
+	for _, n := range repo.Nodes {
+		if n.TreeID == sourceTree.ID {
+			sourceNodes++
+		}
+	}
+	if sourceNodes != sourceNodesBefore {
+		t.Errorf("source tree nodes = %d, want %d (unchanged)", sourceNodes, sourceNodesBefore)
+	}
+}
+
+func TestFinishGenerateRecipeWithFork_CanonicalSourceReadOnly(t *testing.T) {
+	repo := testutil.NewMockRecipeRepo()
+	user := forkUser()
+
+	// Source is a thin canonical reference (HasDiverged=false) with a tree.
+	source := testutil.TestCanonicalLinkedRecipe()
+	source.CreatedByID = 1
+	repo.Recipes[source.ID] = source
+	repo.NextID = source.ID + 1
+	def := source.Canonical.RecipeData
+	rootNode := &models.RecipeNode{
+		Prompt:      "imported recipe",
+		Response:    &def,
+		Type:        models.RecipeTypeImportLink,
+		BranchName:  "original",
+		CreatedByID: source.CreatedByID,
+		IsActive:    true,
+	}
+	if _, err := repo.CreateRecipeTree(source.ID, rootNode); err != nil {
+		t.Fatalf("CreateRecipeTree() error = %v", err)
+	}
+	recipe := seedForkPlaceholder(t, repo, user, source)
+
+	var gotReq ai.ForkRequest
+	provider := &testutil.MockTextProvider{
+		ForkRecipeFunc: func(ctx context.Context, req ai.ForkRequest) (*ai.RecipeResult, error) {
+			gotReq = req
+			return testutil.TestRecipeResult(), nil
+		},
+	}
+
+	svc := newGenRecipeService(repo, provider, &testutil.MockImageProvider{}, nil, nil)
+	svc.FinishGenerateRecipeWithFork(recipe, source, user, "make it vegan", false)
+
+	// The fork context resolved the canonical's def without materializing it.
+	canonicalJSON, _ := json.Marshal(effectiveRecipeDef(source))
+	last := gotReq.ExistingHistory[len(gotReq.ExistingHistory)-1]
+	if last.Role != "assistant" || last.Content != string(canonicalJSON) {
+		t.Errorf("fork context last message = %+v, want the canonical def", last)
+	}
+
+	storedSource := repo.RecipeSnapshot(source.ID)
+	if storedSource.HasDiverged {
+		t.Error("fork must read the canonical read-only: source must NOT be materialized")
+	}
+}
+
+func TestFinishGenerateRecipeWithFork_AIFailureDeletesForkOnly(t *testing.T) {
+	repo := testutil.NewMockRecipeRepo()
+	source := seedForkSource(t, repo)
+	user := forkUser()
+	recipe := seedForkPlaceholder(t, repo, user, source)
+
+	provider := &testutil.MockTextProvider{
+		ForkRecipeFunc: func(ctx context.Context, req ai.ForkRequest) (*ai.RecipeResult, error) {
+			return nil, errors.New("claude unavailable")
+		},
+	}
+
+	svc := newGenRecipeService(repo, provider, &testutil.MockImageProvider{}, nil, nil)
+	svc.FinishGenerateRecipeWithFork(recipe, source, user, "make it vegan", false)
+
+	if repo.RecipeSnapshot(recipe.ID) != nil {
+		t.Error("forked placeholder should be deleted after AI failure")
+	}
+	if repo.RecipeSnapshot(source.ID) == nil {
+		t.Error("source recipe must survive a fork failure")
+	}
+	statuses := repo.StatusUpdates()
+	if len(statuses) != 1 || statuses[0].RecipeID != recipe.ID || statuses[0].Status != "failed" {
+		t.Errorf("StatusUpdates = %v, want the fork marked failed", statuses)
+	}
+}
+
+func TestFinishGenerateRecipeWithFork_SourceWithoutTreeNoHistory(t *testing.T) {
+	repo := testutil.NewMockRecipeRepo()
+	source := &models.Recipe{
+		Model:       gorm.Model{ID: 1},
+		RecipeDef:   testutil.TestRecipeDef(),
+		CreatedByID: 1,
+	}
+	repo.Recipes[source.ID] = source
+	repo.NextID = 2
+	user := forkUser()
+	recipe := seedForkPlaceholder(t, repo, user, source)
+
+	var gotHistory []ai.Message
+	provider := &testutil.MockTextProvider{
+		ForkRecipeFunc: func(ctx context.Context, req ai.ForkRequest) (*ai.RecipeResult, error) {
+			gotHistory = req.ExistingHistory
+			return testutil.TestRecipeResult(), nil
+		},
+	}
+
+	svc := newGenRecipeService(repo, provider, &testutil.MockImageProvider{}, nil, nil)
+	svc.FinishGenerateRecipeWithFork(recipe, source, user, "make it vegan", false)
+
+	if gotHistory != nil {
+		t.Errorf("ExistingHistory = %+v, want nil when the source has no tree", gotHistory)
+	}
+	stored := repo.RecipeSnapshot(recipe.ID)
+	if stored == nil || stored.Status != "ready" {
+		t.Error("fork should still complete without source history")
+	}
+}

--- a/internal/service/recipe_regen_test.go
+++ b/internal/service/recipe_regen_test.go
@@ -1,0 +1,569 @@
+package service
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"reflect"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/windoze95/saltybytes-api/internal/ai"
+	"github.com/windoze95/saltybytes-api/internal/models"
+	"github.com/windoze95/saltybytes-api/internal/testutil"
+	"gorm.io/gorm"
+)
+
+// seedOwnedRecipeWithTree seeds an owned recipe plus a tree with an active
+// root node and returns (in-flight recipe, tree root node). The returned
+// recipe is a detached copy of the stored row — like the real repository,
+// which hydrates a fresh struct from the DB — so in-flight mutations by the
+// service do not leak into the repo until an Update* call commits them.
+func seedOwnedRecipeWithTree(t *testing.T, repo *testutil.MockRecipeRepo, ownerID uint) (*models.Recipe, *models.RecipeNode) {
+	t.Helper()
+	def := testutil.TestRecipeDef()
+	recipe := &models.Recipe{
+		Model:       gorm.Model{ID: 1},
+		RecipeDef:   def,
+		CreatedByID: ownerID,
+	}
+	repo.Recipes[recipe.ID] = recipe
+	repo.NextID = 2
+
+	rootNode := &models.RecipeNode{
+		Prompt:      "make pancakes",
+		Response:    &def,
+		Summary:     "Initial pancake recipe",
+		Type:        models.RecipeTypeChat,
+		BranchName:  "original",
+		CreatedByID: ownerID,
+		IsActive:    true,
+	}
+	if _, err := repo.CreateRecipeTree(recipe.ID, rootNode); err != nil {
+		t.Fatalf("CreateRecipeTree() error = %v", err)
+	}
+	inFlight := *recipe
+	return &inFlight, rootNode
+}
+
+// --- InitRegenerateRecipe ---
+
+func TestInitRegenerateRecipe_NilPersonalization(t *testing.T) {
+	repo := testutil.NewMockRecipeRepo()
+	user := testutil.TestUser()
+	user.Personalization = &models.Personalization{}
+
+	svc := newGenRecipeService(repo, &testutil.MockTextProvider{}, &testutil.MockImageProvider{}, nil, nil)
+	if err := svc.InitRegenerateRecipe(user, 1, "fluffier", false); err == nil {
+		t.Fatal("InitRegenerateRecipe() error = nil, want error for missing personalization")
+	}
+}
+
+func TestInitRegenerateRecipe_RecipeNotFound(t *testing.T) {
+	repo := testutil.NewMockRecipeRepo()
+
+	svc := newGenRecipeService(repo, &testutil.MockTextProvider{}, &testutil.MockImageProvider{}, nil, nil)
+	if err := svc.InitRegenerateRecipe(testutil.TestUser(), 999, "fluffier", false); err == nil {
+		t.Fatal("InitRegenerateRecipe() error = nil, want error for missing recipe")
+	}
+}
+
+func TestInitRegenerateRecipe_NotOwner(t *testing.T) {
+	repo := testutil.NewMockRecipeRepo()
+	user := testutil.TestUser() // ID 1
+	seedOwnedRecipeWithTree(t, repo, 99)
+
+	svc := newGenRecipeService(repo, &testutil.MockTextProvider{}, &testutil.MockImageProvider{}, nil, nil)
+	err := svc.InitRegenerateRecipe(user, 1, "fluffier", false)
+	if err == nil {
+		t.Fatal("InitRegenerateRecipe() error = nil, want unauthorized error")
+	}
+	if !strings.Contains(err.Error(), "unauthorized") {
+		t.Errorf("error = %q, want unauthorized", err)
+	}
+}
+
+func TestInitRegenerateRecipe_HappyPathStartsRegen(t *testing.T) {
+	repo := testutil.NewMockRecipeRepo()
+	user := testutil.TestUser()
+	seedOwnedRecipeWithTree(t, repo, user.ID)
+
+	gate := make(chan struct{})
+	entered := make(chan struct{})
+	t.Cleanup(func() { close(gate) })
+	provider := &testutil.MockTextProvider{
+		RegenerateRecipeFunc: func(ctx context.Context, req ai.RegenerateRequest) (*ai.RecipeResult, error) {
+			close(entered)
+			<-gate
+			return nil, errors.New("aborted by test teardown")
+		},
+	}
+
+	svc := newGenRecipeService(repo, provider, &testutil.MockImageProvider{}, nil, nil)
+	if err := svc.InitRegenerateRecipe(user, 1, "fluffier", false); err != nil {
+		t.Fatalf("InitRegenerateRecipe() error = %v", err)
+	}
+
+	select {
+	case <-entered:
+	case <-time.After(2 * time.Second):
+		t.Fatal("FinishRegenerateRecipe goroutine never called the text provider")
+	}
+}
+
+// --- FinishRegenerateRecipe ---
+
+func TestFinishRegenerateRecipe_HappyPathAppendsNode(t *testing.T) {
+	repo := testutil.NewMockRecipeRepo()
+	user := testutil.TestUser()
+	recipe, rootNode := seedOwnedRecipeWithTree(t, repo, user.ID)
+	originalDefJSON, _ := json.Marshal(recipe.RecipeDef)
+
+	var gotReq ai.RegenerateRequest
+	result := testutil.TestRecipeResult()
+	result.Title = "Fluffier Pancakes"
+	result.UnitSystem = "metric"
+	result.PromptVersion = "pv-regen-1"
+	result.Summary = "Made them fluffier"
+	provider := &testutil.MockTextProvider{
+		RegenerateRecipeFunc: func(ctx context.Context, req ai.RegenerateRequest) (*ai.RecipeResult, error) {
+			gotReq = req
+			return result, nil
+		},
+	}
+	vector := &testutil.MockVectorRepo{}
+	embed := &testutil.MockEmbeddingProvider{
+		GenerateEmbeddingFunc: func(ctx context.Context, text string) ([]float32, error) {
+			return []float32{0.3}, nil
+		},
+	}
+
+	svc := newGenRecipeService(repo, provider, &testutil.MockImageProvider{}, embed, vector)
+	svc.FinishRegenerateRecipe(recipe, user, "make them fluffier", false)
+
+	// Conversation context: the chain root rendered with the pre-regen def.
+	wantHistory := []ai.Message{
+		{Role: "user", Content: "make pancakes"},
+		{Role: "assistant", Content: string(originalDefJSON)},
+	}
+	if !reflect.DeepEqual(gotReq.ExistingHistory, wantHistory) {
+		t.Errorf("ExistingHistory = %+v, want %+v", gotReq.ExistingHistory, wantHistory)
+	}
+	if gotReq.UserPrompt != "make them fluffier" {
+		t.Errorf("UserPrompt = %q", gotReq.UserPrompt)
+	}
+	// Def is re-rendered in the user's unit system preference.
+	if gotReq.UnitSystem != "US Customary" {
+		t.Errorf("req.UnitSystem = %q, want 'US Customary'", gotReq.UnitSystem)
+	}
+
+	stored := repo.RecipeSnapshot(recipe.ID)
+	if stored == nil {
+		t.Fatal("recipe should still exist")
+	}
+	if stored.Title != "Fluffier Pancakes" {
+		t.Errorf("persisted Title = %q, want 'Fluffier Pancakes'", stored.Title)
+	}
+	if recipe.PromptVersion != "pv-regen-1" {
+		t.Errorf("PromptVersion = %q, want the result's prompt version preserved", recipe.PromptVersion)
+	}
+
+	// New node appended as child of the previously active node.
+	tree, _ := repo.GetTreeByRecipeID(recipe.ID)
+	active, err := repo.GetActiveNode(tree.ID)
+	if err != nil {
+		t.Fatalf("GetActiveNode() error = %v", err)
+	}
+	if active.ID == rootNode.ID {
+		t.Fatal("a new node should be active, not the old root")
+	}
+	if active.ParentID == nil || *active.ParentID != rootNode.ID {
+		t.Errorf("new node ParentID = %v, want %d", active.ParentID, rootNode.ID)
+	}
+	if active.Type != models.RecipeTypeRegenChat {
+		t.Errorf("new node Type = %q, want %q", active.Type, models.RecipeTypeRegenChat)
+	}
+	if active.BranchName != rootNode.BranchName {
+		t.Errorf("new node BranchName = %q, want %q (inherited)", active.BranchName, rootNode.BranchName)
+	}
+	if active.Prompt != "make them fluffier" || active.Summary != "Made them fluffier" {
+		t.Errorf("new node prompt/summary = %q/%q", active.Prompt, active.Summary)
+	}
+	if active.Response == nil || active.Response.Title != "Fluffier Pancakes" {
+		t.Error("new node Response should carry the regenerated def")
+	}
+	if rootNode.IsActive {
+		t.Error("old root should have been deactivated")
+	}
+
+	if len(vector.UpdateEmbeddingCalls) != 1 || vector.UpdateEmbeddingCalls[0] != recipe.ID {
+		t.Errorf("UpdateEmbeddingCalls = %v, want [%d]", vector.UpdateEmbeddingCalls, recipe.ID)
+	}
+}
+
+func TestFinishRegenerateRecipe_CanonicalCopyOnWrite(t *testing.T) {
+	repo := testutil.NewMockRecipeRepo()
+	user := testutil.TestUser()
+	seeded := testutil.TestCanonicalLinkedRecipe() // HasDiverged=false, Canonical set
+	seeded.CreatedByID = user.ID
+	repo.Recipes[seeded.ID] = seeded
+	repo.NextID = seeded.ID + 1
+	inFlight := *seeded
+	recipe := &inFlight
+
+	result := testutil.TestRecipeResult()
+	result.Title = "Diverged Pancakes"
+	provider := &testutil.MockTextProvider{
+		RegenerateRecipeFunc: func(ctx context.Context, req ai.RegenerateRequest) (*ai.RecipeResult, error) {
+			return result, nil
+		},
+	}
+
+	svc := newGenRecipeService(repo, provider, &testutil.MockImageProvider{}, nil, nil)
+	svc.FinishRegenerateRecipe(recipe, user, "make it mine", false)
+
+	stored := repo.RecipeSnapshot(recipe.ID)
+	if stored == nil {
+		t.Fatal("recipe should still exist")
+	}
+	if !stored.HasDiverged {
+		t.Error("recipe should be materialized from canonical (HasDiverged=true) before regen mutates it")
+	}
+	if stored.Title != "Diverged Pancakes" {
+		t.Errorf("persisted Title = %q, want the regenerated def to win", stored.Title)
+	}
+}
+
+func TestFinishRegenerateRecipe_AIFailurePreservesRecipe(t *testing.T) {
+	repo := testutil.NewMockRecipeRepo()
+	user := testutil.TestUser()
+	recipe, _ := seedOwnedRecipeWithTree(t, repo, user.ID)
+	nodesBefore := len(repo.Nodes)
+
+	provider := &testutil.MockTextProvider{
+		RegenerateRecipeFunc: func(ctx context.Context, req ai.RegenerateRequest) (*ai.RecipeResult, error) {
+			return nil, errors.New("claude unavailable")
+		},
+	}
+
+	svc := newGenRecipeService(repo, provider, &testutil.MockImageProvider{}, nil, nil)
+	svc.FinishRegenerateRecipe(recipe, user, "fluffier", false)
+
+	stored := repo.RecipeSnapshot(recipe.ID)
+	if stored == nil {
+		t.Fatal("regen failure must NOT delete the existing recipe")
+	}
+	if stored.Title != "Classic Pancakes" {
+		t.Errorf("persisted Title = %q, want the previous version preserved", stored.Title)
+	}
+	if len(repo.Nodes) != nodesBefore {
+		t.Errorf("nodes = %d, want %d (no node appended on failure)", len(repo.Nodes), nodesBefore)
+	}
+}
+
+func TestFinishRegenerateRecipe_ValidationFailurePreservesRecipe(t *testing.T) {
+	repo := testutil.NewMockRecipeRepo()
+	user := testutil.TestUser()
+	recipe, _ := seedOwnedRecipeWithTree(t, repo, user.ID)
+
+	result := testutil.TestRecipeResult()
+	result.Title = ""
+	provider := &testutil.MockTextProvider{
+		RegenerateRecipeFunc: func(ctx context.Context, req ai.RegenerateRequest) (*ai.RecipeResult, error) {
+			return result, nil
+		},
+	}
+
+	svc := newGenRecipeService(repo, provider, &testutil.MockImageProvider{}, nil, nil)
+	svc.FinishRegenerateRecipe(recipe, user, "fluffier", false)
+
+	stored := repo.RecipeSnapshot(recipe.ID)
+	if stored == nil || stored.Title != "Classic Pancakes" {
+		t.Error("validation failure must leave the previous recipe intact")
+	}
+}
+
+func TestFinishRegenerateRecipe_UnitSystemFallbackToPersonalization(t *testing.T) {
+	repo := testutil.NewMockRecipeRepo()
+	user := testutil.TestUser()
+	recipe, _ := seedOwnedRecipeWithTree(t, repo, user.ID)
+
+	result := testutil.TestRecipeResult()
+	result.UnitSystem = ""
+	provider := &testutil.MockTextProvider{
+		RegenerateRecipeFunc: func(ctx context.Context, req ai.RegenerateRequest) (*ai.RecipeResult, error) {
+			return result, nil
+		},
+	}
+
+	svc := newGenRecipeService(repo, provider, &testutil.MockImageProvider{}, nil, nil)
+	svc.FinishRegenerateRecipe(recipe, user, "fluffier", false)
+
+	stored := repo.RecipeSnapshot(recipe.ID)
+	if stored == nil || stored.UnitSystem != "us_customary" {
+		t.Errorf("persisted UnitSystem should fall back to personalization, got %+v", stored)
+	}
+}
+
+func TestFinishRegenerateRecipe_NoTreeStillUpdatesDef(t *testing.T) {
+	repo := testutil.NewMockRecipeRepo()
+	user := testutil.TestUser()
+	seeded := &models.Recipe{
+		Model:       gorm.Model{ID: 1},
+		RecipeDef:   testutil.TestRecipeDef(),
+		CreatedByID: user.ID,
+	}
+	repo.Recipes[seeded.ID] = seeded
+	repo.NextID = 2
+	inFlight := *seeded
+	recipe := &inFlight
+
+	var gotHistory []ai.Message
+	result := testutil.TestRecipeResult()
+	result.Title = "Treeless Pancakes"
+	provider := &testutil.MockTextProvider{
+		RegenerateRecipeFunc: func(ctx context.Context, req ai.RegenerateRequest) (*ai.RecipeResult, error) {
+			gotHistory = req.ExistingHistory
+			return result, nil
+		},
+	}
+
+	svc := newGenRecipeService(repo, provider, &testutil.MockImageProvider{}, nil, nil)
+	svc.FinishRegenerateRecipe(recipe, user, "fluffier", false)
+
+	if gotHistory != nil {
+		t.Errorf("ExistingHistory = %+v, want nil when no tree exists", gotHistory)
+	}
+	stored := repo.RecipeSnapshot(recipe.ID)
+	if stored == nil || stored.Title != "Treeless Pancakes" {
+		t.Error("def should still be updated when the recipe has no tree")
+	}
+	if len(repo.Nodes) != 0 {
+		t.Errorf("no node should be created without a tree, got %d", len(repo.Nodes))
+	}
+}
+
+func TestFinishRegenerateRecipe_PersistFailureSkipsNodeAppend(t *testing.T) {
+	repo := testutil.NewMockRecipeRepo()
+	repo.UpdateRecipeDefErr = errors.New("db down")
+	user := testutil.TestUser()
+	recipe, _ := seedOwnedRecipeWithTree(t, repo, user.ID)
+	nodesBefore := len(repo.Nodes)
+
+	provider := &testutil.MockTextProvider{
+		RegenerateRecipeFunc: func(ctx context.Context, req ai.RegenerateRequest) (*ai.RecipeResult, error) {
+			return testutil.TestRecipeResult(), nil
+		},
+	}
+
+	svc := newGenRecipeService(repo, provider, &testutil.MockImageProvider{}, nil, nil)
+	svc.FinishRegenerateRecipe(recipe, user, "fluffier", false)
+
+	if repo.RecipeSnapshot(recipe.ID) == nil {
+		t.Fatal("regen persist failure must not delete the recipe")
+	}
+	if len(repo.Nodes) != nodesBefore {
+		t.Errorf("nodes = %d, want %d (no node appended when persist fails)", len(repo.Nodes), nodesBefore)
+	}
+}
+
+// --- nodeChainToMessages ---
+
+func chainNode(prompt, summary string, nodeType models.RecipeType) models.RecipeNode {
+	return models.RecipeNode{Prompt: prompt, Summary: summary, Type: nodeType}
+}
+
+func TestNodeChainToMessages_TableDriven(t *testing.T) {
+	def := testutil.TestRecipeDef()
+	defJSON, _ := json.Marshal(&def)
+
+	tests := []struct {
+		name  string
+		nodes []models.RecipeNode
+		want  []ai.Message
+	}{
+		{
+			name:  "empty chain",
+			nodes: nil,
+			want:  nil,
+		},
+		{
+			name:  "single chat node uses current def",
+			nodes: []models.RecipeNode{chainNode("make pancakes", "initial", models.RecipeTypeChat)},
+			want: []ai.Message{
+				{Role: "user", Content: "make pancakes"},
+				{Role: "assistant", Content: string(defJSON)},
+			},
+		},
+		{
+			name: "earlier nodes use summaries, last uses def",
+			nodes: []models.RecipeNode{
+				chainNode("make pancakes", "initial recipe", models.RecipeTypeChat),
+				chainNode("fluffier", "made fluffier", models.RecipeTypeRegenChat),
+				chainNode("less sugar", "reduced sugar", models.RecipeTypeRegenChat),
+			},
+			want: []ai.Message{
+				{Role: "user", Content: "make pancakes"},
+				{Role: "assistant", Content: "initial recipe"},
+				{Role: "user", Content: "fluffier"},
+				{Role: "assistant", Content: "made fluffier"},
+				{Role: "user", Content: "less sugar"},
+				{Role: "assistant", Content: string(defJSON)},
+			},
+		},
+		{
+			name: "manual entry mid-chain is skipped",
+			nodes: []models.RecipeNode{
+				chainNode("", "", models.RecipeTypeManualEntry),
+				chainNode("fluffier", "made fluffier", models.RecipeTypeRegenChat),
+			},
+			want: []ai.Message{
+				{Role: "user", Content: "fluffier"},
+				{Role: "assistant", Content: string(defJSON)},
+			},
+		},
+		{
+			name: "manual entry as last node uses boilerplate",
+			nodes: []models.RecipeNode{
+				chainNode("make pancakes", "initial recipe", models.RecipeTypeChat),
+				chainNode("", "", models.RecipeTypeManualEntry),
+			},
+			want: []ai.Message{
+				{Role: "user", Content: "make pancakes"},
+				{Role: "assistant", Content: "initial recipe"},
+				{Role: "user", Content: "The following response from you is the current revision of the recipe."},
+				{Role: "assistant", Content: string(defJSON)},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := nodeChainToMessages(tt.nodes, &def)
+			if !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("nodeChainToMessages() =\n%+v\nwant\n%+v", got, tt.want)
+			}
+		})
+	}
+}
+
+// --- compactNodeChain ---
+
+// regenChain builds a chain of n regen nodes with predictable prompts/summaries.
+func regenChain(n int) []models.RecipeNode {
+	nodes := make([]models.RecipeNode, n)
+	for i := range nodes {
+		nodes[i] = chainNode(
+			fmt.Sprintf("prompt-%d", i+1),
+			fmt.Sprintf("summary-%d", i+1),
+			models.RecipeTypeRegenChat,
+		)
+	}
+	return nodes
+}
+
+func TestCompactNodeChain_ThresholdMatrix(t *testing.T) {
+	def := testutil.TestRecipeDef()
+	const keepRecent = 2
+
+	tests := []struct {
+		name          string
+		numNodes      int
+		wantCompacted bool
+	}{
+		{"below threshold passes through", keepRecent, false},
+		// Exactly one older node: compaction boilerplate would cost more
+		// tokens than it saves (commit 70a9239), so it is skipped.
+		{"single-ancestor overflow skips compaction", keepRecent + 1, false},
+		{"two older nodes trigger compaction", keepRecent + 2, true},
+		{"deep chain triggers compaction", keepRecent + 5, true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			nodes := regenChain(tt.numNodes)
+			got := compactNodeChain(nodes, &def, keepRecent)
+
+			if !tt.wantCompacted {
+				want := nodeChainToMessages(nodes, &def)
+				if !reflect.DeepEqual(got, want) {
+					t.Errorf("uncompacted chain should equal nodeChainToMessages, got\n%+v\nwant\n%+v", got, want)
+				}
+				return
+			}
+
+			// Compacted: summary message + ack + 2*keepRecent verbatim messages.
+			wantLen := 2 + 2*keepRecent
+			if len(got) != wantLen {
+				t.Fatalf("message count = %d, want %d", len(got), wantLen)
+			}
+			numOlder := tt.numNodes - keepRecent
+			if got[0].Role != "user" || !strings.Contains(got[0].Content, fmt.Sprintf("%d prior revisions", numOlder)) {
+				t.Errorf("summary message = %+v, want user message mentioning %d prior revisions", got[0], numOlder)
+			}
+			for i := 1; i <= numOlder; i++ {
+				bullet := fmt.Sprintf("- prompt-%d: summary-%d", i, i)
+				if !strings.Contains(got[0].Content, bullet) {
+					t.Errorf("summary message missing bullet %q", bullet)
+				}
+			}
+			// No recent node may leak into the summary.
+			if strings.Contains(got[0].Content, fmt.Sprintf("prompt-%d", numOlder+1)) {
+				t.Error("summary message should not include recent nodes")
+			}
+			if got[1].Role != "assistant" {
+				t.Errorf("second message role = %q, want assistant ack", got[1].Role)
+			}
+			// Recent nodes verbatim, last one carrying the current def.
+			wantRecent := nodeChainToMessages(nodes[numOlder:], &def)
+			if !reflect.DeepEqual(got[2:], wantRecent) {
+				t.Errorf("recent messages =\n%+v\nwant\n%+v", got[2:], wantRecent)
+			}
+		})
+	}
+}
+
+func TestCompactNodeChain_OlderNodeWithoutSummaryUsesPromptBullet(t *testing.T) {
+	def := testutil.TestRecipeDef()
+	nodes := []models.RecipeNode{
+		chainNode("prompt-only", "", models.RecipeTypeRegenChat),
+		chainNode("prompt-2", "summary-2", models.RecipeTypeRegenChat),
+		chainNode("recent-1", "summary-r1", models.RecipeTypeRegenChat),
+	}
+
+	got := compactNodeChain(nodes, &def, 1)
+	if len(got) != 4 {
+		t.Fatalf("message count = %d, want 4", len(got))
+	}
+	if !strings.Contains(got[0].Content, "- prompt-only\n") {
+		t.Errorf("summary should contain a prompt-only bullet, got %q", got[0].Content)
+	}
+	if !strings.Contains(got[0].Content, "- prompt-2: summary-2") {
+		t.Errorf("summary should contain the prompt+summary bullet, got %q", got[0].Content)
+	}
+}
+
+func TestCompactNodeChain_AllOlderNodesEmptySkipsSummaryMessage(t *testing.T) {
+	def := testutil.TestRecipeDef()
+	nodes := []models.RecipeNode{
+		chainNode("", "", models.RecipeTypeRegenChat),
+		chainNode("", "", models.RecipeTypeRegenChat),
+		chainNode("recent-1", "summary-r1", models.RecipeTypeRegenChat),
+	}
+
+	got := compactNodeChain(nodes, &def, 1)
+	want := nodeChainToMessages(nodes[2:], &def)
+	if !reflect.DeepEqual(got, want) {
+		t.Errorf("empty older nodes should produce only recent messages, got\n%+v\nwant\n%+v", got, want)
+	}
+}
+
+func TestCompactNodeChain_ProductionThreshold(t *testing.T) {
+	// The regen/fork flows compact only when more than maxUncompactedNodes+1
+	// nodes exist; pin the production constant so a change is deliberate.
+	if maxUncompactedNodes != 6 {
+		t.Errorf("maxUncompactedNodes = %d, want 6", maxUncompactedNodes)
+	}
+}

--- a/internal/service/recipe_tree.go
+++ b/internal/service/recipe_tree.go
@@ -1,9 +1,11 @@
 package service
 
 import (
+	"context"
 	"errors"
 	"fmt"
 
+	"github.com/windoze95/saltybytes-api/internal/ai"
 	"github.com/windoze95/saltybytes-api/internal/config"
 	"github.com/windoze95/saltybytes-api/internal/models"
 	"github.com/windoze95/saltybytes-api/internal/repository"
@@ -13,6 +15,10 @@ import (
 type RecipeTreeService struct {
 	Cfg  *config.Config
 	Repo *repository.RecipeRepository
+	// Optional: set these to keep recipe embeddings in sync when switching
+	// the active node rewrites the recipe definition.
+	EmbedProvider ai.EmbeddingProvider
+	VectorRepo    repository.VectorRepo
 }
 
 // NewRecipeTreeService creates a new RecipeTreeService.
@@ -101,6 +107,10 @@ func (s *RecipeTreeService) SetActiveNode(recipeID uint, nodeID uint) error {
 		if err := s.Repo.UpdateRecipeFromNode(recipeID, node); err != nil {
 			return fmt.Errorf("failed to update recipe from node: %w", err)
 		}
+
+		// The recipe definition changed, so the stored embedding is stale.
+		// Regenerate it best-effort (warn-and-continue on failure).
+		generateAndStoreRecipeEmbedding(context.Background(), s.EmbedProvider, s.VectorRepo, recipeID, node.Response)
 	}
 
 	return nil

--- a/internal/service/recipe_tree.go
+++ b/internal/service/recipe_tree.go
@@ -9,6 +9,7 @@ import (
 	"github.com/windoze95/saltybytes-api/internal/config"
 	"github.com/windoze95/saltybytes-api/internal/models"
 	"github.com/windoze95/saltybytes-api/internal/repository"
+	"github.com/windoze95/saltybytes-api/internal/util"
 )
 
 // RecipeTreeService is the business logic layer for recipe tree operations.
@@ -109,8 +110,17 @@ func (s *RecipeTreeService) SetActiveNode(recipeID uint, nodeID uint) error {
 		}
 
 		// The recipe definition changed, so the stored embedding is stale.
-		// Regenerate it best-effort (warn-and-continue on failure).
-		generateAndStoreRecipeEmbedding(context.Background(), s.EmbedProvider, s.VectorRepo, recipeID, node.Response)
+		// Regenerate it best-effort (warn-and-continue on failure) in the
+		// background with a bounded timeout, so the user-facing branch
+		// switch is not blocked on an external embedding API call.
+		response := node.Response
+		go func() {
+			defer util.RecoverPanic("recipe tree embedding refresh")
+
+			ctx, cancel := context.WithTimeout(context.Background(), embeddingCallTimeout)
+			defer cancel()
+			generateAndStoreRecipeEmbedding(ctx, s.EmbedProvider, s.VectorRepo, recipeID, response)
+		}()
 	}
 
 	return nil

--- a/internal/service/recipe_tree.go
+++ b/internal/service/recipe_tree.go
@@ -3,7 +3,6 @@ package service
 import (
 	"errors"
 	"fmt"
-	"time"
 
 	"github.com/windoze95/saltybytes-api/internal/config"
 	"github.com/windoze95/saltybytes-api/internal/models"
@@ -24,30 +23,9 @@ func NewRecipeTreeService(cfg *config.Config, repo *repository.RecipeRepository)
 	}
 }
 
-// NodeResponse is the response object for a single tree node, suitable for Flutter tree visualization.
-type NodeResponse struct {
-	ID          uint            `json:"id"`
-	ParentID    *uint           `json:"parent_id"`
-	BranchName  string          `json:"branch_name"`
-	Summary     string          `json:"summary"`
-	Type        models.RecipeType `json:"type"`
-	IsActive    bool            `json:"is_active"`
-	IsEphemeral bool            `json:"is_ephemeral"`
-	CreatedByID uint            `json:"created_by_id"`
-	CreatedAt   time.Time       `json:"created_at"`
-	Children    []NodeResponse  `json:"children"`
-}
-
-// TreeResponse is the response object for a full recipe tree.
-type FullTreeResponse struct {
-	TreeID     uint          `json:"tree_id"`
-	RecipeID   uint          `json:"recipe_id"`
-	RootNodeID *uint         `json:"root_node_id"`
-	RootNode   *NodeResponse `json:"root_node"`
-}
-
-// GetTree retrieves the full tree for a recipe and returns it as a nested structure.
-func (s *RecipeTreeService) GetTree(recipeID uint) (*FullTreeResponse, error) {
+// GetTree retrieves the full tree for a recipe as a flat node list. Clients
+// rebuild the tree structure from each node's parent_id.
+func (s *RecipeTreeService) GetTree(recipeID uint) (*TreeResponse, error) {
 	treeRef, err := s.Repo.GetTreeByRecipeID(recipeID)
 	if err != nil {
 		return nil, fmt.Errorf("failed to get recipe tree: %w", err)
@@ -58,61 +36,17 @@ func (s *RecipeTreeService) GetTree(recipeID uint) (*FullTreeResponse, error) {
 		return nil, fmt.Errorf("failed to get tree nodes: %w", err)
 	}
 
-	// Build a map of nodeID -> node for quick lookup
-	nodeMap := make(map[uint]*NodeResponse)
-	for _, n := range tree.Nodes {
-		nodeMap[n.ID] = &NodeResponse{
-			ID:          n.ID,
-			ParentID:    n.ParentID,
-			BranchName:  n.BranchName,
-			Summary:     n.Summary,
-			Type:        n.Type,
-			IsActive:    n.IsActive,
-			IsEphemeral: n.IsEphemeral,
-			CreatedByID: n.CreatedByID,
-			CreatedAt:   n.CreatedAt,
-			Children:    []NodeResponse{},
-		}
+	if tree.Nodes == nil {
+		tree.Nodes = []models.RecipeNode{}
 	}
 
-	// Build the tree by linking children to parents
-	var rootNode *NodeResponse
-	for _, n := range tree.Nodes {
-		nr := nodeMap[n.ID]
-		if n.ParentID != nil {
-			if parent, ok := nodeMap[*n.ParentID]; ok {
-				parent.Children = append(parent.Children, *nr)
-			}
-		}
-		if tree.RootNodeID != nil && n.ID == *tree.RootNodeID {
-			rootNode = nr
-		}
-	}
-
-	// Re-assign children after all are linked (since we copied by value above)
-	if rootNode != nil {
-		rootNode = rebuildNode(rootNode, nodeMap, tree.Nodes)
-	}
-
-	return &FullTreeResponse{
-		TreeID:     tree.ID,
-		RecipeID:   tree.RecipeID,
-		RootNodeID: tree.RootNodeID,
-		RootNode:   rootNode,
+	return &TreeResponse{
+		TreeID:       tree.ID,
+		RecipeID:     tree.RecipeID,
+		RootNodeID:   tree.RootNodeID,
+		ActiveNodeID: activeNodeID(tree.Nodes),
+		Nodes:        tree.Nodes,
 	}, nil
-}
-
-// rebuildNode recursively builds the nested node tree from the flat node list.
-func rebuildNode(node *NodeResponse, nodeMap map[uint]*NodeResponse, allNodes []models.RecipeNode) *NodeResponse {
-	node.Children = []NodeResponse{}
-	for _, n := range allNodes {
-		if n.ParentID != nil && *n.ParentID == node.ID {
-			child := nodeMap[n.ID]
-			child = rebuildNode(child, nodeMap, allNodes)
-			node.Children = append(node.Children, *child)
-		}
-	}
-	return node
 }
 
 // CreateBranch creates a new branch node as a child of the specified parent node.

--- a/internal/service/recipe_tree.go
+++ b/internal/service/recipe_tree.go
@@ -14,7 +14,7 @@ import (
 // RecipeTreeService is the business logic layer for recipe tree operations.
 type RecipeTreeService struct {
 	Cfg  *config.Config
-	Repo *repository.RecipeRepository
+	Repo repository.RecipeRepo
 	// Optional: set these to keep recipe embeddings in sync when switching
 	// the active node rewrites the recipe definition.
 	EmbedProvider ai.EmbeddingProvider
@@ -22,7 +22,7 @@ type RecipeTreeService struct {
 }
 
 // NewRecipeTreeService creates a new RecipeTreeService.
-func NewRecipeTreeService(cfg *config.Config, repo *repository.RecipeRepository) *RecipeTreeService {
+func NewRecipeTreeService(cfg *config.Config, repo repository.RecipeRepo) *RecipeTreeService {
 	return &RecipeTreeService{
 		Cfg:  cfg,
 		Repo: repo,

--- a/internal/service/recipe_tree_service_test.go
+++ b/internal/service/recipe_tree_service_test.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/windoze95/saltybytes-api/internal/config"
 	"github.com/windoze95/saltybytes-api/internal/models"
@@ -244,7 +245,15 @@ func TestRecipeTreeService_SetActiveNode_RewritesDefAndRegeneratesEmbedding(t *t
 			return []float32{0.9}, nil
 		},
 	}
-	vector := &testutil.MockVectorRepo{}
+	// The embedding refresh runs in a background goroutine; the channel both
+	// signals completion and establishes happens-before for the assertions.
+	embeddingStored := make(chan struct{})
+	vector := &testutil.MockVectorRepo{
+		UpdateEmbeddingFunc: func(recipeID uint, embedding []float32) error {
+			close(embeddingStored)
+			return nil
+		},
+	}
 
 	svc := NewRecipeTreeService(&config.Config{}, repo)
 	svc.EmbedProvider = embed
@@ -266,6 +275,11 @@ func TestRecipeTreeService_SetActiveNode_RewritesDefAndRegeneratesEmbedding(t *t
 		t.Errorf("recipe Title = %q, want def rewritten from the node's response", stored.Title)
 	}
 
+	select {
+	case <-embeddingStored:
+	case <-time.After(2 * time.Second):
+		t.Fatal("timed out waiting for the background embedding refresh")
+	}
 	if len(vector.UpdateEmbeddingCalls) != 1 || vector.UpdateEmbeddingCalls[0] != 7 {
 		t.Errorf("UpdateEmbeddingCalls = %v, want [7]", vector.UpdateEmbeddingCalls)
 	}
@@ -295,9 +309,11 @@ func TestRecipeTreeService_SetActiveNode_EmbeddingFailureNonFatal(t *testing.T) 
 	_, child := seedTreeServiceFixture(t, repo)
 
 	vector := &testutil.MockVectorRepo{}
+	embedCalled := make(chan struct{})
 	svc := NewRecipeTreeService(&config.Config{}, repo)
 	svc.EmbedProvider = &testutil.MockEmbeddingProvider{
 		GenerateEmbeddingFunc: func(ctx context.Context, text string) ([]float32, error) {
+			defer close(embedCalled)
 			return nil, errors.New("embedding api down")
 		},
 	}
@@ -305,6 +321,14 @@ func TestRecipeTreeService_SetActiveNode_EmbeddingFailureNonFatal(t *testing.T) 
 
 	if err := svc.SetActiveNode(7, child.ID); err != nil {
 		t.Fatalf("SetActiveNode() error = %v, want embedding failure to be best-effort", err)
+	}
+
+	// Wait for the background refresh to hit the failing provider; on
+	// failure it must skip the vector store entirely.
+	select {
+	case <-embedCalled:
+	case <-time.After(2 * time.Second):
+		t.Fatal("timed out waiting for the background embedding refresh")
 	}
 	if len(vector.UpdateEmbeddingCalls) != 0 {
 		t.Errorf("UpdateEmbeddingCalls = %v, want none after embed failure", vector.UpdateEmbeddingCalls)

--- a/internal/service/recipe_tree_service_test.go
+++ b/internal/service/recipe_tree_service_test.go
@@ -1,0 +1,387 @@
+package service
+
+import (
+	"context"
+	"errors"
+	"strings"
+	"testing"
+
+	"github.com/windoze95/saltybytes-api/internal/config"
+	"github.com/windoze95/saltybytes-api/internal/models"
+	"github.com/windoze95/saltybytes-api/internal/testutil"
+	"gorm.io/gorm"
+)
+
+// seedTreeServiceFixture seeds a recipe (ID 7) plus a tree with an active root
+// and an inactive child node, returning (root, child).
+func seedTreeServiceFixture(t *testing.T, repo *testutil.MockRecipeRepo) (*models.RecipeNode, *models.RecipeNode) {
+	t.Helper()
+	def := testutil.TestRecipeDef()
+	repo.Recipes[7] = &models.Recipe{
+		Model:       gorm.Model{ID: 7},
+		RecipeDef:   def,
+		CreatedByID: 1,
+	}
+	repo.NextID = 8
+
+	root := &models.RecipeNode{
+		Prompt:      "make pancakes",
+		Response:    &def,
+		Type:        models.RecipeTypeChat,
+		BranchName:  "original",
+		CreatedByID: 1,
+		IsActive:    true,
+	}
+	tree, err := repo.CreateRecipeTree(7, root)
+	if err != nil {
+		t.Fatalf("CreateRecipeTree() error = %v", err)
+	}
+
+	childDef := testutil.TestRecipeDef()
+	childDef.Title = "Fluffier Pancakes"
+	child := &models.RecipeNode{
+		TreeID:      tree.ID,
+		ParentID:    &root.ID,
+		Prompt:      "fluffier",
+		Response:    &childDef,
+		Type:        models.RecipeTypeRegenChat,
+		BranchName:  "original",
+		CreatedByID: 1,
+	}
+	if err := repo.AddNodeToTree(child, false); err != nil {
+		t.Fatalf("AddNodeToTree() error = %v", err)
+	}
+	return root, child
+}
+
+// --- GetTree ---
+
+func TestRecipeTreeService_GetTree_FlatResponse(t *testing.T) {
+	repo := testutil.NewMockRecipeRepo()
+	root, _ := seedTreeServiceFixture(t, repo)
+
+	svc := NewRecipeTreeService(&config.Config{}, repo)
+	resp, err := svc.GetTree(7)
+	if err != nil {
+		t.Fatalf("GetTree() error = %v", err)
+	}
+
+	if resp.RecipeID != 7 {
+		t.Errorf("RecipeID = %d, want 7", resp.RecipeID)
+	}
+	if resp.RootNodeID == nil || *resp.RootNodeID != root.ID {
+		t.Errorf("RootNodeID = %v, want %d", resp.RootNodeID, root.ID)
+	}
+	if resp.ActiveNodeID == nil || *resp.ActiveNodeID != root.ID {
+		t.Errorf("ActiveNodeID = %v, want %d (root is active)", resp.ActiveNodeID, root.ID)
+	}
+	if len(resp.Nodes) != 2 {
+		t.Fatalf("Nodes count = %d, want 2 (flat list)", len(resp.Nodes))
+	}
+	// Clients rebuild structure from parent_id: the child must reference root.
+	foundChild := false
+	for _, n := range resp.Nodes {
+		if n.ParentID != nil && *n.ParentID == root.ID {
+			foundChild = true
+		}
+	}
+	if !foundChild {
+		t.Error("flat node list should include the child with its parent_id set")
+	}
+}
+
+func TestRecipeTreeService_GetTree_EmptyNodesNonNil(t *testing.T) {
+	repo := testutil.NewMockRecipeRepo()
+	repo.Trees[1] = &models.RecipeTree{ID: 1, RecipeID: 7}
+	repo.NextTreeID = 2
+
+	svc := NewRecipeTreeService(&config.Config{}, repo)
+	resp, err := svc.GetTree(7)
+	if err != nil {
+		t.Fatalf("GetTree() error = %v", err)
+	}
+	if resp.Nodes == nil {
+		t.Error("Nodes must be non-nil so JSON serializes as []")
+	}
+	if len(resp.Nodes) != 0 {
+		t.Errorf("Nodes count = %d, want 0", len(resp.Nodes))
+	}
+	if resp.ActiveNodeID != nil {
+		t.Errorf("ActiveNodeID = %v, want nil with no nodes", resp.ActiveNodeID)
+	}
+}
+
+func TestRecipeTreeService_GetTree_NoTree(t *testing.T) {
+	repo := testutil.NewMockRecipeRepo()
+
+	svc := NewRecipeTreeService(&config.Config{}, repo)
+	if _, err := svc.GetTree(7); err == nil {
+		t.Fatal("GetTree() error = nil, want error when the recipe has no tree")
+	}
+}
+
+func TestRecipeTreeService_GetTree_NodesError(t *testing.T) {
+	repo := testutil.NewMockRecipeRepo()
+	seedTreeServiceFixture(t, repo)
+	repo.GetTreeWithNodesErr = errors.New("db down")
+
+	svc := NewRecipeTreeService(&config.Config{}, repo)
+	if _, err := svc.GetTree(7); err == nil {
+		t.Fatal("GetTree() error = nil, want error when loading nodes fails")
+	}
+}
+
+// --- CreateBranch ---
+
+func TestRecipeTreeService_CreateBranch_HappyPath(t *testing.T) {
+	repo := testutil.NewMockRecipeRepo()
+	root, _ := seedTreeServiceFixture(t, repo)
+
+	svc := NewRecipeTreeService(&config.Config{}, repo)
+	node, err := svc.CreateBranch(7, root.ID, "experiment", 1)
+	if err != nil {
+		t.Fatalf("CreateBranch() error = %v", err)
+	}
+
+	if node.ID == 0 {
+		t.Error("branch node should get an ID from the repo")
+	}
+	if node.ParentID == nil || *node.ParentID != root.ID {
+		t.Errorf("ParentID = %v, want %d", node.ParentID, root.ID)
+	}
+	if node.BranchName != "experiment" {
+		t.Errorf("BranchName = %q, want 'experiment'", node.BranchName)
+	}
+	if node.TreeID != root.TreeID {
+		t.Errorf("TreeID = %d, want %d", node.TreeID, root.TreeID)
+	}
+	if node.CreatedByID != 1 {
+		t.Errorf("CreatedByID = %d, want 1", node.CreatedByID)
+	}
+	// The branch node is a placeholder: no prompt/response yet and not active.
+	if node.IsActive {
+		t.Error("a new branch node must not become active")
+	}
+	if node.Response != nil {
+		t.Error("a new branch node must not carry a response")
+	}
+	if root.IsActive == false {
+		t.Error("creating a branch must not deactivate the current active node")
+	}
+	if _, err := repo.GetNodeByID(node.ID); err != nil {
+		t.Errorf("branch node should be stored in the repo: %v", err)
+	}
+}
+
+func TestRecipeTreeService_CreateBranch_ParentInDifferentTree(t *testing.T) {
+	repo := testutil.NewMockRecipeRepo()
+	seedTreeServiceFixture(t, repo)
+
+	// A second recipe with its own tree; its root is a foreign parent.
+	otherDef := testutil.TestRecipeDef()
+	repo.Recipes[8] = &models.Recipe{Model: gorm.Model{ID: 8}, RecipeDef: otherDef, CreatedByID: 1}
+	otherRoot := &models.RecipeNode{
+		Prompt:      "other recipe",
+		Response:    &otherDef,
+		Type:        models.RecipeTypeChat,
+		CreatedByID: 1,
+		IsActive:    true,
+	}
+	if _, err := repo.CreateRecipeTree(8, otherRoot); err != nil {
+		t.Fatalf("CreateRecipeTree() error = %v", err)
+	}
+
+	svc := NewRecipeTreeService(&config.Config{}, repo)
+	_, err := svc.CreateBranch(7, otherRoot.ID, "experiment", 1)
+	if err == nil {
+		t.Fatal("CreateBranch() error = nil, want cross-tree parent rejection")
+	}
+	if !strings.Contains(err.Error(), "does not belong") {
+		t.Errorf("error = %q, want parent-tree mismatch message", err)
+	}
+}
+
+func TestRecipeTreeService_CreateBranch_TreeNotFound(t *testing.T) {
+	repo := testutil.NewMockRecipeRepo()
+
+	svc := NewRecipeTreeService(&config.Config{}, repo)
+	if _, err := svc.CreateBranch(7, 1, "experiment", 1); err == nil {
+		t.Fatal("CreateBranch() error = nil, want error when the recipe has no tree")
+	}
+}
+
+func TestRecipeTreeService_CreateBranch_ParentNotFound(t *testing.T) {
+	repo := testutil.NewMockRecipeRepo()
+	seedTreeServiceFixture(t, repo)
+
+	svc := NewRecipeTreeService(&config.Config{}, repo)
+	if _, err := svc.CreateBranch(7, 999, "experiment", 1); err == nil {
+		t.Fatal("CreateBranch() error = nil, want error for missing parent node")
+	}
+}
+
+func TestRecipeTreeService_CreateBranch_AddNodeError(t *testing.T) {
+	repo := testutil.NewMockRecipeRepo()
+	root, _ := seedTreeServiceFixture(t, repo)
+	repo.AddNodeToTreeErr = errors.New("db down")
+
+	svc := NewRecipeTreeService(&config.Config{}, repo)
+	if _, err := svc.CreateBranch(7, root.ID, "experiment", 1); err == nil {
+		t.Fatal("CreateBranch() error = nil, want error when the repo insert fails")
+	}
+}
+
+// --- SetActiveNode ---
+
+func TestRecipeTreeService_SetActiveNode_RewritesDefAndRegeneratesEmbedding(t *testing.T) {
+	repo := testutil.NewMockRecipeRepo()
+	root, child := seedTreeServiceFixture(t, repo)
+
+	var embeddedText string
+	embed := &testutil.MockEmbeddingProvider{
+		GenerateEmbeddingFunc: func(ctx context.Context, text string) ([]float32, error) {
+			embeddedText = text
+			return []float32{0.9}, nil
+		},
+	}
+	vector := &testutil.MockVectorRepo{}
+
+	svc := NewRecipeTreeService(&config.Config{}, repo)
+	svc.EmbedProvider = embed
+	svc.VectorRepo = vector
+
+	if err := svc.SetActiveNode(7, child.ID); err != nil {
+		t.Fatalf("SetActiveNode() error = %v", err)
+	}
+
+	if !child.IsActive {
+		t.Error("target node should be active")
+	}
+	if root.IsActive {
+		t.Error("previous active node should be deactivated")
+	}
+
+	stored := repo.RecipeSnapshot(7)
+	if stored.Title != "Fluffier Pancakes" {
+		t.Errorf("recipe Title = %q, want def rewritten from the node's response", stored.Title)
+	}
+
+	if len(vector.UpdateEmbeddingCalls) != 1 || vector.UpdateEmbeddingCalls[0] != 7 {
+		t.Errorf("UpdateEmbeddingCalls = %v, want [7]", vector.UpdateEmbeddingCalls)
+	}
+	if !strings.Contains(embeddedText, "Fluffier Pancakes") {
+		t.Errorf("embedding text = %q, want it built from the new def", embeddedText)
+	}
+}
+
+func TestRecipeTreeService_SetActiveNode_NilVectorDepsNoPanic(t *testing.T) {
+	repo := testutil.NewMockRecipeRepo()
+	_, child := seedTreeServiceFixture(t, repo)
+
+	// Constructor leaves EmbedProvider/VectorRepo nil; must be nil-safe.
+	svc := NewRecipeTreeService(&config.Config{}, repo)
+	if err := svc.SetActiveNode(7, child.ID); err != nil {
+		t.Fatalf("SetActiveNode() error = %v, want success with nil vector deps", err)
+	}
+
+	stored := repo.RecipeSnapshot(7)
+	if stored.Title != "Fluffier Pancakes" {
+		t.Errorf("recipe Title = %q, want def rewritten even without vector deps", stored.Title)
+	}
+}
+
+func TestRecipeTreeService_SetActiveNode_EmbeddingFailureNonFatal(t *testing.T) {
+	repo := testutil.NewMockRecipeRepo()
+	_, child := seedTreeServiceFixture(t, repo)
+
+	vector := &testutil.MockVectorRepo{}
+	svc := NewRecipeTreeService(&config.Config{}, repo)
+	svc.EmbedProvider = &testutil.MockEmbeddingProvider{
+		GenerateEmbeddingFunc: func(ctx context.Context, text string) ([]float32, error) {
+			return nil, errors.New("embedding api down")
+		},
+	}
+	svc.VectorRepo = vector
+
+	if err := svc.SetActiveNode(7, child.ID); err != nil {
+		t.Fatalf("SetActiveNode() error = %v, want embedding failure to be best-effort", err)
+	}
+	if len(vector.UpdateEmbeddingCalls) != 0 {
+		t.Errorf("UpdateEmbeddingCalls = %v, want none after embed failure", vector.UpdateEmbeddingCalls)
+	}
+}
+
+func TestRecipeTreeService_SetActiveNode_NodeWithoutResponse(t *testing.T) {
+	repo := testutil.NewMockRecipeRepo()
+	root, _ := seedTreeServiceFixture(t, repo)
+
+	// An ephemeral branch placeholder: no response yet.
+	placeholder := &models.RecipeNode{
+		TreeID:      root.TreeID,
+		ParentID:    &root.ID,
+		BranchName:  "experiment",
+		CreatedByID: 1,
+	}
+	if err := repo.AddNodeToTree(placeholder, false); err != nil {
+		t.Fatalf("AddNodeToTree() error = %v", err)
+	}
+
+	vector := &testutil.MockVectorRepo{}
+	svc := NewRecipeTreeService(&config.Config{}, repo)
+	svc.EmbedProvider = &testutil.MockEmbeddingProvider{}
+	svc.VectorRepo = vector
+
+	if err := svc.SetActiveNode(7, placeholder.ID); err != nil {
+		t.Fatalf("SetActiveNode() error = %v", err)
+	}
+
+	stored := repo.RecipeSnapshot(7)
+	if stored.Title != "Classic Pancakes" {
+		t.Errorf("recipe Title = %q, want unchanged when the node has no response", stored.Title)
+	}
+	if len(vector.UpdateEmbeddingCalls) != 0 {
+		t.Errorf("UpdateEmbeddingCalls = %v, want none for a response-less node", vector.UpdateEmbeddingCalls)
+	}
+	if !placeholder.IsActive {
+		t.Error("placeholder should still become the active node")
+	}
+}
+
+func TestRecipeTreeService_SetActiveNode_TreeNotFound(t *testing.T) {
+	repo := testutil.NewMockRecipeRepo()
+
+	svc := NewRecipeTreeService(&config.Config{}, repo)
+	if err := svc.SetActiveNode(7, 1); err == nil {
+		t.Fatal("SetActiveNode() error = nil, want error when the recipe has no tree")
+	}
+}
+
+func TestRecipeTreeService_SetActiveNode_RepoErrors(t *testing.T) {
+	tests := []struct {
+		name  string
+		setup func(repo *testutil.MockRecipeRepo)
+	}{
+		{"set active fails", func(repo *testutil.MockRecipeRepo) {
+			repo.SetActiveNodeErr = errors.New("db down")
+		}},
+		{"node fetch fails", func(repo *testutil.MockRecipeRepo) {
+			repo.GetNodeByIDErr = errors.New("db down")
+		}},
+		{"recipe rewrite fails", func(repo *testutil.MockRecipeRepo) {
+			repo.UpdateRecipeFromNodeErr = errors.New("db down")
+		}},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			repo := testutil.NewMockRecipeRepo()
+			_, child := seedTreeServiceFixture(t, repo)
+			tt.setup(repo)
+
+			svc := NewRecipeTreeService(&config.Config{}, repo)
+			if err := svc.SetActiveNode(7, child.ID); err == nil {
+				t.Fatal("SetActiveNode() error = nil, want repo error to propagate")
+			}
+		})
+	}
+}

--- a/internal/service/subscription.go
+++ b/internal/service/subscription.go
@@ -5,25 +5,29 @@ import (
 	"time"
 
 	"github.com/windoze95/saltybytes-api/internal/config"
+	"github.com/windoze95/saltybytes-api/internal/logger"
 	"github.com/windoze95/saltybytes-api/internal/models"
 	"github.com/windoze95/saltybytes-api/internal/repository"
+	"go.uber.org/zap"
 )
 
 // SubscriptionService handles subscription management and usage limits.
 type SubscriptionService struct {
 	Cfg  *config.Config
-	Repo *repository.UserRepository
+	Repo repository.UserRepo
 }
 
 // NewSubscriptionService creates a new SubscriptionService.
-func NewSubscriptionService(cfg *config.Config, repo *repository.UserRepository) *SubscriptionService {
+func NewSubscriptionService(cfg *config.Config, repo repository.UserRepo) *SubscriptionService {
 	return &SubscriptionService{
 		Cfg:  cfg,
 		Repo: repo,
 	}
 }
 
-// GetSubscription retrieves the subscription for a user.
+// GetSubscription retrieves the subscription for a user. Users without a
+// subscription row (created before rows were stamped at signup) get a
+// free-tier row created on the fly so usage counters can be tracked.
 func (s *SubscriptionService) GetSubscription(userID uint) (*models.Subscription, error) {
 	user, err := s.Repo.GetUserByID(userID)
 	if err != nil {
@@ -31,10 +35,18 @@ func (s *SubscriptionService) GetSubscription(userID uint) (*models.Subscription
 	}
 
 	if user.Subscription == nil {
-		return &models.Subscription{
-			UserID: userID,
-			Tier:   models.TierFree,
-		}, nil
+		sub := &models.Subscription{
+			UserID:         userID,
+			Tier:           models.TierFree,
+			MonthlyResetAt: time.Now().AddDate(0, 1, 0),
+		}
+		if err := s.Repo.CreateSubscription(sub); err != nil {
+			// Fall back to in-memory free-tier defaults so the request can
+			// still be gated correctly even if persisting the row failed.
+			logger.Get().Warn("failed to create missing subscription row; using in-memory free-tier defaults",
+				zap.Uint("user_id", userID), zap.Error(err))
+		}
+		return sub, nil
 	}
 
 	// Reset monthly usage if needed and persist to DB

--- a/internal/service/subscription_test.go
+++ b/internal/service/subscription_test.go
@@ -1,0 +1,147 @@
+package service
+
+import (
+	"testing"
+	"time"
+
+	"github.com/windoze95/saltybytes-api/internal/config"
+	"github.com/windoze95/saltybytes-api/internal/models"
+	"github.com/windoze95/saltybytes-api/internal/testutil"
+	"gorm.io/gorm"
+)
+
+func newTestSubscriptionService(repo *testutil.MockUserRepo) *SubscriptionService {
+	return NewSubscriptionService(&config.Config{}, repo)
+}
+
+func TestGetSubscription_NilSubscription_CreatesFreeRow(t *testing.T) {
+	repo := testutil.NewMockUserRepo()
+	user := testutil.TestUser()
+	user.Subscription = nil
+	repo.Users[user.ID] = user
+
+	svc := newTestSubscriptionService(repo)
+
+	sub, err := svc.GetSubscription(user.ID)
+	if err != nil {
+		t.Fatalf("GetSubscription error: %v", err)
+	}
+	if sub.Tier != models.TierFree {
+		t.Errorf("Tier = %q, want %q", sub.Tier, models.TierFree)
+	}
+	if !sub.MonthlyResetAt.After(time.Now()) {
+		t.Error("MonthlyResetAt should be set in the future for a new row")
+	}
+	if repo.Users[user.ID].Subscription == nil {
+		t.Error("subscription row should have been persisted")
+	}
+}
+
+func TestCheckLimit_TriggersMonthlyReset(t *testing.T) {
+	repo := testutil.NewMockUserRepo()
+	user := testutil.TestUser()
+	user.Subscription = &models.Subscription{
+		Model:                gorm.Model{ID: 1},
+		UserID:               user.ID,
+		Tier:                 models.TierFree,
+		AllergenAnalysesUsed: 5,
+		WebSearchesUsed:      20,
+		AIGenerationsUsed:    50,
+		MonthlyResetAt:       time.Now().Add(-time.Hour), // overdue
+	}
+	repo.Users[user.ID] = user
+
+	svc := newTestSubscriptionService(repo)
+
+	for _, usageType := range []string{"allergen", "search", "ai_generation"} {
+		allowed, err := svc.CheckLimit(user.ID, usageType)
+		if err != nil {
+			t.Fatalf("CheckLimit(%q) error: %v", usageType, err)
+		}
+		if !allowed {
+			t.Errorf("CheckLimit(%q) = false, want true after overdue monthly reset", usageType)
+		}
+	}
+
+	sub := repo.Users[user.ID].Subscription
+	if sub.AllergenAnalysesUsed != 0 || sub.WebSearchesUsed != 0 || sub.AIGenerationsUsed != 0 {
+		t.Errorf("counters not reset: %d/%d/%d", sub.AllergenAnalysesUsed, sub.WebSearchesUsed, sub.AIGenerationsUsed)
+	}
+	if !sub.MonthlyResetAt.After(time.Now()) {
+		t.Error("MonthlyResetAt should be advanced into the future")
+	}
+}
+
+func TestCheckLimit_FreeUserAtLimit(t *testing.T) {
+	repo := testutil.NewMockUserRepo()
+	user := testutil.TestUser()
+	user.Subscription = &models.Subscription{
+		Model:             gorm.Model{ID: 1},
+		UserID:            user.ID,
+		Tier:              models.TierFree,
+		AIGenerationsUsed: 50,
+		MonthlyResetAt:    time.Now().Add(time.Hour),
+	}
+	repo.Users[user.ID] = user
+
+	svc := newTestSubscriptionService(repo)
+
+	allowed, err := svc.CheckLimit(user.ID, "ai_generation")
+	if err != nil {
+		t.Fatalf("CheckLimit error: %v", err)
+	}
+	if allowed {
+		t.Error("CheckLimit = true, want false for free user at limit")
+	}
+}
+
+func TestCheckLimit_UnknownUsageType(t *testing.T) {
+	repo := testutil.NewMockUserRepo()
+	user := testutil.TestUser()
+	repo.Users[user.ID] = user
+
+	svc := newTestSubscriptionService(repo)
+
+	if _, err := svc.CheckLimit(user.ID, "bogus"); err == nil {
+		t.Error("CheckLimit with unknown usage type should error")
+	}
+}
+
+func TestIncrementUsage_Valid(t *testing.T) {
+	repo := testutil.NewMockUserRepo()
+	user := testutil.TestUser()
+	user.Subscription = &models.Subscription{
+		Model:          gorm.Model{ID: 1},
+		UserID:         user.ID,
+		Tier:           models.TierFree,
+		MonthlyResetAt: time.Now().Add(time.Hour),
+	}
+	repo.Users[user.ID] = user
+
+	svc := newTestSubscriptionService(repo)
+
+	if err := svc.IncrementUsage(user.ID, "ai_generation"); err != nil {
+		t.Fatalf("IncrementUsage error: %v", err)
+	}
+	if got := repo.Users[user.ID].Subscription.AIGenerationsUsed; got != 1 {
+		t.Errorf("AIGenerationsUsed = %d, want 1", got)
+	}
+}
+
+func TestIncrementUsage_UnknownType(t *testing.T) {
+	repo := testutil.NewMockUserRepo()
+	svc := newTestSubscriptionService(repo)
+
+	if err := svc.IncrementUsage(1, "bogus"); err == nil {
+		t.Error("IncrementUsage with unknown usage type should error")
+	}
+}
+
+func TestUpgradeSubscription_NotAvailable(t *testing.T) {
+	repo := testutil.NewMockUserRepo()
+	svc := newTestSubscriptionService(repo)
+
+	if _, err := svc.UpgradeSubscription(1); err == nil {
+		t.Error("UpgradeSubscription should error until paid plans are wired up")
+	}
+}

--- a/internal/service/subscription_test.go
+++ b/internal/service/subscription_test.go
@@ -1,6 +1,7 @@
 package service
 
 import (
+	"fmt"
 	"testing"
 	"time"
 
@@ -72,6 +73,121 @@ func TestCheckLimit_TriggersMonthlyReset(t *testing.T) {
 	}
 }
 
+func TestGetSubscription_MonthlyReset_ZeroesCounters(t *testing.T) {
+	repo := testutil.NewMockUserRepo()
+	user := testutil.TestUser()
+	user.Subscription = &models.Subscription{
+		Model:                gorm.Model{ID: 1},
+		UserID:               user.ID,
+		Tier:                 models.TierFree,
+		AllergenAnalysesUsed: 5,
+		WebSearchesUsed:      20,
+		AIGenerationsUsed:    50,
+		MonthlyResetAt:       time.Now().Add(-24 * time.Hour), // overdue
+	}
+	repo.Users[user.ID] = user
+
+	svc := newTestSubscriptionService(repo)
+
+	sub, err := svc.GetSubscription(user.ID)
+	if err != nil {
+		t.Fatalf("GetSubscription error: %v", err)
+	}
+	if sub.AllergenAnalysesUsed != 0 || sub.WebSearchesUsed != 0 || sub.AIGenerationsUsed != 0 {
+		t.Errorf("returned counters not zeroed: %d/%d/%d", sub.AllergenAnalysesUsed, sub.WebSearchesUsed, sub.AIGenerationsUsed)
+	}
+	if !sub.MonthlyResetAt.After(time.Now()) {
+		t.Error("MonthlyResetAt should be advanced into the future")
+	}
+	// The reset must also be persisted, not just reflected in the return value.
+	persisted := repo.Users[user.ID].Subscription
+	if persisted.AllergenAnalysesUsed != 0 || persisted.WebSearchesUsed != 0 || persisted.AIGenerationsUsed != 0 {
+		t.Errorf("persisted counters not zeroed: %d/%d/%d", persisted.AllergenAnalysesUsed, persisted.WebSearchesUsed, persisted.AIGenerationsUsed)
+	}
+}
+
+func TestGetSubscription_NoReset_BeforeWindow(t *testing.T) {
+	repo := testutil.NewMockUserRepo()
+	user := testutil.TestUser()
+	user.Subscription = &models.Subscription{
+		Model:                gorm.Model{ID: 1},
+		UserID:               user.ID,
+		Tier:                 models.TierFree,
+		AllergenAnalysesUsed: 3,
+		MonthlyResetAt:       time.Now().Add(time.Hour), // not yet due
+	}
+	repo.Users[user.ID] = user
+
+	svc := newTestSubscriptionService(repo)
+
+	sub, err := svc.GetSubscription(user.ID)
+	if err != nil {
+		t.Fatalf("GetSubscription error: %v", err)
+	}
+	if sub.AllergenAnalysesUsed != 3 {
+		t.Errorf("AllergenAnalysesUsed = %d, want unchanged 3", sub.AllergenAnalysesUsed)
+	}
+}
+
+func TestGetSubscription_CreateRowFails_InMemoryFallback(t *testing.T) {
+	repo := testutil.NewMockUserRepo()
+	user := testutil.TestUser()
+	user.Subscription = nil
+	repo.Users[user.ID] = user
+	repo.CreateSubscriptionErr = fmt.Errorf("db down")
+
+	svc := newTestSubscriptionService(repo)
+
+	// Persisting the row fails, but the caller still gets free-tier defaults
+	// so gating works for this request.
+	sub, err := svc.GetSubscription(user.ID)
+	if err != nil {
+		t.Fatalf("GetSubscription error: %v (should fall back to in-memory defaults)", err)
+	}
+	if sub == nil || sub.Tier != models.TierFree {
+		t.Fatalf("sub = %+v, want in-memory free-tier subscription", sub)
+	}
+	if repo.Users[user.ID].Subscription != nil {
+		t.Error("subscription row should not have been persisted when create fails")
+	}
+}
+
+func TestGetSubscription_UserNotFound(t *testing.T) {
+	repo := testutil.NewMockUserRepo()
+	svc := newTestSubscriptionService(repo)
+
+	if _, err := svc.GetSubscription(999); err == nil {
+		t.Error("GetSubscription for unknown user should error")
+	}
+}
+
+func TestCheckLimit_PremiumUnlimited(t *testing.T) {
+	repo := testutil.NewMockUserRepo()
+	user := testutil.TestUser()
+	user.Subscription = &models.Subscription{
+		Model:                gorm.Model{ID: 1},
+		UserID:               user.ID,
+		Tier:                 models.TierPremium,
+		AllergenAnalysesUsed: 1000,
+		WebSearchesUsed:      1000,
+		AIGenerationsUsed:    1000,
+		MonthlyResetAt:       time.Now().Add(time.Hour),
+	}
+	repo.Users[user.ID] = user
+
+	svc := newTestSubscriptionService(repo)
+
+	for _, usageType := range []string{"allergen", "search", "ai_generation"} {
+		allowed, err := svc.CheckLimit(user.ID, usageType)
+		if err != nil {
+			t.Fatalf("CheckLimit(%q) error: %v", usageType, err)
+		}
+		if !allowed {
+			t.Errorf("CheckLimit(%q) = false, want true for premium regardless of usage", usageType)
+		}
+	}
+}
+
 func TestCheckLimit_FreeUserAtLimit(t *testing.T) {
 	repo := testutil.NewMockUserRepo()
 	user := testutil.TestUser()
@@ -108,23 +224,42 @@ func TestCheckLimit_UnknownUsageType(t *testing.T) {
 }
 
 func TestIncrementUsage_Valid(t *testing.T) {
-	repo := testutil.NewMockUserRepo()
-	user := testutil.TestUser()
-	user.Subscription = &models.Subscription{
-		Model:          gorm.Model{ID: 1},
-		UserID:         user.ID,
-		Tier:           models.TierFree,
-		MonthlyResetAt: time.Now().Add(time.Hour),
+	tests := []struct {
+		usageType string
+		counter   func(s *models.Subscription) int
+	}{
+		{"allergen", func(s *models.Subscription) int { return s.AllergenAnalysesUsed }},
+		{"search", func(s *models.Subscription) int { return s.WebSearchesUsed }},
+		{"ai_generation", func(s *models.Subscription) int { return s.AIGenerationsUsed }},
 	}
-	repo.Users[user.ID] = user
 
-	svc := newTestSubscriptionService(repo)
+	for _, tt := range tests {
+		t.Run(tt.usageType, func(t *testing.T) {
+			repo := testutil.NewMockUserRepo()
+			user := testutil.TestUser()
+			user.Subscription = &models.Subscription{
+				Model:          gorm.Model{ID: 1},
+				UserID:         user.ID,
+				Tier:           models.TierFree,
+				MonthlyResetAt: time.Now().Add(time.Hour),
+			}
+			repo.Users[user.ID] = user
 
-	if err := svc.IncrementUsage(user.ID, "ai_generation"); err != nil {
-		t.Fatalf("IncrementUsage error: %v", err)
-	}
-	if got := repo.Users[user.ID].Subscription.AIGenerationsUsed; got != 1 {
-		t.Errorf("AIGenerationsUsed = %d, want 1", got)
+			svc := newTestSubscriptionService(repo)
+
+			if err := svc.IncrementUsage(user.ID, tt.usageType); err != nil {
+				t.Fatalf("IncrementUsage(%q) error: %v", tt.usageType, err)
+			}
+			sub := repo.Users[user.ID].Subscription
+			if got := tt.counter(sub); got != 1 {
+				t.Errorf("%s counter = %d, want 1", tt.usageType, got)
+			}
+			// Only the targeted counter moves.
+			total := sub.AllergenAnalysesUsed + sub.WebSearchesUsed + sub.AIGenerationsUsed
+			if total != 1 {
+				t.Errorf("sum of counters = %d, want exactly 1 incremented", total)
+			}
+		})
 	}
 }
 

--- a/internal/service/user.go
+++ b/internal/service/user.go
@@ -101,14 +101,20 @@ func (s *UserService) CreateUser(username, firstName, email, password string) (*
 // used to enumerate usernames and never leaks internal error details.
 var ErrInvalidCredentials = errors.New("invalid username or password")
 
+// dummyBcryptHash is a cost-10 bcrypt hash (of a fixed throwaway string) that
+// is compared against when the username does not exist, so unknown-user and
+// wrong-password failures take comparable time. Without it, the early return
+// skips the ~50-100ms bcrypt compare and response latency leaks whether a
+// username exists.
+var dummyBcryptHash = []byte("$2a$10$eTN04vDBzQvPQeH2t2QGHe/dB4sezgOEiN7Jd9/BB4cv7Hkgimei6")
+
 // LoginUser logs in a user.
 func (s *UserService) LoginUser(username, password string) (*models.User, error) {
 	user, err := s.Repo.GetUserAuthByUsername(username)
-	if err != nil {
-		return nil, ErrInvalidCredentials
-	}
-
-	if user.Auth == nil {
+	if err != nil || user == nil || user.Auth == nil {
+		// Burn a bcrypt compare so this path takes as long as a real
+		// password check (prevents username enumeration via timing).
+		_ = bcrypt.CompareHashAndPassword(dummyBcryptHash, []byte(password))
 		return nil, ErrInvalidCredentials
 	}
 

--- a/internal/service/user.go
+++ b/internal/service/user.go
@@ -96,18 +96,38 @@ func (s *UserService) CreateUser(username, firstName, email, password string) (*
 	return user, nil
 }
 
+// ErrInvalidCredentials is returned for every login failure mode (unknown
+// username, missing auth record, or wrong password) so the API cannot be
+// used to enumerate usernames and never leaks internal error details.
+var ErrInvalidCredentials = errors.New("invalid username or password")
+
 // LoginUser logs in a user.
 func (s *UserService) LoginUser(username, password string) (*models.User, error) {
 	user, err := s.Repo.GetUserAuthByUsername(username)
 	if err != nil {
-		return nil, err
+		return nil, ErrInvalidCredentials
+	}
+
+	if user.Auth == nil {
+		return nil, ErrInvalidCredentials
 	}
 
 	if err := bcrypt.CompareHashAndPassword([]byte(user.Auth.HashedPassword), []byte(password)); err != nil {
-		return nil, errors.New("invalid username or password")
+		return nil, ErrInvalidCredentials
 	}
 
 	return user, nil
+}
+
+// GetUserWithAuthByID gets a user with their auth record (token version) loaded.
+func (s *UserService) GetUserWithAuthByID(userID uint) (*models.User, error) {
+	return s.Repo.GetUserWithAuthByID(userID)
+}
+
+// LogoutUser revokes all outstanding refresh tokens for a user by
+// incrementing their token version.
+func (s *UserService) LogoutUser(userID uint) error {
+	return s.Repo.IncrementTokenVersion(userID)
 }
 
 // ToUserResponse converts a User to a UserResponse.

--- a/internal/service/user.go
+++ b/internal/service/user.go
@@ -141,9 +141,13 @@ func (s *UserService) GetUserByID(userID uint) (*models.User, error) {
 	return s.Repo.GetUserByID(userID)
 }
 
-// UpdatePersonalization updates a user's personalization settings.
-func (s *UserService) UpdatePersonalization(user *models.User, updatedPersonalization *models.Personalization) error {
-	return s.Repo.UpdatePersonalization(user.ID, updatedPersonalization)
+// UpdatePersonalization partially updates a user's personalization settings.
+// Nil fields in the update are left unchanged.
+func (s *UserService) UpdatePersonalization(user *models.User, update *models.PersonalizationUpdate) error {
+	if update.UnitSystem != nil && *update.UnitSystem != "us_customary" && *update.UnitSystem != "metric" {
+		return fmt.Errorf("unit_system must be 'us_customary' or 'metric'")
+	}
+	return s.Repo.UpdatePersonalization(user.ID, update)
 }
 
 // UpdateUser updates a user's profile fields (first name, email).

--- a/internal/service/user_service_test.go
+++ b/internal/service/user_service_test.go
@@ -1,6 +1,7 @@
 package service
 
 import (
+	"errors"
 	"testing"
 
 	"github.com/windoze95/saltybytes-api/internal/config"
@@ -114,6 +115,9 @@ func TestLoginUser_WrongPassword(t *testing.T) {
 	if err == nil {
 		t.Fatal("LoginUser with wrong password should return error")
 	}
+	if !errors.Is(err, ErrInvalidCredentials) {
+		t.Errorf("err = %v, want ErrInvalidCredentials", err)
+	}
 }
 
 func TestLoginUser_UserNotFound(t *testing.T) {
@@ -123,6 +127,26 @@ func TestLoginUser_UserNotFound(t *testing.T) {
 	_, err := svc.LoginUser("nonexistent", "Password1!")
 	if err == nil {
 		t.Fatal("LoginUser with nonexistent user should return error")
+	}
+	// Same generic error as a bad password, so the API cannot leak which
+	// usernames exist or surface raw repository errors.
+	if !errors.Is(err, ErrInvalidCredentials) {
+		t.Errorf("err = %v, want ErrInvalidCredentials", err)
+	}
+}
+
+func TestLogoutUser_IncrementsTokenVersion(t *testing.T) {
+	repo := testutil.NewMockUserRepo()
+	user := testutil.TestUser()
+	repo.Users[user.ID] = user
+
+	svc := newTestUserService(repo)
+
+	if err := svc.LogoutUser(user.ID); err != nil {
+		t.Fatalf("LogoutUser error: %v", err)
+	}
+	if got := repo.Users[user.ID].Auth.TokenVersion; got != 1 {
+		t.Errorf("TokenVersion = %d, want 1", got)
 	}
 }
 

--- a/internal/service/user_service_test.go
+++ b/internal/service/user_service_test.go
@@ -135,6 +135,15 @@ func TestLoginUser_UserNotFound(t *testing.T) {
 	}
 }
 
+func TestLoginUser_DummyHashIsValidBcrypt(t *testing.T) {
+	// The constant-time dummy compare only equalizes timing if the hash is a
+	// well-formed bcrypt hash: a malformed one fails fast on parsing.
+	err := bcrypt.CompareHashAndPassword(dummyBcryptHash, []byte("any password"))
+	if !errors.Is(err, bcrypt.ErrMismatchedHashAndPassword) {
+		t.Errorf("CompareHashAndPassword(dummyBcryptHash) = %v, want ErrMismatchedHashAndPassword (valid hash, wrong password)", err)
+	}
+}
+
 func TestLogoutUser_IncrementsTokenVersion(t *testing.T) {
 	repo := testutil.NewMockUserRepo()
 	user := testutil.TestUser()

--- a/internal/service/voice.go
+++ b/internal/service/voice.go
@@ -25,8 +25,10 @@ func NewVoiceService(cfg *config.Config, textProvider ai.TextProvider, speechPro
 }
 
 // ProcessVoiceCommand transcribes audio and classifies the user's intent.
-func (s *VoiceService) ProcessVoiceCommand(ctx context.Context, audioData []byte) (*ai.VoiceIntent, error) {
-	transcript, err := s.SpeechProvider.TranscribeAudio(ctx, audioData)
+// format is the audio container format (e.g. "webm", "m4a"); empty defaults
+// to webm.
+func (s *VoiceService) ProcessVoiceCommand(ctx context.Context, audioData []byte, format string) (*ai.VoiceIntent, error) {
+	transcript, err := s.SpeechProvider.TranscribeAudio(ctx, audioData, format)
 	if err != nil {
 		return nil, fmt.Errorf("transcribe audio: %w", err)
 	}

--- a/internal/service/voice_test.go
+++ b/internal/service/voice_test.go
@@ -1,0 +1,202 @@
+package service
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"strings"
+	"testing"
+
+	"github.com/windoze95/saltybytes-api/internal/ai"
+	"github.com/windoze95/saltybytes-api/internal/config"
+	"github.com/windoze95/saltybytes-api/internal/testutil"
+)
+
+func TestNewVoiceService_WiresDependencies(t *testing.T) {
+	cfg := &config.Config{}
+	text := &testutil.MockTextProvider{}
+	speech := &testutil.MockSpeechProvider{}
+
+	svc := NewVoiceService(cfg, text, speech)
+	if svc.Cfg != cfg {
+		t.Error("NewVoiceService did not keep the config")
+	}
+	if svc.TextProvider != ai.TextProvider(text) {
+		t.Error("NewVoiceService did not keep the text provider")
+	}
+	if svc.SpeechProvider != ai.SpeechProvider(speech) {
+		t.Error("NewVoiceService did not keep the speech provider")
+	}
+}
+
+func TestProcessVoiceCommand_TranscriptFlowsToClassifier(t *testing.T) {
+	audio := []byte{0x1a, 0x45, 0xdf, 0xa3} // webm magic bytes
+	var gotAudio []byte
+	var gotFormat string
+	var gotTranscript string
+
+	speech := &testutil.MockSpeechProvider{
+		TranscribeAudioFunc: func(ctx context.Context, audioData []byte, format string) (string, error) {
+			gotAudio = audioData
+			gotFormat = format
+			return "scroll down a bit", nil
+		},
+	}
+	text := &testutil.MockTextProvider{
+		ClassifyVoiceIntentFunc: func(ctx context.Context, transcript string) (*ai.VoiceIntent, error) {
+			gotTranscript = transcript
+			return &ai.VoiceIntent{Type: "scroll_down", Amount: "small"}, nil
+		},
+	}
+
+	svc := NewVoiceService(&config.Config{}, text, speech)
+	intent, err := svc.ProcessVoiceCommand(context.Background(), audio, "m4a")
+	if err != nil {
+		t.Fatalf("ProcessVoiceCommand error: %v", err)
+	}
+
+	if !bytes.Equal(gotAudio, audio) {
+		t.Error("audio bytes were not passed to the speech provider unchanged")
+	}
+	if gotFormat != "m4a" {
+		t.Errorf("speech provider format = %q, want 'm4a'", gotFormat)
+	}
+	if gotTranscript != "scroll down a bit" {
+		t.Errorf("classifier transcript = %q, want the Whisper output", gotTranscript)
+	}
+	if intent.Type != "scroll_down" || intent.Amount != "small" {
+		t.Errorf("intent = %+v, want scroll_down/small", intent)
+	}
+}
+
+func TestProcessVoiceCommand_TranscribeError(t *testing.T) {
+	classifierCalled := false
+	speech := &testutil.MockSpeechProvider{
+		TranscribeAudioFunc: func(ctx context.Context, audioData []byte, format string) (string, error) {
+			return "", errors.New("whisper down")
+		},
+	}
+	text := &testutil.MockTextProvider{
+		ClassifyVoiceIntentFunc: func(ctx context.Context, transcript string) (*ai.VoiceIntent, error) {
+			classifierCalled = true
+			return &ai.VoiceIntent{Type: "ignore"}, nil
+		},
+	}
+
+	svc := NewVoiceService(&config.Config{}, text, speech)
+	intent, err := svc.ProcessVoiceCommand(context.Background(), []byte("audio"), "")
+	if err == nil {
+		t.Fatal("ProcessVoiceCommand should fail when transcription fails")
+	}
+	if intent != nil {
+		t.Errorf("intent = %+v, want nil on error", intent)
+	}
+	if !strings.Contains(err.Error(), "transcribe audio") {
+		t.Errorf("error = %q, want it wrapped with 'transcribe audio'", err)
+	}
+	if !strings.Contains(err.Error(), "whisper down") {
+		t.Errorf("error = %q, want the underlying cause preserved", err)
+	}
+	if classifierCalled {
+		t.Error("intent classification ran even though transcription failed")
+	}
+}
+
+func TestProcessVoiceCommand_ClassifyError(t *testing.T) {
+	speech := &testutil.MockSpeechProvider{
+		TranscribeAudioFunc: func(ctx context.Context, audioData []byte, format string) (string, error) {
+			return "what temperature for the oven", nil
+		},
+	}
+	text := &testutil.MockTextProvider{
+		ClassifyVoiceIntentFunc: func(ctx context.Context, transcript string) (*ai.VoiceIntent, error) {
+			return nil, errors.New("claude down")
+		},
+	}
+
+	svc := NewVoiceService(&config.Config{}, text, speech)
+	intent, err := svc.ProcessVoiceCommand(context.Background(), []byte("audio"), "webm")
+	if err == nil {
+		t.Fatal("ProcessVoiceCommand should fail when classification fails")
+	}
+	if intent != nil {
+		t.Errorf("intent = %+v, want nil on error", intent)
+	}
+	if !strings.Contains(err.Error(), "classify voice intent") {
+		t.Errorf("error = %q, want it wrapped with 'classify voice intent'", err)
+	}
+}
+
+func TestProcessVoiceCommand_EmptyTranscriptionStillClassified(t *testing.T) {
+	// Documents current behavior: an empty (silent) transcription is not an
+	// error in the service; it is forwarded to the classifier, which is
+	// expected to return an "ignore" intent.
+	var gotTranscript = "sentinel"
+	speech := &testutil.MockSpeechProvider{
+		TranscribeAudioFunc: func(ctx context.Context, audioData []byte, format string) (string, error) {
+			return "", nil
+		},
+	}
+	text := &testutil.MockTextProvider{
+		ClassifyVoiceIntentFunc: func(ctx context.Context, transcript string) (*ai.VoiceIntent, error) {
+			gotTranscript = transcript
+			return &ai.VoiceIntent{Type: "ignore"}, nil
+		},
+	}
+
+	svc := NewVoiceService(&config.Config{}, text, speech)
+	intent, err := svc.ProcessVoiceCommand(context.Background(), []byte("silence"), "webm")
+	if err != nil {
+		t.Fatalf("ProcessVoiceCommand error: %v", err)
+	}
+	if gotTranscript != "" {
+		t.Errorf("classifier received %q, want the empty transcript", gotTranscript)
+	}
+	if intent.Type != "ignore" {
+		t.Errorf("intent.Type = %q, want 'ignore'", intent.Type)
+	}
+}
+
+func TestAnswerCookingQuestion_ThreadsQuestionAndContext(t *testing.T) {
+	var gotQuestion, gotContext string
+	text := &testutil.MockTextProvider{
+		CookingQAFunc: func(ctx context.Context, question string, recipeContext string) (string, error) {
+			gotQuestion = question
+			gotContext = recipeContext
+			return "Use 375F for 25 minutes.", nil
+		},
+	}
+
+	svc := NewVoiceService(&config.Config{}, text, nil)
+	recipeContext := "Roast Chicken recipe\n\nThe user is currently on step 3."
+	answer, err := svc.AnswerCookingQuestion(context.Background(), "what temperature?", recipeContext)
+	if err != nil {
+		t.Fatalf("AnswerCookingQuestion error: %v", err)
+	}
+	if answer != "Use 375F for 25 minutes." {
+		t.Errorf("answer = %q", answer)
+	}
+	if gotQuestion != "what temperature?" {
+		t.Errorf("question passed to CookingQA = %q", gotQuestion)
+	}
+	if gotContext != recipeContext {
+		t.Errorf("recipe context = %q, want the full context including the current-step note", gotContext)
+	}
+}
+
+func TestAnswerCookingQuestion_ErrorPropagates(t *testing.T) {
+	text := &testutil.MockTextProvider{
+		CookingQAFunc: func(ctx context.Context, question string, recipeContext string) (string, error) {
+			return "", errors.New("qa unavailable")
+		},
+	}
+
+	svc := NewVoiceService(&config.Config{}, text, nil)
+	answer, err := svc.AnswerCookingQuestion(context.Background(), "how long?", "")
+	if err == nil || !strings.Contains(err.Error(), "qa unavailable") {
+		t.Errorf("err = %v, want the provider error to propagate", err)
+	}
+	if answer != "" {
+		t.Errorf("answer = %q, want empty on error", answer)
+	}
+}

--- a/internal/testutil/mocks.go
+++ b/internal/testutil/mocks.go
@@ -581,7 +581,8 @@ type MockUserRepo struct {
 	Users  map[uint]*models.User
 	NextID uint
 
-	CreateUserErr error
+	CreateUserErr         error
+	CreateSubscriptionErr error
 }
 
 // NewMockUserRepo creates a new MockUserRepo with initialized maps.
@@ -718,6 +719,9 @@ func (m *MockUserRepo) IncrementTokenVersion(userID uint) error {
 }
 
 func (m *MockUserRepo) CreateSubscription(sub *models.Subscription) error {
+	if m.CreateSubscriptionErr != nil {
+		return m.CreateSubscriptionErr
+	}
 	m.mu.Lock()
 	defer m.mu.Unlock()
 

--- a/internal/testutil/mocks.go
+++ b/internal/testutil/mocks.go
@@ -147,14 +147,70 @@ type MockRecipeRepo struct {
 	NextNodeID uint
 
 	// Error overrides: set these to force specific methods to return errors.
-	CreateRecipeErr         error
-	GetRecipeByIDErr        error
-	DeleteRecipeErr         error
-	UpdateRecipeTitleErr    error
-	UpdateRecipeImageURLErr error
-	UpdateRecipeDefErr      error
-	CreateRecipeTreeErr     error
-	AddNodeToTreeErr        error
+	CreateRecipeErr                   error
+	GetRecipeByIDErr                  error
+	DeleteRecipeErr                   error
+	UpdateRecipeTitleErr              error
+	UpdateRecipeImageURLErr           error
+	UpdateRecipeDefErr                error
+	CreateRecipeTreeErr               error
+	AddNodeToTreeErr                  error
+	GetTreeByRecipeIDErr              error
+	GetTreeWithNodesErr               error
+	GetActiveNodeErr                  error
+	GetNodeByIDErr                    error
+	GetNodeAncestorsErr               error
+	SetActiveNodeErr                  error
+	UpdateRecipeFromNodeErr           error
+	MaterializeRecipeFromCanonicalErr error
+
+	// Call records (guarded by mu; read via the snapshot accessors). These
+	// survive recipe deletion, so tests can assert on transient state like a
+	// "failed" status set just before cleanup, or async image URL updates.
+	statusUpdates   []MockStatusUpdate
+	imageURLUpdates []MockImageURLUpdate
+}
+
+// MockStatusUpdate records a single UpdateRecipeStatus invocation.
+type MockStatusUpdate struct {
+	RecipeID uint
+	Status   string
+}
+
+// MockImageURLUpdate records a single UpdateRecipeImageURL invocation.
+type MockImageURLUpdate struct {
+	RecipeID uint
+	ImageURL string
+}
+
+// StatusUpdates returns a race-safe snapshot of UpdateRecipeStatus calls.
+func (m *MockRecipeRepo) StatusUpdates() []MockStatusUpdate {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	out := make([]MockStatusUpdate, len(m.statusUpdates))
+	copy(out, m.statusUpdates)
+	return out
+}
+
+// ImageURLUpdates returns a race-safe snapshot of UpdateRecipeImageURL calls.
+func (m *MockRecipeRepo) ImageURLUpdates() []MockImageURLUpdate {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	out := make([]MockImageURLUpdate, len(m.imageURLUpdates))
+	copy(out, m.imageURLUpdates)
+	return out
+}
+
+// RecipeSnapshot returns a race-safe copy of a stored recipe, or nil if absent.
+func (m *MockRecipeRepo) RecipeSnapshot(recipeID uint) *models.Recipe {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	r, ok := m.Recipes[recipeID]
+	if !ok {
+		return nil
+	}
+	cp := *r
+	return &cp
 }
 
 // NewMockRecipeRepo creates a new MockRecipeRepo with initialized maps.
@@ -261,6 +317,7 @@ func (m *MockRecipeRepo) UpdateRecipeStatus(recipeID uint, status string) error 
 	m.mu.Lock()
 	defer m.mu.Unlock()
 
+	m.statusUpdates = append(m.statusUpdates, MockStatusUpdate{RecipeID: recipeID, Status: status})
 	if r, ok := m.Recipes[recipeID]; ok {
 		r.Status = status
 	}
@@ -274,6 +331,7 @@ func (m *MockRecipeRepo) UpdateRecipeImageURL(recipeID uint, imageURL string) er
 	m.mu.Lock()
 	defer m.mu.Unlock()
 
+	m.imageURLUpdates = append(m.imageURLUpdates, MockImageURLUpdate{RecipeID: recipeID, ImageURL: imageURL})
 	if r, ok := m.Recipes[recipeID]; ok {
 		r.ImageURL = imageURL
 	}
@@ -352,6 +410,9 @@ func (m *MockRecipeRepo) CreateRecipeTree(recipeID uint, rootNode *models.Recipe
 }
 
 func (m *MockRecipeRepo) GetTreeByRecipeID(recipeID uint) (*models.RecipeTree, error) {
+	if m.GetTreeByRecipeIDErr != nil {
+		return nil, m.GetTreeByRecipeIDErr
+	}
 	m.mu.Lock()
 	defer m.mu.Unlock()
 
@@ -364,6 +425,9 @@ func (m *MockRecipeRepo) GetTreeByRecipeID(recipeID uint) (*models.RecipeTree, e
 }
 
 func (m *MockRecipeRepo) GetTreeWithNodes(treeID uint) (*models.RecipeTree, error) {
+	if m.GetTreeWithNodesErr != nil {
+		return nil, m.GetTreeWithNodesErr
+	}
 	m.mu.Lock()
 	defer m.mu.Unlock()
 
@@ -382,6 +446,9 @@ func (m *MockRecipeRepo) GetTreeWithNodes(treeID uint) (*models.RecipeTree, erro
 }
 
 func (m *MockRecipeRepo) GetActiveNode(treeID uint) (*models.RecipeNode, error) {
+	if m.GetActiveNodeErr != nil {
+		return nil, m.GetActiveNodeErr
+	}
 	m.mu.Lock()
 	defer m.mu.Unlock()
 
@@ -394,6 +461,9 @@ func (m *MockRecipeRepo) GetActiveNode(treeID uint) (*models.RecipeNode, error) 
 }
 
 func (m *MockRecipeRepo) GetNodeByID(nodeID uint) (*models.RecipeNode, error) {
+	if m.GetNodeByIDErr != nil {
+		return nil, m.GetNodeByIDErr
+	}
 	m.mu.Lock()
 	defer m.mu.Unlock()
 
@@ -418,6 +488,9 @@ func (m *MockRecipeRepo) GetNodeChildren(nodeID uint) ([]models.RecipeNode, erro
 }
 
 func (m *MockRecipeRepo) GetNodeAncestors(nodeID uint) ([]models.RecipeNode, error) {
+	if m.GetNodeAncestorsErr != nil {
+		return nil, m.GetNodeAncestorsErr
+	}
 	m.mu.Lock()
 	defer m.mu.Unlock()
 
@@ -459,6 +532,9 @@ func (m *MockRecipeRepo) AddNodeToTree(node *models.RecipeNode, setActive bool) 
 }
 
 func (m *MockRecipeRepo) SetActiveNode(treeID uint, nodeID uint) error {
+	if m.SetActiveNodeErr != nil {
+		return m.SetActiveNodeErr
+	}
 	m.mu.Lock()
 	defer m.mu.Unlock()
 
@@ -471,6 +547,9 @@ func (m *MockRecipeRepo) SetActiveNode(treeID uint, nodeID uint) error {
 }
 
 func (m *MockRecipeRepo) UpdateRecipeFromNode(recipeID uint, node *models.RecipeNode) error {
+	if m.UpdateRecipeFromNodeErr != nil {
+		return m.UpdateRecipeFromNodeErr
+	}
 	m.mu.Lock()
 	defer m.mu.Unlock()
 
@@ -481,6 +560,9 @@ func (m *MockRecipeRepo) UpdateRecipeFromNode(recipeID uint, node *models.Recipe
 }
 
 func (m *MockRecipeRepo) MaterializeRecipeFromCanonical(recipeID uint, data models.RecipeDef) error {
+	if m.MaterializeRecipeFromCanonicalErr != nil {
+		return m.MaterializeRecipeFromCanonicalErr
+	}
 	m.mu.Lock()
 	defer m.mu.Unlock()
 

--- a/internal/testutil/mocks.go
+++ b/internal/testutil/mocks.go
@@ -564,12 +564,26 @@ func (m *MockUserRepo) UpdateUserSettingsKeepScreenAwake(userID uint, keepScreen
 	return nil
 }
 
-func (m *MockUserRepo) UpdatePersonalization(userID uint, updatedPersonalization *models.Personalization) error {
+func (m *MockUserRepo) UpdatePersonalization(userID uint, update *models.PersonalizationUpdate) error {
 	m.mu.Lock()
 	defer m.mu.Unlock()
 
 	if u, ok := m.Users[userID]; ok {
-		u.Personalization = updatedPersonalization
+		if u.Personalization == nil {
+			u.Personalization = &models.Personalization{UserID: userID}
+		}
+		if update.UnitSystem != nil {
+			u.Personalization.UnitSystem = *update.UnitSystem
+		}
+		if update.Requirements != nil {
+			u.Personalization.Requirements = *update.Requirements
+		}
+		if update.CookingContext != nil {
+			u.Personalization.CookingContext = *update.CookingContext
+		}
+		if update.UID != nil {
+			u.Personalization.UID = *update.UID
+		}
 	}
 	return nil
 }

--- a/internal/testutil/mocks.go
+++ b/internal/testutil/mocks.go
@@ -522,6 +522,17 @@ func (m *MockUserRepo) GetUserByID(userID uint) (*models.User, error) {
 	return u, nil
 }
 
+func (m *MockUserRepo) GetUserWithAuthByID(userID uint) (*models.User, error) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	u, ok := m.Users[userID]
+	if !ok {
+		return nil, fmt.Errorf("user not found")
+	}
+	return u, nil
+}
+
 func (m *MockUserRepo) GetUserAuthByUsername(username string) (*models.User, error) {
 	m.mu.Lock()
 	defer m.mu.Unlock()
@@ -598,6 +609,66 @@ func (m *MockUserRepo) UsernameExists(username string) (bool, error) {
 		}
 	}
 	return false, nil
+}
+
+func (m *MockUserRepo) IncrementTokenVersion(userID uint) error {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	u, ok := m.Users[userID]
+	if !ok || u.Auth == nil {
+		return fmt.Errorf("no auth record found for user")
+	}
+	u.Auth.TokenVersion++
+	return nil
+}
+
+func (m *MockUserRepo) CreateSubscription(sub *models.Subscription) error {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	u, ok := m.Users[sub.UserID]
+	if !ok {
+		return fmt.Errorf("user not found")
+	}
+	u.Subscription = sub
+	return nil
+}
+
+func (m *MockUserRepo) IncrementSubscriptionUsage(userID uint, column string) error {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	u, ok := m.Users[userID]
+	if !ok || u.Subscription == nil {
+		return fmt.Errorf("no subscription found for user")
+	}
+	switch column {
+	case "allergen_analyses_used":
+		u.Subscription.AllergenAnalysesUsed++
+	case "web_searches_used":
+		u.Subscription.WebSearchesUsed++
+	case "ai_generations_used":
+		u.Subscription.AIGenerationsUsed++
+	default:
+		return fmt.Errorf("unknown usage column: %s", column)
+	}
+	return nil
+}
+
+func (m *MockUserRepo) ResetSubscriptionUsage(userID uint, nextReset time.Time) error {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	u, ok := m.Users[userID]
+	if !ok || u.Subscription == nil {
+		return fmt.Errorf("no subscription found for user")
+	}
+	u.Subscription.AllergenAnalysesUsed = 0
+	u.Subscription.WebSearchesUsed = 0
+	u.Subscription.AIGenerationsUsed = 0
+	u.Subscription.MonthlyResetAt = nextReset
+	return nil
 }
 
 // --- MockSearchProvider ---

--- a/internal/testutil/mocks.go
+++ b/internal/testutil/mocks.go
@@ -24,7 +24,7 @@ type MockTextProvider struct {
 	EstimatePortionsFunc        func(ctx context.Context, recipeDef interface{}) (*ai.PortionEstimate, error)
 	ExtractRecipeFromTextFunc   func(ctx context.Context, text string, unitSystem string) (*ai.RecipeResult, error)
 	CookingQAFunc               func(ctx context.Context, question string, recipeContext string) (string, error)
-	DietaryInterviewFunc        func(ctx context.Context, messages []ai.Message, memberName string) (string, error)
+	DietaryInterviewFunc        func(ctx context.Context, messages []ai.Message, memberName string) (*ai.DietaryInterviewResult, error)
 }
 
 func (m *MockTextProvider) GenerateRecipe(ctx context.Context, req ai.RecipeRequest) (*ai.RecipeResult, error) {
@@ -83,11 +83,11 @@ func (m *MockTextProvider) CookingQA(ctx context.Context, question string, recip
 	return "", fmt.Errorf("CookingQA not configured")
 }
 
-func (m *MockTextProvider) DietaryInterview(ctx context.Context, messages []ai.Message, memberName string) (string, error) {
+func (m *MockTextProvider) DietaryInterview(ctx context.Context, messages []ai.Message, memberName string) (*ai.DietaryInterviewResult, error) {
 	if m.DietaryInterviewFunc != nil {
 		return m.DietaryInterviewFunc(ctx, messages, memberName)
 	}
-	return "", fmt.Errorf("DietaryInterview not configured")
+	return nil, fmt.Errorf("DietaryInterview not configured")
 }
 
 // --- MockVisionProvider ---
@@ -765,6 +765,76 @@ func (m *MockSearchCacheRepo) DeleteStale(maxAge time.Duration) (int64, error) {
 	return 0, nil
 }
 
+// --- MockFamilyRepo ---
+
+// MockFamilyRepo mocks repository.FamilyRepo for testing.
+type MockFamilyRepo struct {
+	CreateFamilyFunc              func(family *models.Family) error
+	GetFamilyByOwnerIDFunc        func(ownerID uint) (*models.Family, error)
+	CreateFamilyMemberFunc        func(member *models.FamilyMember) error
+	GetFamilyMemberByIDFunc       func(id uint) (*models.FamilyMember, error)
+	UpdateFamilyMemberFunc        func(member *models.FamilyMember) error
+	DeleteFamilyMemberFunc        func(id uint) error
+	UpdateDietaryProfileFunc      func(profile *models.DietaryProfile) error
+	GetOrCreateDietaryProfileFunc func(memberID uint) (*models.DietaryProfile, error)
+}
+
+func (m *MockFamilyRepo) CreateFamily(family *models.Family) error {
+	if m.CreateFamilyFunc != nil {
+		return m.CreateFamilyFunc(family)
+	}
+	return nil
+}
+
+func (m *MockFamilyRepo) GetFamilyByOwnerID(ownerID uint) (*models.Family, error) {
+	if m.GetFamilyByOwnerIDFunc != nil {
+		return m.GetFamilyByOwnerIDFunc(ownerID)
+	}
+	return nil, fmt.Errorf("GetFamilyByOwnerID not configured")
+}
+
+func (m *MockFamilyRepo) CreateFamilyMember(member *models.FamilyMember) error {
+	if m.CreateFamilyMemberFunc != nil {
+		return m.CreateFamilyMemberFunc(member)
+	}
+	return nil
+}
+
+func (m *MockFamilyRepo) GetFamilyMemberByID(id uint) (*models.FamilyMember, error) {
+	if m.GetFamilyMemberByIDFunc != nil {
+		return m.GetFamilyMemberByIDFunc(id)
+	}
+	return nil, fmt.Errorf("GetFamilyMemberByID not configured")
+}
+
+func (m *MockFamilyRepo) UpdateFamilyMember(member *models.FamilyMember) error {
+	if m.UpdateFamilyMemberFunc != nil {
+		return m.UpdateFamilyMemberFunc(member)
+	}
+	return nil
+}
+
+func (m *MockFamilyRepo) DeleteFamilyMember(id uint) error {
+	if m.DeleteFamilyMemberFunc != nil {
+		return m.DeleteFamilyMemberFunc(id)
+	}
+	return nil
+}
+
+func (m *MockFamilyRepo) UpdateDietaryProfile(profile *models.DietaryProfile) error {
+	if m.UpdateDietaryProfileFunc != nil {
+		return m.UpdateDietaryProfileFunc(profile)
+	}
+	return nil
+}
+
+func (m *MockFamilyRepo) GetOrCreateDietaryProfile(memberID uint) (*models.DietaryProfile, error) {
+	if m.GetOrCreateDietaryProfileFunc != nil {
+		return m.GetOrCreateDietaryProfileFunc(memberID)
+	}
+	return &models.DietaryProfile{MemberID: memberID}, nil
+}
+
 // --- MockCanonicalRecipeRepo ---
 
 // MockCanonicalRecipeRepo mocks repository.CanonicalRecipeRepo for testing.
@@ -823,3 +893,4 @@ var _ repository.RecipeRepo = (*MockRecipeRepo)(nil)
 var _ repository.UserRepo = (*MockUserRepo)(nil)
 var _ repository.SearchCacheRepo = (*MockSearchCacheRepo)(nil)
 var _ repository.CanonicalRecipeRepo = (*MockCanonicalRecipeRepo)(nil)
+var _ repository.FamilyRepo = (*MockFamilyRepo)(nil)

--- a/internal/testutil/mocks.go
+++ b/internal/testutil/mocks.go
@@ -228,6 +228,18 @@ func (m *MockRecipeRepo) DeleteRecipe(recipeID uint) error {
 	m.mu.Lock()
 	defer m.mu.Unlock()
 
+	// Mirror the real repository: deleting a recipe also removes its tree and nodes.
+	for treeID, tree := range m.Trees {
+		if tree.RecipeID == recipeID {
+			for nodeID, node := range m.Nodes {
+				if node.TreeID == treeID {
+					delete(m.Nodes, nodeID)
+				}
+			}
+			delete(m.Trees, treeID)
+		}
+	}
+
 	delete(m.Recipes, recipeID)
 	return nil
 }

--- a/internal/testutil/mocks.go
+++ b/internal/testutil/mocks.go
@@ -122,12 +122,12 @@ func (m *MockImageProvider) GenerateImage(ctx context.Context, prompt string) ([
 
 // MockSpeechProvider is a mock implementation of ai.SpeechProvider.
 type MockSpeechProvider struct {
-	TranscribeAudioFunc func(ctx context.Context, audioData []byte) (string, error)
+	TranscribeAudioFunc func(ctx context.Context, audioData []byte, format string) (string, error)
 }
 
-func (m *MockSpeechProvider) TranscribeAudio(ctx context.Context, audioData []byte) (string, error) {
+func (m *MockSpeechProvider) TranscribeAudio(ctx context.Context, audioData []byte, format string) (string, error) {
 	if m.TranscribeAudioFunc != nil {
-		return m.TranscribeAudioFunc(ctx, audioData)
+		return m.TranscribeAudioFunc(ctx, audioData, format)
 	}
 	return "", fmt.Errorf("TranscribeAudio not configured")
 }

--- a/internal/testutil/mocks.go
+++ b/internal/testutil/mocks.go
@@ -16,15 +16,15 @@ import (
 
 // MockTextProvider is a mock implementation of ai.TextProvider.
 type MockTextProvider struct {
-	GenerateRecipeFunc          func(ctx context.Context, req ai.RecipeRequest) (*ai.RecipeResult, error)
-	RegenerateRecipeFunc        func(ctx context.Context, req ai.RegenerateRequest) (*ai.RecipeResult, error)
-	ForkRecipeFunc              func(ctx context.Context, req ai.ForkRequest) (*ai.RecipeResult, error)
-	AnalyzeAllergensFunc        func(ctx context.Context, req ai.AllergenRequest) (*ai.AllergenResult, error)
-	ClassifyVoiceIntentFunc     func(ctx context.Context, transcript string) (*ai.VoiceIntent, error)
-	EstimatePortionsFunc        func(ctx context.Context, recipeDef interface{}) (*ai.PortionEstimate, error)
-	ExtractRecipeFromTextFunc   func(ctx context.Context, text string, unitSystem string) (*ai.RecipeResult, error)
-	CookingQAFunc               func(ctx context.Context, question string, recipeContext string) (string, error)
-	DietaryInterviewFunc        func(ctx context.Context, messages []ai.Message, memberName string) (*ai.DietaryInterviewResult, error)
+	GenerateRecipeFunc        func(ctx context.Context, req ai.RecipeRequest) (*ai.RecipeResult, error)
+	RegenerateRecipeFunc      func(ctx context.Context, req ai.RegenerateRequest) (*ai.RecipeResult, error)
+	ForkRecipeFunc            func(ctx context.Context, req ai.ForkRequest) (*ai.RecipeResult, error)
+	AnalyzeAllergensFunc      func(ctx context.Context, req ai.AllergenRequest) (*ai.AllergenResult, error)
+	ClassifyVoiceIntentFunc   func(ctx context.Context, transcript string) (*ai.VoiceIntent, error)
+	EstimatePortionsFunc      func(ctx context.Context, recipeDef interface{}) (*ai.PortionEstimate, error)
+	ExtractRecipeFromTextFunc func(ctx context.Context, text string, unitSystem string) (*ai.RecipeResult, error)
+	CookingQAFunc             func(ctx context.Context, question string, recipeContext string) (string, error)
+	DietaryInterviewFunc      func(ctx context.Context, messages []ai.Message, memberName string) (*ai.DietaryInterviewResult, error)
 }
 
 func (m *MockTextProvider) GenerateRecipe(ctx context.Context, req ai.RecipeRequest) (*ai.RecipeResult, error) {
@@ -136,25 +136,25 @@ func (m *MockSpeechProvider) TranscribeAudio(ctx context.Context, audioData []by
 
 // MockRecipeRepo is an in-memory mock implementation of repository.RecipeRepo.
 type MockRecipeRepo struct {
-	mu       sync.Mutex
-	Recipes  map[uint]*models.Recipe
-	Tags     map[string]*models.Tag
-	Trees    map[uint]*models.RecipeTree
-	Nodes    map[uint]*models.RecipeNode
-	NextID   uint
-	NextTagID uint
+	mu         sync.Mutex
+	Recipes    map[uint]*models.Recipe
+	Tags       map[string]*models.Tag
+	Trees      map[uint]*models.RecipeTree
+	Nodes      map[uint]*models.RecipeNode
+	NextID     uint
+	NextTagID  uint
 	NextTreeID uint
 	NextNodeID uint
 
 	// Error overrides: set these to force specific methods to return errors.
-	CreateRecipeErr              error
-	GetRecipeByIDErr             error
-	DeleteRecipeErr              error
-	UpdateRecipeTitleErr         error
-	UpdateRecipeImageURLErr      error
-	UpdateRecipeDefErr           error
-	CreateRecipeTreeErr          error
-	AddNodeToTreeErr             error
+	CreateRecipeErr         error
+	GetRecipeByIDErr        error
+	DeleteRecipeErr         error
+	UpdateRecipeTitleErr    error
+	UpdateRecipeImageURLErr error
+	UpdateRecipeDefErr      error
+	CreateRecipeTreeErr     error
+	AddNodeToTreeErr        error
 }
 
 // NewMockRecipeRepo creates a new MockRecipeRepo with initialized maps.

--- a/internal/testutil/mocks_allergen.go
+++ b/internal/testutil/mocks_allergen.go
@@ -1,0 +1,53 @@
+package testutil
+
+import (
+	"github.com/windoze95/saltybytes-api/internal/models"
+	"github.com/windoze95/saltybytes-api/internal/repository"
+)
+
+// MockAllergenRepo mocks repository.AllergenRepo for testing.
+type MockAllergenRepo struct {
+	CreateAnalysisFunc           func(analysis *models.AllergenAnalysis) error
+	GetAnalysisByRecipeIDFunc    func(recipeID uint) (*models.AllergenAnalysis, error)
+	GetAnalysisByNodeIDFunc      func(nodeID uint) (*models.AllergenAnalysis, error)
+	UpdateAnalysisFunc           func(analysis *models.AllergenAnalysis) error
+	DeleteAnalysisByRecipeIDFunc func(recipeID uint) error
+}
+
+func (m *MockAllergenRepo) CreateAnalysis(analysis *models.AllergenAnalysis) error {
+	if m.CreateAnalysisFunc != nil {
+		return m.CreateAnalysisFunc(analysis)
+	}
+	return nil
+}
+
+func (m *MockAllergenRepo) GetAnalysisByRecipeID(recipeID uint) (*models.AllergenAnalysis, error) {
+	if m.GetAnalysisByRecipeIDFunc != nil {
+		return m.GetAnalysisByRecipeIDFunc(recipeID)
+	}
+	return nil, repository.NotFoundError{}
+}
+
+func (m *MockAllergenRepo) GetAnalysisByNodeID(nodeID uint) (*models.AllergenAnalysis, error) {
+	if m.GetAnalysisByNodeIDFunc != nil {
+		return m.GetAnalysisByNodeIDFunc(nodeID)
+	}
+	return nil, repository.NotFoundError{}
+}
+
+func (m *MockAllergenRepo) UpdateAnalysis(analysis *models.AllergenAnalysis) error {
+	if m.UpdateAnalysisFunc != nil {
+		return m.UpdateAnalysisFunc(analysis)
+	}
+	return nil
+}
+
+func (m *MockAllergenRepo) DeleteAnalysisByRecipeID(recipeID uint) error {
+	if m.DeleteAnalysisByRecipeIDFunc != nil {
+		return m.DeleteAnalysisByRecipeIDFunc(recipeID)
+	}
+	return nil
+}
+
+// Compile-time interface check.
+var _ repository.AllergenRepo = (*MockAllergenRepo)(nil)

--- a/internal/testutil/mocks_stream.go
+++ b/internal/testutil/mocks_stream.go
@@ -1,0 +1,29 @@
+package testutil
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/windoze95/saltybytes-api/internal/ai"
+)
+
+// --- MockStreamingTextProvider ---
+
+// MockStreamingTextProvider is a mock implementation of ai.StreamingTextProvider.
+// It embeds MockTextProvider for the synchronous TextProvider surface and adds
+// the streaming entry point. Use a plain MockTextProvider when a test needs a
+// provider that does NOT support streaming (to exercise the sync fallback).
+type MockStreamingTextProvider struct {
+	MockTextProvider
+	StreamGenerateRecipeFunc func(ctx context.Context, req ai.RecipeRequest, events chan<- ai.StreamEvent) (*ai.RecipeResult, error)
+}
+
+func (m *MockStreamingTextProvider) StreamGenerateRecipe(ctx context.Context, req ai.RecipeRequest, events chan<- ai.StreamEvent) (*ai.RecipeResult, error) {
+	if m.StreamGenerateRecipeFunc != nil {
+		return m.StreamGenerateRecipeFunc(ctx, req, events)
+	}
+	return nil, fmt.Errorf("StreamGenerateRecipe not configured")
+}
+
+// Compile-time interface check.
+var _ ai.StreamingTextProvider = (*MockStreamingTextProvider)(nil)

--- a/internal/testutil/mocks_vector.go
+++ b/internal/testutil/mocks_vector.go
@@ -1,0 +1,95 @@
+package testutil
+
+import (
+	"fmt"
+
+	"github.com/windoze95/saltybytes-api/internal/models"
+	"github.com/windoze95/saltybytes-api/internal/repository"
+)
+
+// --- MockVectorRepo ---
+
+// MockVectorRepo is a mock implementation of repository.VectorRepo.
+// Set the Func fields to control behavior; unset funcs return zero values
+// (or an error where a result is required).
+type MockVectorRepo struct {
+	FindSimilarFunc                  func(embeddingLiteral string, excludeRecipeID uint, limit int) ([]models.Recipe, error)
+	GetRecipeEmbeddingFunc           func(recipeID uint) (*string, error)
+	UpdateEmbeddingFunc              func(recipeID uint, embedding []float32) error
+	SearchUserRecipesByEmbeddingFunc func(userID uint, embeddingLiteral string, limit int) ([]models.Recipe, error)
+	SearchUserRecipesByTitleFunc     func(userID uint, query string, onlyMissingEmbedding bool, limit int) ([]models.Recipe, error)
+
+	// Call records for assertions.
+	FindSimilarCalls                  []MockFindSimilarCall
+	UpdateEmbeddingCalls              []uint
+	GetRecipeEmbeddingCalls           []uint
+	SearchUserRecipesByEmbeddingCalls []uint
+	SearchUserRecipesByTitleCalls     []MockTitleSearchCall
+}
+
+// MockFindSimilarCall records the arguments of a FindSimilar invocation.
+type MockFindSimilarCall struct {
+	EmbeddingLiteral string
+	ExcludeRecipeID  uint
+	Limit            int
+}
+
+// MockTitleSearchCall records the arguments of a SearchUserRecipesByTitle invocation.
+type MockTitleSearchCall struct {
+	UserID               uint
+	Query                string
+	OnlyMissingEmbedding bool
+	Limit                int
+}
+
+func (m *MockVectorRepo) FindSimilar(embeddingLiteral string, excludeRecipeID uint, limit int) ([]models.Recipe, error) {
+	m.FindSimilarCalls = append(m.FindSimilarCalls, MockFindSimilarCall{
+		EmbeddingLiteral: embeddingLiteral,
+		ExcludeRecipeID:  excludeRecipeID,
+		Limit:            limit,
+	})
+	if m.FindSimilarFunc != nil {
+		return m.FindSimilarFunc(embeddingLiteral, excludeRecipeID, limit)
+	}
+	return []models.Recipe{}, nil
+}
+
+func (m *MockVectorRepo) GetRecipeEmbedding(recipeID uint) (*string, error) {
+	m.GetRecipeEmbeddingCalls = append(m.GetRecipeEmbeddingCalls, recipeID)
+	if m.GetRecipeEmbeddingFunc != nil {
+		return m.GetRecipeEmbeddingFunc(recipeID)
+	}
+	return nil, fmt.Errorf("GetRecipeEmbedding not configured")
+}
+
+func (m *MockVectorRepo) UpdateEmbedding(recipeID uint, embedding []float32) error {
+	m.UpdateEmbeddingCalls = append(m.UpdateEmbeddingCalls, recipeID)
+	if m.UpdateEmbeddingFunc != nil {
+		return m.UpdateEmbeddingFunc(recipeID, embedding)
+	}
+	return nil
+}
+
+func (m *MockVectorRepo) SearchUserRecipesByEmbedding(userID uint, embeddingLiteral string, limit int) ([]models.Recipe, error) {
+	m.SearchUserRecipesByEmbeddingCalls = append(m.SearchUserRecipesByEmbeddingCalls, userID)
+	if m.SearchUserRecipesByEmbeddingFunc != nil {
+		return m.SearchUserRecipesByEmbeddingFunc(userID, embeddingLiteral, limit)
+	}
+	return []models.Recipe{}, nil
+}
+
+func (m *MockVectorRepo) SearchUserRecipesByTitle(userID uint, query string, onlyMissingEmbedding bool, limit int) ([]models.Recipe, error) {
+	m.SearchUserRecipesByTitleCalls = append(m.SearchUserRecipesByTitleCalls, MockTitleSearchCall{
+		UserID:               userID,
+		Query:                query,
+		OnlyMissingEmbedding: onlyMissingEmbedding,
+		Limit:                limit,
+	})
+	if m.SearchUserRecipesByTitleFunc != nil {
+		return m.SearchUserRecipesByTitleFunc(userID, query, onlyMissingEmbedding, limit)
+	}
+	return []models.Recipe{}, nil
+}
+
+// Compile-time interface check.
+var _ repository.VectorRepo = (*MockVectorRepo)(nil)

--- a/internal/util/context_utils_test.go
+++ b/internal/util/context_utils_test.go
@@ -1,0 +1,106 @@
+package util
+
+import (
+	"net/http/httptest"
+	"testing"
+
+	"github.com/gin-gonic/gin"
+	"github.com/windoze95/saltybytes-api/internal/models"
+)
+
+func newTestGinContext() *gin.Context {
+	gin.SetMode(gin.TestMode)
+	c, _ := gin.CreateTestContext(httptest.NewRecorder())
+	return c
+}
+
+func TestGetUserFromContext_Present(t *testing.T) {
+	c := newTestGinContext()
+	want := &models.User{Username: "chef"}
+	c.Set("user", want)
+
+	got, err := GetUserFromContext(c)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if got != want {
+		t.Errorf("GetUserFromContext returned %p, want the same pointer %p", got, want)
+	}
+}
+
+func TestGetUserFromContext_Absent(t *testing.T) {
+	c := newTestGinContext()
+
+	got, err := GetUserFromContext(c)
+	if err == nil {
+		t.Fatal("expected error when no user is set, got nil")
+	}
+	if got != nil {
+		t.Errorf("expected nil user, got %+v", got)
+	}
+	if err.Error() != "no user information" {
+		t.Errorf("error = %q, want 'no user information'", err.Error())
+	}
+}
+
+func TestGetUserFromContext_WrongType(t *testing.T) {
+	c := newTestGinContext()
+	// A value user (not *models.User) must be rejected.
+	c.Set("user", models.User{Username: "chef"})
+
+	got, err := GetUserFromContext(c)
+	if err == nil {
+		t.Fatal("expected error for wrong-typed user value, got nil")
+	}
+	if got != nil {
+		t.Errorf("expected nil user, got %+v", got)
+	}
+	if err.Error() != "user information is of the wrong type" {
+		t.Errorf("error = %q, want 'user information is of the wrong type'", err.Error())
+	}
+}
+
+func TestGetUserIDFromContext_Present(t *testing.T) {
+	c := newTestGinContext()
+	c.Set("user_id", uint(42))
+
+	got, err := GetUserIDFromContext(c)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if got != 42 {
+		t.Errorf("GetUserIDFromContext = %d, want 42", got)
+	}
+}
+
+func TestGetUserIDFromContext_Absent(t *testing.T) {
+	c := newTestGinContext()
+
+	got, err := GetUserIDFromContext(c)
+	if err == nil {
+		t.Fatal("expected error when no user_id is set, got nil")
+	}
+	if got != 0 {
+		t.Errorf("expected zero user ID, got %d", got)
+	}
+	if err.Error() != "no user ID information" {
+		t.Errorf("error = %q, want 'no user ID information'", err.Error())
+	}
+}
+
+func TestGetUserIDFromContext_WrongType(t *testing.T) {
+	c := newTestGinContext()
+	// An int (not uint) must be rejected.
+	c.Set("user_id", 42)
+
+	got, err := GetUserIDFromContext(c)
+	if err == nil {
+		t.Fatal("expected error for wrong-typed user_id, got nil")
+	}
+	if got != 0 {
+		t.Errorf("expected zero user ID, got %d", got)
+	}
+	if err.Error() != "user ID information is of the wrong type" {
+		t.Errorf("error = %q, want 'user ID information is of the wrong type'", err.Error())
+	}
+}

--- a/internal/util/json_test.go
+++ b/internal/util/json_test.go
@@ -1,0 +1,96 @@
+package util
+
+import (
+	"strings"
+	"testing"
+)
+
+type jsonSample struct {
+	Name  string `json:"name"`
+	Count int    `json:"count"`
+}
+
+func TestSerializeToJSONString_Struct(t *testing.T) {
+	got, err := SerializeToJSONString(jsonSample{Name: "salt", Count: 3})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	want := `{"name":"salt","count":3}`
+	if got != want {
+		t.Errorf("SerializeToJSONString = %q, want %q", got, want)
+	}
+}
+
+func TestSerializeToJSONString_UnsupportedType(t *testing.T) {
+	if _, err := SerializeToJSONString(make(chan int)); err == nil {
+		t.Error("expected error serializing a channel, got nil")
+	}
+}
+
+func TestSerializeToJSONStringWithBuffer_AppendsNewline(t *testing.T) {
+	got, err := SerializeToJSONStringWithBuffer(jsonSample{Name: "pepper", Count: 1})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	// json.Encoder always terminates each value with a newline.
+	if !strings.HasSuffix(got, "\n") {
+		t.Errorf("expected trailing newline from encoder, got %q", got)
+	}
+	want := `{"name":"pepper","count":1}`
+	if strings.TrimSpace(got) != want {
+		t.Errorf("SerializeToJSONStringWithBuffer = %q, want %q (plus newline)", got, want)
+	}
+}
+
+func TestSerializeToJSONStringWithBuffer_UnsupportedType(t *testing.T) {
+	if _, err := SerializeToJSONStringWithBuffer(func() {}); err == nil {
+		t.Error("expected error serializing a func, got nil")
+	}
+}
+
+func TestDeserializeFromJSONString_RoundTrip(t *testing.T) {
+	in := jsonSample{Name: "cumin", Count: 7}
+	s, err := SerializeToJSONString(in)
+	if err != nil {
+		t.Fatalf("serialize: %v", err)
+	}
+
+	var out jsonSample
+	if err := DeserializeFromJSONString(s, &out); err != nil {
+		t.Fatalf("deserialize: %v", err)
+	}
+	if out != in {
+		t.Errorf("round trip = %+v, want %+v", out, in)
+	}
+}
+
+func TestDeserializeFromJSONString_NonPointerRejected(t *testing.T) {
+	tests := []struct {
+		name   string
+		target interface{}
+	}{
+		{"struct value", jsonSample{}},
+		{"string value", "not a pointer"},
+		{"int value", 42},
+		{"nil interface", nil},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			err := DeserializeFromJSONString(`{"name":"x"}`, tc.target)
+			if err == nil {
+				t.Fatal("expected error for non-pointer target, got nil")
+			}
+			if err.Error() != "input must be a pointer" {
+				t.Errorf("error = %q, want 'input must be a pointer'", err.Error())
+			}
+		})
+	}
+}
+
+func TestDeserializeFromJSONString_InvalidJSON(t *testing.T) {
+	var out jsonSample
+	if err := DeserializeFromJSONString(`{"name": broken`, &out); err == nil {
+		t.Error("expected error for malformed JSON, got nil")
+	}
+}

--- a/internal/util/recover.go
+++ b/internal/util/recover.go
@@ -1,0 +1,24 @@
+package util
+
+import (
+	"runtime/debug"
+
+	"github.com/windoze95/saltybytes-api/internal/logger"
+	"go.uber.org/zap"
+)
+
+// RecoverPanic logs and swallows a panic in a detached goroutine. Gin's
+// Recovery middleware only protects request-handler goroutines, so background
+// goroutines (AI generation, websocket dispatch, embedding refresh) must
+// recover themselves or a single panic takes down the whole process.
+//
+// Usage: defer util.RecoverPanic("scope description")
+func RecoverPanic(scope string) {
+	if r := recover(); r != nil {
+		logger.Get().Error("panic recovered in background goroutine",
+			zap.String("scope", scope),
+			zap.Any("panic", r),
+			zap.ByteString("stack", debug.Stack()),
+		)
+	}
+}

--- a/internal/util/recover_test.go
+++ b/internal/util/recover_test.go
@@ -1,0 +1,59 @@
+package util
+
+import (
+	"errors"
+	"testing"
+	"time"
+)
+
+func TestRecoverPanic_SwallowsPanicAndAllowsReturn(t *testing.T) {
+	reached := false
+	func() {
+		defer RecoverPanic("unit test scope")
+		reached = true
+		panic(errors.New("kaboom"))
+	}()
+
+	if !reached {
+		t.Fatal("function body did not run")
+	}
+	// Reaching this line at all proves the panic was recovered.
+}
+
+func TestRecoverPanic_NoPanicIsNoOp(t *testing.T) {
+	func() {
+		defer RecoverPanic("calm scope")
+	}()
+	// Nothing to assert: RecoverPanic must not itself panic or log spuriously
+	// when there is no panic in flight.
+}
+
+func TestRecoverPanic_ProtectsBackgroundGoroutine(t *testing.T) {
+	done := make(chan struct{})
+
+	go func() {
+		defer close(done)
+		defer RecoverPanic("background goroutine")
+		panic("goroutine panic")
+	}()
+
+	// If RecoverPanic failed to recover, the unrecovered panic would crash the
+	// whole test process, so completing this wait is the assertion.
+	select {
+	case <-done:
+	case <-time.After(2 * time.Second):
+		t.Fatal("goroutine did not finish")
+	}
+}
+
+func TestRecoverPanic_NonErrorPanicValue(t *testing.T) {
+	func() {
+		defer RecoverPanic("string panic scope")
+		panic("plain string panic")
+	}()
+
+	func() {
+		defer RecoverPanic("int panic scope")
+		panic(42)
+	}()
+}

--- a/internal/ws/cooking.go
+++ b/internal/ws/cooking.go
@@ -16,6 +16,7 @@ import (
 	"github.com/windoze95/saltybytes-api/internal/logger"
 	"github.com/windoze95/saltybytes-api/internal/models"
 	"github.com/windoze95/saltybytes-api/internal/service"
+	"github.com/windoze95/saltybytes-api/internal/util"
 	"go.uber.org/zap"
 )
 
@@ -318,6 +319,10 @@ func (ch *CookingHandler) dispatchAsync(client *Client, payload json.RawMessage,
 	}
 	go func() {
 		defer client.releaseHandlerSlot()
+		// Recover here: gin's Recovery middleware does not cover detached
+		// goroutines, so a panic in one session's handler would otherwise
+		// crash the whole process.
+		defer util.RecoverPanic("cooking ws async handler")
 		handler(client, payload)
 	}()
 }

--- a/internal/ws/cooking.go
+++ b/internal/ws/cooking.go
@@ -3,6 +3,7 @@ package ws
 import (
 	"context"
 	"encoding/json"
+	"fmt"
 	"net/http"
 	"strconv"
 	"strings"
@@ -30,6 +31,9 @@ const (
 	MsgTypeNavigateCommand = "navigate_command" // Voice-driven navigation
 	MsgTypeError           = "error"            // Error message
 	MsgTypeConnected       = "connected"        // Connection confirmed
+	MsgTypeStepChange      = "step_change"      // User moved to a different recipe step
+	MsgTypePing            = "ping"             // Client keepalive probe
+	MsgTypePong            = "pong"             // Server keepalive reply
 )
 
 // WSMessage is the envelope for all messages sent over the cooking WebSocket.
@@ -55,10 +59,19 @@ type EphemeralEditPayload struct {
 	Modification string `json:"modification"`
 }
 
-// VoiceTranscriptPayload carries a transcription from audio input.
+// VoiceTranscriptPayload carries a transcription from audio input. When
+// Transcript is set (on-device STT), Whisper is skipped and the text goes
+// straight to intent classification. Otherwise AudioData is transcribed
+// first; Format optionally names its container format (e.g. "webm", "m4a").
 type VoiceTranscriptPayload struct {
 	Transcript string `json:"transcript"`
 	AudioData  []byte `json:"audio_data,omitempty"` // base64-encoded
+	Format     string `json:"format,omitempty"`     // audio format for AudioData; defaults to webm
+}
+
+// StepChangePayload reports which recipe step the user is currently viewing.
+type StepChangePayload struct {
+	Step int `json:"step"`
 }
 
 // VoiceIntentPayload carries the classified intent of a voice command.
@@ -118,6 +131,12 @@ func NewCookingHandler(hub *Hub, jwtSecret string, voiceService *service.VoiceSe
 var upgrader = websocket.Upgrader{
 	CheckOrigin: func(r *http.Request) bool {
 		origin := r.Header.Get("Origin")
+		// Non-browser clients (e.g. the Flutter app's WebSocketChannel) send
+		// no Origin header. Allow them; session auth is still enforced via
+		// the ?token= query parameter.
+		if origin == "" {
+			return true
+		}
 		switch origin {
 		case "https://saltybytes.ai",
 			"https://www.saltybytes.ai",
@@ -205,13 +224,7 @@ func (ch *CookingHandler) HandleCookingSession(c *gin.Context) {
 	}
 
 	// Create client and register with hub
-	client := &Client{
-		Hub:    ch.Hub,
-		Conn:   conn,
-		Send:   make(chan []byte, 256),
-		RoomID: recipeID,
-		UserID: userID,
-	}
+	client := NewClient(ch.Hub, conn, recipeID, userID)
 	ch.Hub.Register <- client
 
 	// Send connected confirmation
@@ -223,7 +236,7 @@ func (ch *CookingHandler) HandleCookingSession(c *gin.Context) {
 		Type:    MsgTypeConnected,
 		Payload: connectedPayload,
 	})
-	client.Send <- connectedMsg
+	client.TrySend(connectedMsg)
 
 	log.Info("cooking session started",
 		zap.String("recipe_id", recipeID),
@@ -256,7 +269,9 @@ func (ch *CookingHandler) handleMessage(client *Client, data []byte) {
 
 	switch msg.Type {
 	case MsgTypeChatMessage:
-		ch.handleChatMessage(client, msg.Payload)
+		// Slow (AI round-trip): run async so the read pump keeps draining
+		// cheap messages like step_change and ephemeral edits.
+		ch.dispatchAsync(client, msg.Payload, ch.handleChatMessage)
 
 	case MsgTypeEphemeralEdit:
 		// Broadcast ephemeral edit to all clients in the room
@@ -275,11 +290,67 @@ func (ch *CookingHandler) handleMessage(client *Client, data []byte) {
 		}
 
 	case MsgTypeVoiceTranscript:
-		ch.handleVoiceTranscript(client, msg.Payload)
+		// Slow (Whisper and/or AI round-trip): run async.
+		ch.dispatchAsync(client, msg.Payload, ch.handleVoiceTranscript)
+
+	case MsgTypeStepChange:
+		ch.handleStepChange(client, msg.Payload)
+
+	case MsgTypePing:
+		pongMsg, _ := json.Marshal(WSMessage{
+			Type:    MsgTypePong,
+			Payload: json.RawMessage(`{}`),
+		})
+		client.TrySend(pongMsg)
 
 	default:
 		ch.sendError(client, "unknown message type: "+msg.Type)
 	}
+}
+
+// dispatchAsync runs a potentially slow handler (cooking QA, voice
+// processing) in its own goroutine so it doesn't block the client's read
+// pump. Concurrency is bounded per client; excess requests are rejected.
+func (ch *CookingHandler) dispatchAsync(client *Client, payload json.RawMessage, handler func(*Client, json.RawMessage)) {
+	if !client.tryAcquireHandlerSlot() {
+		ch.sendError(client, "too many requests in flight; please wait")
+		return
+	}
+	go func() {
+		defer client.releaseHandlerSlot()
+		handler(client, payload)
+	}()
+}
+
+// handleStepChange records the recipe step the user is currently viewing so
+// subsequent cooking QA answers can use it as context.
+func (ch *CookingHandler) handleStepChange(client *Client, payload json.RawMessage) {
+	var stepChange StepChangePayload
+	if err := json.Unmarshal(payload, &stepChange); err != nil {
+		ch.sendError(client, "invalid step change payload")
+		return
+	}
+
+	if stepChange.Step < 0 {
+		ch.sendError(client, "step must be non-negative")
+		return
+	}
+
+	client.SetCurrentStep(stepChange.Step)
+}
+
+// recipeContextWithStep appends the client's current step (if known) to the
+// recipe context so the AI can answer relative to where the user is.
+func recipeContextWithStep(client *Client, recipeContext string) string {
+	step, ok := client.CurrentStep()
+	if !ok {
+		return recipeContext
+	}
+	stepNote := fmt.Sprintf("The user is currently on step %d.", step)
+	if recipeContext == "" {
+		return stepNote
+	}
+	return recipeContext + "\n\n" + stepNote
 }
 
 // handleChatMessage processes a cooking Q&A question.
@@ -305,7 +376,7 @@ func (ch *CookingHandler) handleChatMessage(client *Client, payload json.RawMess
 		zap.Uint("user_id", client.UserID),
 	)
 
-	answer, err := ch.VoiceService.AnswerCookingQuestion(ctx, chatMsg.Message, chatMsg.RecipeContext)
+	answer, err := ch.VoiceService.AnswerCookingQuestion(ctx, chatMsg.Message, recipeContextWithStep(client, chatMsg.RecipeContext))
 	if err != nil {
 		log.Error("failed to get cooking answer",
 			zap.String("room_id", client.RoomID),
@@ -323,7 +394,7 @@ func (ch *CookingHandler) handleChatMessage(client *Client, payload json.RawMess
 		Type:    MsgTypeChatResponse,
 		Payload: responsePayload,
 	})
-	client.Send <- responseMsg
+	client.TrySend(responseMsg)
 }
 
 // handleVoiceTranscript processes a voice transcription.
@@ -352,7 +423,7 @@ func (ch *CookingHandler) handleVoiceTranscript(client *Client, payload json.Raw
 			zap.String("room_id", client.RoomID),
 			zap.Uint("user_id", client.UserID),
 		)
-		intent, err = ch.VoiceService.ProcessVoiceCommand(ctx, transcript.AudioData)
+		intent, err = ch.VoiceService.ProcessVoiceCommand(ctx, transcript.AudioData, transcript.Format)
 	} else {
 		log.Info("classifying voice intent from text",
 			zap.String("room_id", client.RoomID),
@@ -381,7 +452,7 @@ func (ch *CookingHandler) handleVoiceTranscript(client *Client, payload json.Raw
 		Type:    MsgTypeVoiceIntent,
 		Payload: intentPayload,
 	})
-	client.Send <- intentMsg
+	client.TrySend(intentMsg)
 
 	// Map intent to specific command messages
 	switch intent.Type {
@@ -398,7 +469,7 @@ func (ch *CookingHandler) handleVoiceTranscript(client *Client, payload json.Raw
 			Type:    MsgTypeScrollCommand,
 			Payload: scrollPayload,
 		})
-		client.Send <- scrollMsg
+		client.TrySend(scrollMsg)
 
 	case "navigate":
 		navPayload, _ := json.Marshal(NavigateCommandPayload{
@@ -408,10 +479,10 @@ func (ch *CookingHandler) handleVoiceTranscript(client *Client, payload json.Raw
 			Type:    MsgTypeNavigateCommand,
 			Payload: navPayload,
 		})
-		client.Send <- navMsg
+		client.TrySend(navMsg)
 
 	case "question":
-		answer, err := ch.VoiceService.AnswerCookingQuestion(ctx, intent.Text, "")
+		answer, err := ch.VoiceService.AnswerCookingQuestion(ctx, intent.Text, recipeContextWithStep(client, ""))
 		if err != nil {
 			log.Error("failed to answer voice question",
 				zap.String("room_id", client.RoomID),
@@ -428,7 +499,7 @@ func (ch *CookingHandler) handleVoiceTranscript(client *Client, payload json.Raw
 			Type:    MsgTypeChatResponse,
 			Payload: chatPayload,
 		})
-		client.Send <- chatMsg
+		client.TrySend(chatMsg)
 
 	case "ignore":
 		// Do nothing
@@ -450,5 +521,5 @@ func (ch *CookingHandler) sendError(client *Client, message string) {
 		Type:    MsgTypeError,
 		Payload: errPayload,
 	})
-	client.Send <- errMsg
+	client.TrySend(errMsg)
 }

--- a/internal/ws/cooking_test.go
+++ b/internal/ws/cooking_test.go
@@ -4,6 +4,9 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"strings"
 	"testing"
 	"time"
 
@@ -30,12 +33,7 @@ func setupTestCookingHandler() (*CookingHandler, *testutil.MockTextProvider, *te
 // websocket.Conn. This works because the handler methods write to client.Send
 // rather than Conn directly.
 func newTestClient(hub *Hub, roomID string, userID uint) *Client {
-	return &Client{
-		Hub:    hub,
-		Send:   make(chan []byte, 256),
-		RoomID: roomID,
-		UserID: userID,
-	}
+	return NewClient(hub, nil, roomID, userID)
 }
 
 // readMessage reads a single WSMessage from the client's Send channel with a
@@ -150,9 +148,12 @@ func TestHandleVoiceTranscript_WithAudioData(t *testing.T) {
 	ch, mockText, mockSpeech := setupTestCookingHandler()
 	client := newTestClient(ch.Hub, "recipe-1", 42)
 
-	mockSpeech.TranscribeAudioFunc = func(ctx context.Context, audioData []byte) (string, error) {
+	mockSpeech.TranscribeAudioFunc = func(ctx context.Context, audioData []byte, format string) (string, error) {
 		if string(audioData) != "fake-audio-bytes" {
 			t.Errorf("unexpected audio data: %q", string(audioData))
+		}
+		if format != "" {
+			t.Errorf("expected empty format, got %q", format)
 		}
 		return "scroll down please", nil
 	}
@@ -499,6 +500,304 @@ func TestHandleMessage_RoutesVoiceTranscript(t *testing.T) {
 	if msg.Type != MsgTypeVoiceIntent {
 		t.Fatalf("expected type %q, got %q", MsgTypeVoiceIntent, msg.Type)
 	}
+}
+
+// --- ping / pong tests ---
+
+func TestHandleMessage_PingPong(t *testing.T) {
+	ch, _, _ := setupTestCookingHandler()
+	client := newTestClient(ch.Hub, "recipe-1", 42)
+
+	data, _ := json.Marshal(WSMessage{
+		Type:    MsgTypePing,
+		Payload: json.RawMessage(`{}`),
+	})
+	ch.handleMessage(client, data)
+
+	msg := readMessage(t, client)
+	if msg.Type != MsgTypePong {
+		t.Fatalf("expected type %q, got %q", MsgTypePong, msg.Type)
+	}
+	assertNoMoreMessages(t, client)
+}
+
+func TestHandleMessage_PingWithoutPayload(t *testing.T) {
+	ch, _, _ := setupTestCookingHandler()
+	client := newTestClient(ch.Hub, "recipe-1", 42)
+
+	ch.handleMessage(client, []byte(`{"type":"ping"}`))
+
+	msg := readMessage(t, client)
+	if msg.Type != MsgTypePong {
+		t.Fatalf("expected type %q, got %q", MsgTypePong, msg.Type)
+	}
+}
+
+// --- step_change tests ---
+
+func TestHandleMessage_StepChange_UpdatesClientState(t *testing.T) {
+	ch, _, _ := setupTestCookingHandler()
+	client := newTestClient(ch.Hub, "recipe-1", 42)
+
+	if _, ok := client.CurrentStep(); ok {
+		t.Fatal("expected no current step before step_change")
+	}
+
+	payload, _ := json.Marshal(StepChangePayload{Step: 3})
+	data, _ := json.Marshal(WSMessage{
+		Type:    MsgTypeStepChange,
+		Payload: payload,
+	})
+	ch.handleMessage(client, data)
+
+	step, ok := client.CurrentStep()
+	if !ok {
+		t.Fatal("expected current step to be set after step_change")
+	}
+	if step != 3 {
+		t.Errorf("expected step 3, got %d", step)
+	}
+	// step_change produces no response message
+	assertNoMoreMessages(t, client)
+}
+
+func TestHandleStepChange_InvalidPayload(t *testing.T) {
+	ch, _, _ := setupTestCookingHandler()
+	client := newTestClient(ch.Hub, "recipe-1", 42)
+
+	ch.handleStepChange(client, json.RawMessage(`{"step":"three"}`))
+
+	msg := readMessage(t, client)
+	if msg.Type != MsgTypeError {
+		t.Fatalf("expected error type, got %q", msg.Type)
+	}
+	var errPayload ErrorPayload
+	if err := json.Unmarshal(msg.Payload, &errPayload); err != nil {
+		t.Fatalf("failed to unmarshal ErrorPayload: %v", err)
+	}
+	if errPayload.Message != "invalid step change payload" {
+		t.Errorf("unexpected error message: %q", errPayload.Message)
+	}
+}
+
+func TestHandleStepChange_NegativeStep(t *testing.T) {
+	ch, _, _ := setupTestCookingHandler()
+	client := newTestClient(ch.Hub, "recipe-1", 42)
+
+	ch.handleStepChange(client, json.RawMessage(`{"step":-1}`))
+
+	msg := readMessage(t, client)
+	if msg.Type != MsgTypeError {
+		t.Fatalf("expected error type, got %q", msg.Type)
+	}
+	if _, ok := client.CurrentStep(); ok {
+		t.Error("negative step should not be stored")
+	}
+}
+
+func TestStepChange_ThreadsIntoQAContext(t *testing.T) {
+	ch, mockText, _ := setupTestCookingHandler()
+	client := newTestClient(ch.Hub, "recipe-1", 42)
+
+	// Report the current step first.
+	stepPayload, _ := json.Marshal(StepChangePayload{Step: 4})
+	stepData, _ := json.Marshal(WSMessage{
+		Type:    MsgTypeStepChange,
+		Payload: stepPayload,
+	})
+	ch.handleMessage(client, stepData)
+
+	contextCh := make(chan string, 1)
+	mockText.CookingQAFunc = func(ctx context.Context, question, recipeContext string) (string, error) {
+		contextCh <- recipeContext
+		return "Stir until combined.", nil
+	}
+
+	chatPayload, _ := json.Marshal(ChatMessagePayload{
+		Message:       "what now?",
+		RecipeContext: "pasta recipe",
+	})
+	chatData, _ := json.Marshal(WSMessage{
+		Type:    MsgTypeChatMessage,
+		Payload: chatPayload,
+	})
+	ch.handleMessage(client, chatData)
+
+	msg := readMessage(t, client)
+	if msg.Type != MsgTypeChatResponse {
+		t.Fatalf("expected type %q, got %q", MsgTypeChatResponse, msg.Type)
+	}
+
+	recipeContext := <-contextCh
+	if !strings.Contains(recipeContext, "pasta recipe") {
+		t.Errorf("expected recipe context to keep the original context, got %q", recipeContext)
+	}
+	if !strings.Contains(recipeContext, "The user is currently on step 4.") {
+		t.Errorf("expected recipe context to mention step 4, got %q", recipeContext)
+	}
+}
+
+func TestHandleVoiceTranscript_QuestionIncludesStepContext(t *testing.T) {
+	ch, mockText, _ := setupTestCookingHandler()
+	client := newTestClient(ch.Hub, "recipe-1", 42)
+	client.SetCurrentStep(7)
+
+	mockText.ClassifyVoiceIntentFunc = func(ctx context.Context, transcript string) (*ai.VoiceIntent, error) {
+		return &ai.VoiceIntent{
+			Type: "question",
+			Text: "is it done yet",
+		}, nil
+	}
+	contextCh := make(chan string, 1)
+	mockText.CookingQAFunc = func(ctx context.Context, question, recipeContext string) (string, error) {
+		contextCh <- recipeContext
+		return "Almost.", nil
+	}
+
+	payload, _ := json.Marshal(VoiceTranscriptPayload{
+		Transcript: "is it done yet",
+	})
+	ch.handleVoiceTranscript(client, payload)
+
+	// VoiceIntent, then ChatResponse
+	msg := readMessage(t, client)
+	if msg.Type != MsgTypeVoiceIntent {
+		t.Fatalf("expected type %q, got %q", MsgTypeVoiceIntent, msg.Type)
+	}
+	msg2 := readMessage(t, client)
+	if msg2.Type != MsgTypeChatResponse {
+		t.Fatalf("expected type %q, got %q", MsgTypeChatResponse, msg2.Type)
+	}
+
+	recipeContext := <-contextCh
+	if recipeContext != "The user is currently on step 7." {
+		t.Errorf("expected step-only context, got %q", recipeContext)
+	}
+}
+
+// --- voice format plumbing tests ---
+
+func TestHandleVoiceTranscript_AudioFormatPassedToSpeechProvider(t *testing.T) {
+	ch, mockText, mockSpeech := setupTestCookingHandler()
+	client := newTestClient(ch.Hub, "recipe-1", 42)
+
+	var gotFormat string
+	mockSpeech.TranscribeAudioFunc = func(ctx context.Context, audioData []byte, format string) (string, error) {
+		gotFormat = format
+		return "scroll down", nil
+	}
+	mockText.ClassifyVoiceIntentFunc = func(ctx context.Context, transcript string) (*ai.VoiceIntent, error) {
+		return &ai.VoiceIntent{Type: "ignore"}, nil
+	}
+
+	payload, _ := json.Marshal(VoiceTranscriptPayload{
+		AudioData: []byte("fake-audio"),
+		Format:    "m4a",
+	})
+	ch.handleVoiceTranscript(client, payload)
+
+	msg := readMessage(t, client)
+	if msg.Type != MsgTypeVoiceIntent {
+		t.Fatalf("expected type %q, got %q", MsgTypeVoiceIntent, msg.Type)
+	}
+	if gotFormat != "m4a" {
+		t.Errorf("expected format m4a to reach the speech provider, got %q", gotFormat)
+	}
+}
+
+// --- CheckOrigin tests ---
+
+func TestCheckOrigin(t *testing.T) {
+	cases := []struct {
+		origin string
+		want   bool
+	}{
+		{"", true}, // native clients (Flutter) send no Origin header
+		{"https://saltybytes.ai", true},
+		{"https://www.saltybytes.ai", true},
+		{"https://api.saltybytes.ai", true},
+		{"http://localhost", true},
+		{"http://localhost:3000", true},
+		{"https://evil.example.com", false},
+		{"http://saltybytes.ai.evil.com", false},
+	}
+
+	for _, tc := range cases {
+		req := httptest.NewRequest(http.MethodGet, "/v1/ws/cook/1", nil)
+		if tc.origin != "" {
+			req.Header.Set("Origin", tc.origin)
+		}
+		if got := upgrader.CheckOrigin(req); got != tc.want {
+			t.Errorf("CheckOrigin(origin=%q) = %v, want %v", tc.origin, got, tc.want)
+		}
+	}
+}
+
+// --- async dispatch tests ---
+
+func TestDispatchAsync_BoundedConcurrency(t *testing.T) {
+	ch, mockText, _ := setupTestCookingHandler()
+	client := newTestClient(ch.Hub, "recipe-1", 42)
+
+	started := make(chan struct{}, 4)
+	release := make(chan struct{})
+	mockText.CookingQAFunc = func(ctx context.Context, question, recipeContext string) (string, error) {
+		started <- struct{}{}
+		<-release
+		return "done", nil
+	}
+
+	chatPayload, _ := json.Marshal(ChatMessagePayload{Message: "question"})
+	chatData, _ := json.Marshal(WSMessage{
+		Type:    MsgTypeChatMessage,
+		Payload: chatPayload,
+	})
+
+	// Two slow handlers may run concurrently without blocking handleMessage.
+	ch.handleMessage(client, chatData)
+	ch.handleMessage(client, chatData)
+	for i := 0; i < 2; i++ {
+		select {
+		case <-started:
+		case <-time.After(2 * time.Second):
+			t.Fatal("async handler did not start")
+		}
+	}
+
+	// A third request is rejected immediately while two are in flight.
+	ch.handleMessage(client, chatData)
+	msg := readMessage(t, client)
+	if msg.Type != MsgTypeError {
+		t.Fatalf("expected error type for third in-flight request, got %q", msg.Type)
+	}
+	var errPayload ErrorPayload
+	if err := json.Unmarshal(msg.Payload, &errPayload); err != nil {
+		t.Fatalf("failed to unmarshal ErrorPayload: %v", err)
+	}
+	if errPayload.Message != "too many requests in flight; please wait" {
+		t.Errorf("unexpected error message: %q", errPayload.Message)
+	}
+
+	// Cheap messages are still processed inline while slow handlers run.
+	stepPayload, _ := json.Marshal(StepChangePayload{Step: 2})
+	stepData, _ := json.Marshal(WSMessage{
+		Type:    MsgTypeStepChange,
+		Payload: stepPayload,
+	})
+	ch.handleMessage(client, stepData)
+	if step, ok := client.CurrentStep(); !ok || step != 2 {
+		t.Errorf("expected step_change to be handled while handlers in flight, got step=%d ok=%v", step, ok)
+	}
+
+	// Release the blocked handlers; both responses arrive.
+	close(release)
+	for i := 0; i < 2; i++ {
+		resp := readMessage(t, client)
+		if resp.Type != MsgTypeChatResponse {
+			t.Fatalf("expected type %q, got %q", MsgTypeChatResponse, resp.Type)
+		}
+	}
+	assertNoMoreMessages(t, client)
 }
 
 func TestHandleVoiceTranscript_QuestionIntent_AnswerError(t *testing.T) {

--- a/internal/ws/hub.go
+++ b/internal/ws/hub.go
@@ -21,6 +21,11 @@ const (
 
 	// Maximum message size allowed from peer.
 	maxMessageSize = 8192
+
+	// Maximum number of slow handlers (cooking QA, voice processing) that may
+	// run concurrently per client. Cheap handlers (ping, step_change,
+	// ephemeral edits) are not bounded by this.
+	maxConcurrentHandlers = 2
 )
 
 // Client represents a single WebSocket connection.
@@ -30,6 +35,94 @@ type Client struct {
 	Send   chan []byte
 	RoomID string
 	UserID uint
+
+	// done is closed exactly once (via closeOnce) when the client is
+	// unregistered or evicted by the hub. The Send channel itself is NEVER
+	// closed, so concurrent handler goroutines can never panic with
+	// send-on-closed-channel; they observe done instead.
+	done      chan struct{}
+	closeOnce sync.Once
+
+	// handlerSem bounds concurrent long-running message handlers per client.
+	handlerSem chan struct{}
+
+	// currentStep tracks which recipe step the user is viewing, guarded by
+	// stepMu. hasStep distinguishes "step 0" from "never reported".
+	stepMu      sync.RWMutex
+	currentStep int
+	hasStep     bool
+}
+
+// NewClient creates a Client with its channels initialized.
+func NewClient(hub *Hub, conn *websocket.Conn, roomID string, userID uint) *Client {
+	return &Client{
+		Hub:        hub,
+		Conn:       conn,
+		Send:       make(chan []byte, 256),
+		RoomID:     roomID,
+		UserID:     userID,
+		done:       make(chan struct{}),
+		handlerSem: make(chan struct{}, maxConcurrentHandlers),
+	}
+}
+
+// markClosed signals that the client is dead. Safe to call multiple times
+// (e.g. eviction by the hub followed by the read pump unregistering).
+func (c *Client) markClosed() {
+	c.closeOnce.Do(func() {
+		close(c.done)
+	})
+}
+
+// TrySend delivers a message to the client's send buffer. It returns false if
+// the client has been closed. Because the Send channel is never closed, this
+// can never panic; a send blocked on a full buffer is released when the hub
+// closes the client.
+func (c *Client) TrySend(message []byte) bool {
+	select {
+	case <-c.done:
+		return false
+	default:
+	}
+	select {
+	case c.Send <- message:
+		return true
+	case <-c.done:
+		return false
+	}
+}
+
+// tryAcquireHandlerSlot reserves a slot for a long-running handler. It
+// returns false without blocking if the client already has the maximum number
+// of handlers in flight.
+func (c *Client) tryAcquireHandlerSlot() bool {
+	select {
+	case c.handlerSem <- struct{}{}:
+		return true
+	default:
+		return false
+	}
+}
+
+// releaseHandlerSlot frees a slot reserved by tryAcquireHandlerSlot.
+func (c *Client) releaseHandlerSlot() {
+	<-c.handlerSem
+}
+
+// SetCurrentStep records which recipe step the user is currently viewing.
+func (c *Client) SetCurrentStep(step int) {
+	c.stepMu.Lock()
+	c.currentStep = step
+	c.hasStep = true
+	c.stepMu.Unlock()
+}
+
+// CurrentStep returns the user's current recipe step. The bool is false if
+// the client has never reported a step.
+func (c *Client) CurrentStep() (int, bool) {
+	c.stepMu.RLock()
+	defer c.stepMu.RUnlock()
+	return c.currentStep, c.hasStep
 }
 
 // Hub maintains active rooms and broadcasts messages.
@@ -83,7 +176,6 @@ func (h *Hub) Run() {
 			if clients, ok := h.Rooms[client.RoomID]; ok {
 				if _, exists := clients[client]; exists {
 					delete(clients, client)
-					close(client.Send)
 					if len(clients) == 0 {
 						delete(h.Rooms, client.RoomID)
 					}
@@ -91,15 +183,23 @@ func (h *Hub) Run() {
 			}
 			h.mu.Unlock()
 
+			// Never close client.Send: handler goroutines may still be
+			// sending. Signal death via the done channel instead.
+			client.markClosed()
+
 			log.Info("client unregistered",
 				zap.String("room_id", client.RoomID),
 				zap.Uint("user_id", client.UserID),
 			)
 
 		case msg := <-h.Broadcast:
+			// Collect clients that can't keep up during a read-locked
+			// iteration, then evict them afterwards under a write lock.
+			// Mutating the map while ranging over it under a dropped read
+			// lock is racy.
+			var doomed []*Client
 			h.mu.RLock()
-			clients := h.Rooms[msg.RoomID]
-			for client := range clients {
+			for client := range h.Rooms[msg.RoomID] {
 				// Skip sender if present
 				if msg.Sender != nil && client == msg.Sender {
 					continue
@@ -107,19 +207,34 @@ func (h *Hub) Run() {
 				select {
 				case client.Send <- msg.Message:
 				default:
-					// Client's send buffer is full; disconnect it.
-					h.mu.RUnlock()
-					h.mu.Lock()
-					delete(h.Rooms[msg.RoomID], client)
-					close(client.Send)
-					if len(h.Rooms[msg.RoomID]) == 0 {
-						delete(h.Rooms, msg.RoomID)
-					}
-					h.mu.Unlock()
-					h.mu.RLock()
+					// Client's send buffer is full; evict it below.
+					doomed = append(doomed, client)
 				}
 			}
 			h.mu.RUnlock()
+
+			if len(doomed) > 0 {
+				h.mu.Lock()
+				for _, client := range doomed {
+					if clients, ok := h.Rooms[msg.RoomID]; ok {
+						if _, exists := clients[client]; exists {
+							delete(clients, client)
+							if len(clients) == 0 {
+								delete(h.Rooms, msg.RoomID)
+							}
+						}
+					}
+				}
+				h.mu.Unlock()
+
+				for _, client := range doomed {
+					client.markClosed()
+					log.Warn("evicted slow websocket client",
+						zap.String("room_id", client.RoomID),
+						zap.Uint("user_id", client.UserID),
+					)
+				}
+			}
 		}
 	}
 }
@@ -171,13 +286,8 @@ func (c *Client) WritePump() {
 
 	for {
 		select {
-		case message, ok := <-c.Send:
+		case message := <-c.Send:
 			c.Conn.SetWriteDeadline(time.Now().Add(writeWait))
-			if !ok {
-				// Hub closed the channel.
-				c.Conn.WriteMessage(websocket.CloseMessage, []byte{})
-				return
-			}
 
 			w, err := c.Conn.NextWriter(websocket.TextMessage)
 			if err != nil {
@@ -188,6 +298,12 @@ func (c *Client) WritePump() {
 			if err := w.Close(); err != nil {
 				return
 			}
+
+		case <-c.done:
+			// The hub closed this client.
+			c.Conn.SetWriteDeadline(time.Now().Add(writeWait))
+			c.Conn.WriteMessage(websocket.CloseMessage, []byte{})
+			return
 
 		case <-ticker.C:
 			c.Conn.SetWriteDeadline(time.Now().Add(writeWait))

--- a/internal/ws/hub_rooms_test.go
+++ b/internal/ws/hub_rooms_test.go
@@ -1,0 +1,169 @@
+package ws
+
+import (
+	"testing"
+	"time"
+)
+
+// roomExists checks the hub's room map under its lock.
+func roomExists(h *Hub, roomID string) bool {
+	h.mu.RLock()
+	defer h.mu.RUnlock()
+	_, ok := h.Rooms[roomID]
+	return ok
+}
+
+// waitForRoomGone polls until the room disappears from the hub or times out.
+func waitForRoomGone(t *testing.T, h *Hub, roomID string) {
+	t.Helper()
+	deadline := time.Now().Add(2 * time.Second)
+	for roomExists(h, roomID) {
+		if time.Now().After(deadline) {
+			t.Fatalf("room %q was not removed from the hub", roomID)
+		}
+		time.Sleep(5 * time.Millisecond)
+	}
+}
+
+func TestHubBroadcast_RoomIsolation(t *testing.T) {
+	hub := NewHub()
+	go hub.Run()
+
+	inRoom := NewClient(hub, nil, "room-a", 1)
+	otherRoom := NewClient(hub, nil, "room-b", 2)
+
+	hub.Register <- inRoom
+	hub.Register <- otherRoom
+
+	hub.Broadcast <- &RoomMessage{
+		RoomID:  "room-a",
+		Message: []byte(`{"type":"hello"}`),
+	}
+
+	select {
+	case <-inRoom.Send:
+	case <-time.After(2 * time.Second):
+		t.Fatal("client in the target room did not receive the broadcast")
+	}
+
+	select {
+	case msg := <-otherRoom.Send:
+		t.Fatalf("client in a different room received the broadcast: %s", string(msg))
+	case <-time.After(50 * time.Millisecond):
+		// OK — message stayed within room-a.
+	}
+}
+
+func TestHub_RegisterMultipleClients_SystemBroadcastReachesAll(t *testing.T) {
+	hub := NewHub()
+	go hub.Run()
+
+	first := NewClient(hub, nil, "room-1", 1)
+	second := NewClient(hub, nil, "room-1", 2)
+
+	hub.Register <- first
+	hub.Register <- second
+
+	// Sender nil marks a system message: nobody is skipped.
+	hub.Broadcast <- &RoomMessage{
+		RoomID:  "room-1",
+		Message: []byte(`{"type":"system"}`),
+	}
+
+	for _, c := range []*Client{first, second} {
+		select {
+		case <-c.Send:
+		case <-time.After(2 * time.Second):
+			t.Fatalf("client %d did not receive the system broadcast", c.UserID)
+		}
+	}
+}
+
+func TestHub_UnregisterLastClientRemovesRoom(t *testing.T) {
+	hub := NewHub()
+	go hub.Run()
+
+	first := NewClient(hub, nil, "room-1", 1)
+	second := NewClient(hub, nil, "room-1", 2)
+
+	hub.Register <- first
+	hub.Register <- second
+
+	hub.Unregister <- first
+	select {
+	case <-first.done:
+	case <-time.After(2 * time.Second):
+		t.Fatal("first client was not closed on unregister")
+	}
+	// One client remains, so the room must still exist.
+	if !roomExists(hub, "room-1") {
+		t.Fatal("room was removed while a client was still registered")
+	}
+
+	hub.Unregister <- second
+	select {
+	case <-second.done:
+	case <-time.After(2 * time.Second):
+		t.Fatal("second client was not closed on unregister")
+	}
+	waitForRoomGone(t, hub, "room-1")
+}
+
+func TestHubBroadcast_UnknownRoomIsNoOp(t *testing.T) {
+	hub := NewHub()
+	go hub.Run()
+
+	client := NewClient(hub, nil, "room-1", 1)
+	hub.Register <- client
+
+	// Broadcasting to a room nobody joined must not panic or wedge the hub.
+	hub.Broadcast <- &RoomMessage{
+		RoomID:  "ghost-room",
+		Message: []byte(`{"type":"into the void"}`),
+	}
+
+	// The hub still services real rooms afterwards.
+	hub.Broadcast <- &RoomMessage{
+		RoomID:  "room-1",
+		Message: []byte(`{"type":"alive"}`),
+	}
+	select {
+	case <-client.Send:
+	case <-time.After(2 * time.Second):
+		t.Fatal("hub stopped delivering after a broadcast to an unknown room")
+	}
+}
+
+func TestHub_UnregisterUnknownClientIsNoOp(t *testing.T) {
+	hub := NewHub()
+	go hub.Run()
+
+	registered := NewClient(hub, nil, "room-1", 1)
+	hub.Register <- registered
+
+	// Unregistering a client that never registered (e.g. handshake failed
+	// before Register) must not disturb the room or panic.
+	stranger := NewClient(hub, nil, "room-1", 99)
+	hub.Unregister <- stranger
+
+	select {
+	case <-stranger.done:
+		// The hub still marks the stray client closed so its pumps exit.
+	case <-time.After(2 * time.Second):
+		t.Fatal("stray client was not marked closed")
+	}
+
+	if !roomExists(hub, "room-1") {
+		t.Fatal("room was removed by unregistering a non-member")
+	}
+
+	hub.Broadcast <- &RoomMessage{
+		RoomID:  "room-1",
+		Message: []byte(`{"type":"still here"}`),
+	}
+	select {
+	case <-registered.Send:
+	case <-time.After(2 * time.Second):
+		t.Fatal("registered client did not receive broadcast after stray unregister")
+	}
+}

--- a/internal/ws/hub_test.go
+++ b/internal/ws/hub_test.go
@@ -1,0 +1,145 @@
+package ws
+
+import (
+	"testing"
+	"time"
+)
+
+func TestHub_UnregisterClosesClientWithoutClosingSend(t *testing.T) {
+	hub := NewHub()
+	go hub.Run()
+
+	client := NewClient(hub, nil, "room-1", 1)
+	hub.Register <- client
+	hub.Unregister <- client
+
+	select {
+	case <-client.done:
+	case <-time.After(2 * time.Second):
+		t.Fatal("client done channel was not closed on unregister")
+	}
+
+	// The Send channel must remain open: TrySend returns false but never
+	// panics with send-on-closed-channel.
+	if client.TrySend([]byte("late message")) {
+		t.Error("TrySend should return false after the client is closed")
+	}
+}
+
+func TestHubBroadcast_FullSendBufferEvictsClientSafely(t *testing.T) {
+	hub := NewHub()
+	go hub.Run()
+
+	slow := NewClient(hub, nil, "room-1", 1)
+	slow.Send = make(chan []byte, 1) // tiny buffer so it fills immediately
+	fast := NewClient(hub, nil, "room-1", 2)
+
+	hub.Register <- slow
+	hub.Register <- fast
+
+	// Fill the slow client's buffer so the broadcast cannot be delivered.
+	slow.Send <- []byte("filler")
+
+	hub.Broadcast <- &RoomMessage{
+		RoomID:  "room-1",
+		Message: []byte(`{"type":"first"}`),
+	}
+
+	// The fast client still receives the message.
+	select {
+	case <-fast.Send:
+	case <-time.After(2 * time.Second):
+		t.Fatal("fast client did not receive the first broadcast")
+	}
+
+	// The slow client is evicted: done closed, Send left open.
+	select {
+	case <-slow.done:
+	case <-time.After(2 * time.Second):
+		t.Fatal("slow client was not evicted after its send buffer filled")
+	}
+	if slow.TrySend([]byte("x")) {
+		t.Error("TrySend to an evicted client should return false")
+	}
+
+	// A second broadcast must not panic or deadlock and still reaches the
+	// fast client.
+	hub.Broadcast <- &RoomMessage{
+		RoomID:  "room-1",
+		Message: []byte(`{"type":"second"}`),
+	}
+	select {
+	case <-fast.Send:
+	case <-time.After(2 * time.Second):
+		t.Fatal("fast client did not receive the second broadcast")
+	}
+
+	// Unregistering the already-evicted client must be a no-op (no double
+	// close panic).
+	hub.Unregister <- slow
+
+	// The hub keeps working afterwards.
+	hub.Broadcast <- &RoomMessage{
+		RoomID:  "room-1",
+		Message: []byte(`{"type":"third"}`),
+	}
+	select {
+	case <-fast.Send:
+	case <-time.After(2 * time.Second):
+		t.Fatal("fast client did not receive the third broadcast")
+	}
+}
+
+func TestHubBroadcast_SkipsSender(t *testing.T) {
+	hub := NewHub()
+	go hub.Run()
+
+	sender := NewClient(hub, nil, "room-1", 1)
+	receiver := NewClient(hub, nil, "room-1", 2)
+
+	hub.Register <- sender
+	hub.Register <- receiver
+
+	hub.Broadcast <- &RoomMessage{
+		RoomID:  "room-1",
+		Message: []byte(`{"type":"hello"}`),
+		Sender:  sender,
+	}
+
+	select {
+	case <-receiver.Send:
+	case <-time.After(2 * time.Second):
+		t.Fatal("receiver did not get the broadcast")
+	}
+
+	select {
+	case msg := <-sender.Send:
+		t.Fatalf("sender should not receive its own broadcast, got %s", string(msg))
+	case <-time.After(50 * time.Millisecond):
+		// OK — nothing delivered to the sender
+	}
+}
+
+func TestTrySend_UnblocksWhenClientCloses(t *testing.T) {
+	client := NewClient(nil, nil, "room-1", 1)
+	client.Send = make(chan []byte) // unbuffered with no reader: send blocks
+
+	result := make(chan bool, 1)
+	go func() {
+		result <- client.TrySend([]byte("msg"))
+	}()
+
+	// Give the goroutine a moment to block on the send, then close the
+	// client. Even if it hasn't blocked yet, TrySend must return false.
+	time.Sleep(50 * time.Millisecond)
+	client.markClosed()
+
+	select {
+	case ok := <-result:
+		if ok {
+			t.Error("expected TrySend to return false after the client closed")
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("TrySend did not unblock after the client closed")
+	}
+}


### PR DESCRIPTION
## Summary

13 commits finishing every incomplete subsystem found in a full-codebase audit.

### Vector search — fully operational
- Similarity endpoint reuses **stored embeddings** (generates+persists only on miss), excludes the source recipe, applies a cosine-distance threshold, supports `?limit=`, and returns the camelCase `RecipeListItem` DTO the app can actually parse
- New **HNSW index on `recipes.embedding`**; startup **backfill** for recipes + canonicals with NULL embeddings; canonical embeddings now populated on upsert
- `SetActiveNode` regenerates the embedding after rewriting the recipe def (drift fix)
- **Semantic home search**: `GET /v1/recipes?q=` embeds the query and vector-searches the user's own recipes, merged with an ILIKE fallback

### Unit system (US ↔ Metric)
- `PUT /users/me/personalization` is now a **partial update** — toggling units no longer wipes `cooking_context`
- Manual import accepts `unit_system`, `image_url`, per-ingredient `metric_*`/`original_text`; stops stamping the user's system over source-preserved imports
- New deterministic **JSON-LD ingredient parser** (fractions, unicode, ranges, unit alias table) so the dominant import path gets structured units and conversion works
- `ai.UnitSystemPreserveSource` replaces the magic string; Haiku-path `unit_system` fallback via `detectUnitSystem`

### Database & lifecycle
- Fixed the silently-failing `ADD CONSTRAINT IF NOT EXISTS` (invalid PG syntax) via a guarded `DO $$` block; all migration Execs error-checked; `AutoMigrate` failure now fatal
- Recipe deletion cleans up trees/nodes and treats S3 deletion as best-effort
- **Versioned S3 image keys** + correct ContentType — regenerated images no longer hidden behind URL caches; UUID keys for uploads
- snake_case JSON tags for tree/family/allergen responses (previously unparseable PascalCase)

### Auth & subscriptions
- Refresh-token revocation via `token_version` + new `POST /v1/auth/logout`; refresh now loads the user
- Generic login errors (no username enumeration — including a bcrypt timing-equalization), per-IP rate limiting on auth routes with trusted-proxy config, CORS allow-headers fix
- `GET /v1/recipes/:id` now requires auth (was anonymously enumerable)
- AI-generation gating enforced (chat/stream/regen/fork) through `CheckLimit` with working monthly reset; nil-subscription users get free-tier defaults; upgrade returns 501

### Cooking WebSocket & voice
- `CheckOrigin` accepts empty-Origin native clients (the Flutter app was getting 403 on upgrade)
- New `ping`/`pong` + `step_change` handling (current step feeds cooking-QA context); transcript-path voice with audio-format plumbing
- Hub race fixes (safe eviction, no send-on-closed-channel), bounded async dispatch for slow AI handlers

### AI provider
- Model IDs configurable via `ANTHROPIC_MODEL` / `ANTHROPIC_LIGHT_MODEL`; default migrated off the **retired** `claude-3-5-sonnet-20241022` to `claude-sonnet-4-6`
- Dietary interview returns structured `{response, complete, profile}` via a `save_dietary_profile` tool
- `EstimatePortions` wired into imports lacking portion data

### Review pass
Five adversarial reviewers audited the full diff; all verified findings fixed — including a **cross-tenant S3 deletion vector** (keys derived from attacker-controllable `ImageURL`), an XFF rate-limit bypass, a `lastSeen` data race, and goroutine-leak/panic-recovery hardening.

## Test plan
- Suite grew **234 → 571 test functions**, all offline (CI deploy gate safe), 10/10 packages green, `go vet` + `gofmt` clean, service/ws/ai/util race-clean
- New coverage: recipeChat/Regen/Fork, recipe tree, allergen, family (+interview), subscription, user endpoints, middleware (incl. rate limiter), multi-recipe, voice, ws hub, util, ai taxonomy/middleware/stream, vector repo + semantic search, ingredient parser

⚠️ Deploy notes: AutoMigrate adds `user_auths.token_version` (default 0 — existing refresh tokens stay valid) and the recipes HNSW index; the embedding backfill runs once on startup (batched, rate-limited). `ANTHROPIC_MODEL` env is optional.

🤖 Generated with [Claude Code](https://claude.com/claude-code)