### PR TITLE
Preserve source units on recipe import

### DIFF
--- a/configs/prompts.yaml
+++ b/configs/prompts.yaml
@@ -49,10 +49,12 @@ recipe:
       system_prefix: |
         You are a professional chef and recipe analyst. You are analyzing an image of a recipe or food to extract recipe details.
       system: |
-        You must use the {{.UnitSystem}} unit system for the primary measurements (unit and amount fields).
+        Use the original units visible in the image as the primary measurements (unit and amount fields). Do not convert source measurements just to match a user preference.
+        If the image has no clear written measurements and you must infer them, use the {{.UnitSystem}} unit system for those inferred primary measurements.
         For EVERY ingredient, you must ALSO provide the metric equivalent in the metric_unit and metric_amount fields.
         Use accurate cooking-specific conversions (e.g., 1 cup all-purpose flour = 120g, 1 cup granulated sugar = 200g, 1 cup butter = 227g, 1 cup water/milk = 240mL).
-        If the primary unit system is already Metric, duplicate the values into metric_unit and metric_amount.
+        If the primary unit is already metric, duplicate the values into metric_unit and metric_amount.
+        Report the detected primary measurement system via the unit_system field.
         If the image shows a prepared dish without a visible recipe, infer the recipe based on the dish's appearance. Estimate ingredient quantities based on visual portion size.
         {{if .Requirements}}The user has the following dietary requirements and preferences: {{.Requirements}}{{end}}
       user: |
@@ -61,10 +63,12 @@ recipe:
       system_prefix: |
         You extract structured recipe data from free-form text. Parse the text to identify the title, ingredients with quantities and units, step-by-step instructions, and estimated cook time.
       system: |
-        You must use the {{.UnitSystem}} unit system for the primary measurements (unit and amount fields).
+        Use the original units from the source content as the primary measurements (unit and amount fields). Do not convert source measurements just to match a user preference.
+        If the source content has no clear measurements and you must infer them, use the {{.UnitSystem}} unit system for those inferred primary measurements.
         For EVERY ingredient, you must ALSO provide the metric equivalent in the metric_unit and metric_amount fields.
         Use accurate cooking-specific conversions (e.g., 1 cup all-purpose flour = 120g, 1 cup granulated sugar = 200g, 1 cup butter = 227g, 1 cup water/milk = 240mL).
-        If the primary unit system is already Metric, duplicate the values into metric_unit and metric_amount.
+        If the primary unit is already metric, duplicate the values into metric_unit and metric_amount.
+        Report the detected primary measurement system via the unit_system field.
       user: |
         Extract the recipe from the following text:
         {{.Prompt}}
@@ -74,10 +78,12 @@ recipe:
         When quantities are missing, use reasonable defaults (e.g., "salt" → "1 pinch salt", "oil for frying" → "2 tbsp oil").
         When units are ambiguous, prefer the most common cooking interpretation (e.g., "1 tomato" → pieces, not weight).
       system: |
-        You must use the {{.UnitSystem}} unit system for the primary measurements (unit and amount fields).
+        Use the original units from the source content as the primary measurements (unit and amount fields). Do not convert source measurements just to match a user preference.
+        If the source content has no clear measurements and you must infer them, use the {{.UnitSystem}} unit system for those inferred primary measurements.
         For EVERY ingredient, you must ALSO provide the metric equivalent in the metric_unit and metric_amount fields.
         Use accurate cooking-specific conversions (e.g., 1 cup all-purpose flour = 120g, 1 cup granulated sugar = 200g, 1 cup butter = 227g, 1 cup water/milk = 240mL).
-        If the primary unit system is already Metric, duplicate the values into metric_unit and metric_amount.
+        If the primary unit is already metric, duplicate the values into metric_unit and metric_amount.
+        Report the detected primary measurement system via the unit_system field.
       user: |
         Extract the recipe from the following page content:
         {{.Prompt}}
@@ -158,10 +164,12 @@ import:
     system_prefix: |
       You extract structured recipe data from free-form text. Parse the text to identify the title, ingredients with quantities and units, step-by-step instructions, and estimated cook time.
     system: |
-      You must use the {{.UnitSystem}} unit system for the primary measurements (unit and amount fields).
+      Use the original units from the source text as the primary measurements (unit and amount fields). Do not convert source measurements just to match a user preference.
+      If the source text has no clear measurements and you must infer them, use the {{.UnitSystem}} unit system for those inferred primary measurements.
       For EVERY ingredient, you must ALSO provide the metric equivalent in the metric_unit and metric_amount fields.
       Use accurate cooking-specific conversions (e.g., 1 cup all-purpose flour = 120g, 1 cup granulated sugar = 200g, 1 cup butter = 227g, 1 cup water/milk = 240mL).
-      If the primary unit system is already Metric, duplicate the values into metric_unit and metric_amount.
+      If the primary unit is already metric, duplicate the values into metric_unit and metric_amount.
+      Report the detected primary measurement system via the unit_system field.
     user: |
       Extract the recipe from the following text:
       {{.Prompt}}
@@ -172,9 +180,11 @@ import:
       When units are ambiguous, prefer the most common cooking interpretation (e.g., "1 tomato" → pieces, not weight).
     system: |
       Use the original units from the source text as the primary measurements.
+      Do not convert source measurements just to match a user preference.
       For EVERY ingredient, also provide the metric equivalent in metric_unit and metric_amount.
       Use accurate cooking-specific conversions (e.g., 1 cup all-purpose flour = 120g, 1 cup granulated sugar = 200g, 1 cup butter = 227g, 1 cup water/milk = 240mL).
       If the primary unit is already metric, duplicate the values into metric_unit and metric_amount.
+      Report the detected primary measurement system via the unit_system field.
     user: |
       Extract the recipe from the following page content:
       {{.Prompt}}

--- a/internal/service/import.go
+++ b/internal/service/import.go
@@ -618,9 +618,7 @@ func (s *ImportService) ImportFromText(ctx context.Context, text string, user *m
 	}
 
 	def := recipeResultToRecipeDef(result)
-	if def.UnitSystem == "" {
-		def.UnitSystem = user.Personalization.UnitSystem
-	}
+	ensureUnitSystem(&def)
 	resp, _, err := s.createImportedRecipe(ctx, &def, user, models.RecipeTypeImportCopypasta, "", "", nil, result.Hashtags, result.PromptVersion)
 	return resp, err
 }

--- a/internal/service/import_service_test.go
+++ b/internal/service/import_service_test.go
@@ -50,6 +50,9 @@ func TestImportFromText_Success(t *testing.T) {
 	repo := testutil.NewMockRecipeRepo()
 	mockText := &testutil.MockTextProvider{
 		ExtractRecipeFromTextFunc: func(ctx context.Context, text string, unitSystem string) (*ai.RecipeResult, error) {
+			if unitSystem != "US Customary" {
+				t.Errorf("unitSystem = %q, want fallback preference 'US Customary'", unitSystem)
+			}
 			return testutil.TestRecipeResult(), nil
 		},
 	}
@@ -79,6 +82,9 @@ func TestImportFromText_MetricUser(t *testing.T) {
 	repo := testutil.NewMockRecipeRepo()
 	mockText := &testutil.MockTextProvider{
 		ExtractRecipeFromTextFunc: func(ctx context.Context, text string, unitSystem string) (*ai.RecipeResult, error) {
+			if unitSystem != "Metric" {
+				t.Errorf("unitSystem = %q, want fallback preference 'Metric'", unitSystem)
+			}
 			return testutil.TestRecipeResult(), nil
 		},
 	}
@@ -91,8 +97,39 @@ func TestImportFromText_MetricUser(t *testing.T) {
 	if err != nil {
 		t.Fatalf("ImportFromText error: %v", err)
 	}
+	if resp.UnitSystem != "us_customary" {
+		t.Errorf("ImportFromText UnitSystem = %q, want source units 'us_customary'", resp.UnitSystem)
+	}
+}
+
+func TestImportFromText_DetectsMetricSourceForUSUser(t *testing.T) {
+	repo := testutil.NewMockRecipeRepo()
+	mockText := &testutil.MockTextProvider{
+		ExtractRecipeFromTextFunc: func(ctx context.Context, text string, unitSystem string) (*ai.RecipeResult, error) {
+			if unitSystem != "US Customary" {
+				t.Errorf("unitSystem = %q, want fallback preference 'US Customary'", unitSystem)
+			}
+			return &ai.RecipeResult{
+				Title: "Metric Cake",
+				Ingredients: []ai.IngredientResult{
+					{Name: "flour", Unit: "g", Amount: 250, MetricUnit: "g", MetricAmount: 250, OriginalText: "250 g flour"},
+					{Name: "milk", Unit: "mL", Amount: 100, MetricUnit: "mL", MetricAmount: 100, OriginalText: "100 mL milk"},
+				},
+				Instructions: []string{"Mix"},
+				ImagePrompt:  "A cake",
+			}, nil
+		},
+	}
+
+	svc := newTestImportService(repo, mockText, nil)
+	user := testutil.TestUser()
+
+	resp, err := svc.ImportFromText(context.Background(), "250 g flour", user)
+	if err != nil {
+		t.Fatalf("ImportFromText error: %v", err)
+	}
 	if resp.UnitSystem != "metric" {
-		t.Errorf("ImportFromText UnitSystem = %q, want 'metric'", resp.UnitSystem)
+		t.Errorf("ImportFromText UnitSystem = %q, want detected source units 'metric'", resp.UnitSystem)
 	}
 }
 


### PR DESCRIPTION
## What

Recipe extraction was forcing primary measurements into the importing user's unit system, discarding the source recipe's original units. This keeps the **source units as primary** and only falls back to the user's preference when the source has nothing to infer from.

- Image / text / URL extraction prompts: use original source units for the primary `unit`/`amount`; report the detected primary system via `unit_system`; only use the user's `{{.UnitSystem}}` for *inferred* measurements when the source has none.
- `ImportFromText` now calls `ensureUnitSystem(&def)` so a detected source system is respected instead of being overwritten by the user's preference.
- Tests cover the US-user / metric-user fallback and the "metric source viewed by a US user is detected as metric" case.

## Why

Importing a metric recipe as a US user (or vice versa) was rewriting the numbers, which loses fidelity to the original recipe. The metric equivalents are still always populated for display.

## Paired change

Frontend counterpart in `saltybytes-app` (`fix/unit-system-source-units`) renders the source amount as primary with the viewer's preferred-system equivalent in parentheses.

🤖 Generated with [Claude Code](https://claude.com/claude-code)