### PR TITLE
Same-dimension-first unit engine + source-fidelity fixes

### DIFF
--- a/configs/prompts.yaml
+++ b/configs/prompts.yaml
@@ -19,10 +19,12 @@ recipe:
     system_prefix: |
       You are a professional chef and recipe creator. You are modifying an existing recipe based on the user's new requirements.
     system: |
-      You must use the {{.UnitSystem}} unit system for the primary measurements (unit and amount fields).
+      Preserve the source recipe's original measurement units as the primary measurements (unit and amount fields). Do not convert existing ingredients to a different unit system just to match a user preference.
+      For any NEW ingredient you introduce that has no source measurement, use the {{.UnitSystem}} unit system.
       For EVERY ingredient, you must ALSO provide the metric equivalent in the metric_unit and metric_amount fields.
       Use accurate cooking-specific conversions (e.g., 1 cup all-purpose flour = 120g, 1 cup granulated sugar = 200g, 1 cup butter = 227g, 1 cup water/milk = 240mL).
-      If the primary unit system is already Metric, duplicate the values into metric_unit and metric_amount.
+      If the primary unit is already metric, duplicate the values into metric_unit and metric_amount.
+      Report the detected primary measurement system via the unit_system field.
       {{if .Requirements}}The user has the following dietary requirements and preferences: {{.Requirements}}{{end}}
       {{if .CookingContext}}{{.CookingContext}}{{end}}
     user: |
@@ -31,10 +33,12 @@ recipe:
     system_prefix: |
       You are a professional chef and recipe creator. You are revising an existing recipe based on the user's feedback and conversation history.
     system: |
-      You must use the {{.UnitSystem}} unit system for the primary measurements (unit and amount fields).
+      Preserve the source recipe's original measurement units as the primary measurements (unit and amount fields). Do not convert existing ingredients to a different unit system just to match a user preference.
+      For any NEW ingredient you introduce that has no source measurement, use the {{.UnitSystem}} unit system.
       For EVERY ingredient, you must ALSO provide the metric equivalent in the metric_unit and metric_amount fields.
       Use accurate cooking-specific conversions (e.g., 1 cup all-purpose flour = 120g, 1 cup granulated sugar = 200g, 1 cup butter = 227g, 1 cup water/milk = 240mL).
-      If the primary unit system is already Metric, duplicate the values into metric_unit and metric_amount.
+      If the primary unit is already metric, duplicate the values into metric_unit and metric_amount.
+      Report the detected primary measurement system via the unit_system field.
       {{if .Requirements}}The user has the following dietary requirements and preferences: {{.Requirements}}{{end}}
       {{if .CookingContext}}{{.CookingContext}}{{end}}
     user: |
@@ -55,6 +59,7 @@ recipe:
         Use accurate cooking-specific conversions (e.g., 1 cup all-purpose flour = 120g, 1 cup granulated sugar = 200g, 1 cup butter = 227g, 1 cup water/milk = 240mL).
         If the primary unit is already metric, duplicate the values into metric_unit and metric_amount.
         Report the detected primary measurement system via the unit_system field.
+        Copy each ingredient's verbatim line, exactly as written in the source, into the original_text field.
         If the image shows a prepared dish without a visible recipe, infer the recipe based on the dish's appearance. Estimate ingredient quantities based on visual portion size.
         {{if .Requirements}}The user has the following dietary requirements and preferences: {{.Requirements}}{{end}}
       user: |
@@ -170,6 +175,7 @@ import:
       Use accurate cooking-specific conversions (e.g., 1 cup all-purpose flour = 120g, 1 cup granulated sugar = 200g, 1 cup butter = 227g, 1 cup water/milk = 240mL).
       If the primary unit is already metric, duplicate the values into metric_unit and metric_amount.
       Report the detected primary measurement system via the unit_system field.
+      Copy each ingredient's verbatim line, exactly as written in the source, into the original_text field.
     user: |
       Extract the recipe from the following text:
       {{.Prompt}}
@@ -185,6 +191,7 @@ import:
       Use accurate cooking-specific conversions (e.g., 1 cup all-purpose flour = 120g, 1 cup granulated sugar = 200g, 1 cup butter = 227g, 1 cup water/milk = 240mL).
       If the primary unit is already metric, duplicate the values into metric_unit and metric_amount.
       Report the detected primary measurement system via the unit_system field.
+      Copy each ingredient's verbatim line, exactly as written in the source, into the original_text field.
     user: |
       Extract the recipe from the following page content:
       {{.Prompt}}

--- a/internal/ai/anthropic.go
+++ b/internal/ai/anthropic.go
@@ -94,8 +94,10 @@ func createRecipeTool(summaryPrompt string) anthropic.ToolUnionParam {
 								"name":          map[string]interface{}{"type": "string", "description": "Name of the ingredient, do not include unit or amount in this field"},
 								"unit":          map[string]interface{}{"type": "string", "description": "Unit for the ingredient, comply with UnitSystem specified.", "enum": []string{"pieces", "tsp", "tbsp", "fl oz", "cup", "pt", "qt", "gal", "oz", "lb", "mL", "L", "mg", "g", "kg", "pinch", "dash", "drop", "bushel"}},
 								"amount":        map[string]interface{}{"type": "number", "description": "Amount of the ingredient"},
+								"amount_high":   map[string]interface{}{"type": "number", "description": "Upper bound when the source gives a range (e.g. '2-3 cups' -> amount 2, amount_high 3). Omit or 0 for a single amount."},
 								"metric_unit":   map[string]interface{}{"type": "string", "description": "Metric equivalent unit. Always metric (g, kg, mL, L, mg). Duplicate primary if already metric.", "enum": []string{"mg", "g", "kg", "mL", "L"}},
 								"metric_amount": map[string]interface{}{"type": "number", "description": "Metric equivalent amount. Use accurate cooking conversions (1 cup flour=120g, 1 cup butter=227g, 1 cup water=240mL). Round to practical amounts."},
+								"original_text": map[string]interface{}{"type": "string", "description": "The verbatim ingredient line as written in the source (e.g. '1 1/2 cups all-purpose flour, sifted'). Copy it exactly; leave empty only when generating an original recipe with no source text."},
 							},
 						},
 					},
@@ -164,8 +166,10 @@ type ingredientToolRes struct {
 	Name         string  `json:"name"`
 	Unit         string  `json:"unit"`
 	Amount       float64 `json:"amount"`
+	AmountHigh   float64 `json:"amount_high"`
 	MetricUnit   string  `json:"metric_unit"`
 	MetricAmount float64 `json:"metric_amount"`
+	OriginalText string  `json:"original_text"`
 }
 
 // analyzeAllergensTool builds the Claude tool definition for allergen analysis.
@@ -425,8 +429,10 @@ func toolResultToRecipeResult(tr *recipeToolResult) *RecipeResult {
 			Name:         ing.Name,
 			Unit:         ing.Unit,
 			Amount:       ing.Amount,
+			AmountHigh:   ing.AmountHigh,
 			MetricUnit:   ing.MetricUnit,
 			MetricAmount: ing.MetricAmount,
+			OriginalText: ing.OriginalText,
 		}
 	}
 	return &RecipeResult{

--- a/internal/ai/provider.go
+++ b/internal/ai/provider.go
@@ -89,6 +89,7 @@ type IngredientResult struct {
 	Name         string
 	Unit         string
 	Amount       float64
+	AmountHigh   float64
 	MetricUnit   string
 	MetricAmount float64
 	OriginalText string

--- a/internal/handlers/import.go
+++ b/internal/handlers/import.go
@@ -209,11 +209,17 @@ func (h *ImportHandler) ImportManual(c *gin.Context) {
 	}
 
 	// Use the unit system supplied by the client when present (e.g. preserved
-	// from a preview extraction); only fall back to the user's personalization
-	// when the request does not specify one.
+	// from a preview extraction). Otherwise detect it from the entered
+	// ingredients so a US recipe typed by a metric user is labeled correctly,
+	// only falling back to the user's personalization when no unit markers
+	// exist at all.
 	unitSystem := request.UnitSystem
 	if unitSystem == "" {
-		unitSystem = user.Personalization.UnitSystem
+		if detected, hasMarker := service.DetectUnitSystemFromIngredients(ingredients); hasMarker {
+			unitSystem = detected
+		} else {
+			unitSystem = user.Personalization.UnitSystem
+		}
 	}
 
 	recipeDef := &models.RecipeDef{

--- a/internal/models/openai_embedded.go
+++ b/internal/models/openai_embedded.go
@@ -43,6 +43,13 @@ func (j RecipeDef) Value() (driver.Value, error) {
 }
 
 // Ingredient is a struct that represents an ingredient in a recipe.
+//
+// Unit/Amount are the SOURCE measurement (authoritative primary, never rewritten
+// to a viewer's preference). MetricUnit/MetricAmount carry the AI-provided
+// density-aware metric equivalent. MeasureKind/BaseAmount are deterministic,
+// user-agnostic normalization (see internal/units) used for display conversion,
+// scaling, and future unit-aware search. AmountHigh is the upper bound of a
+// range quantity ("2-3 cups"); zero for a scalar.
 type Ingredient struct {
 	Name         string  `json:"name"`
 	Unit         string  `json:"unit"`
@@ -50,6 +57,9 @@ type Ingredient struct {
 	MetricUnit   string  `json:"metric_unit,omitempty"`
 	MetricAmount float64 `json:"metric_amount,omitempty"`
 	OriginalText string  `json:"original_text,omitempty"`
+	MeasureKind  string  `json:"measure_kind,omitempty"`
+	BaseAmount   float64 `json:"base_amount,omitempty"`
+	AmountHigh   float64 `json:"amount_high,omitempty"`
 }
 
 // Ingredients is a slice of Ingredient.

--- a/internal/service/canonical.go
+++ b/internal/service/canonical.go
@@ -22,6 +22,12 @@ func MaterializeCanonical(recipe *models.Recipe, repo repository.RecipeRepo) err
 		data.SourceURL = recipe.SourceURL
 	}
 
+	// Detach the ingredient slice from the shared canonical struct, then
+	// backfill normalized measurement fields. This lazily upgrades canonicals
+	// materialized before the normalization fields existed.
+	data.Ingredients = append(models.Ingredients(nil), data.Ingredients...)
+	normalizeIngredients(&data)
+
 	recipe.RecipeDef = data
 	recipe.HasDiverged = true
 

--- a/internal/service/import.go
+++ b/internal/service/import.go
@@ -18,6 +18,7 @@ import (
 	"github.com/windoze95/saltybytes-api/internal/models"
 	"github.com/windoze95/saltybytes-api/internal/repository"
 	"github.com/windoze95/saltybytes-api/internal/s3"
+	"github.com/windoze95/saltybytes-api/internal/units"
 	"go.uber.org/zap"
 )
 
@@ -575,9 +576,7 @@ func (s *ImportService) ImportFromPhoto(ctx context.Context, imageData []byte, u
 	}
 
 	def := recipeResultToRecipeDef(result)
-	if def.UnitSystem == "" {
-		def.UnitSystem = user.Personalization.UnitSystem
-	}
+	ensureUnitSystem(&def)
 
 	// Create the recipe first to get an ID for S3 upload
 	recipeResponse, recipeID, err := s.createImportedRecipe(ctx, &def, user, models.RecipeTypeImportVision, "", "", nil, result.Hashtags, result.PromptVersion)
@@ -835,6 +834,13 @@ func (s *ImportService) createImportedRecipe(ctx context.Context, recipeDef *mod
 		return nil, 0, fmt.Errorf("recipe title is required")
 	}
 
+	// Idempotent safety net: ensure every imported recipe carries normalized
+	// measurement fields even if it reached here without going through a
+	// builder (e.g. the manual path). Detach the ingredient slice first so a
+	// cache-hit canonical's backing array is never mutated in place.
+	recipeDef.Ingredients = append(models.Ingredients(nil), recipeDef.Ingredients...)
+	normalizeIngredients(recipeDef)
+
 	// Estimate portions when the import lacks them (best-effort).
 	if recipeDef.Portions <= 0 && s.Normalize != nil {
 		if estimate, err := s.Normalize.EstimatePortions(ctx, recipeDef); err != nil {
@@ -1062,11 +1068,12 @@ func jsonLDToRecipeDef(recipe *jsonLDRecipe) (*models.RecipeDef, []string, strin
 	// always preserving the original text for display.
 	ingredients := make(models.Ingredients, len(recipe.Ingredients))
 	for i, ingStr := range recipe.Ingredients {
-		if amount, unit, name, ok := ParseIngredientLine(ingStr); ok {
+		if amount, high, unit, name, ok := ParseIngredientLine(ingStr); ok {
 			ingredients[i] = models.Ingredient{
 				Name:         name,
 				Unit:         unit,
 				Amount:       amount,
+				AmountHigh:   high,
 				OriginalText: ingStr,
 			}
 		} else {
@@ -1096,7 +1103,7 @@ func jsonLDToRecipeDef(recipe *jsonLDRecipe) (*models.RecipeDef, []string, strin
 
 	imageURL := parseJSONLDImage(recipe.Image)
 
-	return &models.RecipeDef{
+	def := &models.RecipeDef{
 		Title:        recipe.Name,
 		Ingredients:  ingredients,
 		Instructions: instructions,
@@ -1104,7 +1111,9 @@ func jsonLDToRecipeDef(recipe *jsonLDRecipe) (*models.RecipeDef, []string, strin
 		Portions:     portions,
 		ImagePrompt:  fmt.Sprintf("A photo of %s", recipe.Name),
 		UnitSystem:   unitSystem,
-	}, hashtags, imageURL, nil
+	}
+	normalizeIngredients(def)
+	return def, hashtags, imageURL, nil
 }
 
 // parseJSONLDImage extracts the first usable https image URL from a JSON-LD
@@ -1147,6 +1156,40 @@ func ensureUnitSystem(def *models.RecipeDef) {
 	def.UnitSystem = detectUnitSystem(lines)
 }
 
+// normalizeIngredients populates the deterministic, user-agnostic measurement
+// fields on every ingredient (MeasureKind + BaseAmount) and runs the density
+// sanity guard on the AI metric equivalent. It is idempotent and takes no user
+// input, so it is safe to call at every RecipeDef-construction point and keeps
+// the canonical recipe identical regardless of who imported it.
+//
+// The density guard: when a volume ingredient carries a mass metric equivalent,
+// the implied density must be physically plausible (roughly 0.1–3.0 g/mL spans
+// everything from puffed cereal to honey). An order-of-magnitude hallucination
+// ("2 cups flour = 5000 g") is rejected in favor of an exact same-dimension
+// metric volume, so a metric viewer still gets a sane number with no curated
+// density table.
+func normalizeIngredients(def *models.RecipeDef) {
+	if def == nil {
+		return
+	}
+	for i := range def.Ingredients {
+		ing := &def.Ingredients[i]
+		kind := units.MeasureKind(ing.Unit, ing.Name, ing.MetricUnit)
+		ing.MeasureKind = kind
+		ing.BaseAmount = units.BaseAmount(ing.Amount, ing.Unit, kind)
+
+		if kind == units.KindVolume && ing.BaseAmount > 0 && ing.MetricAmount > 0 &&
+			units.DimensionOf(ing.MetricUnit) == units.KindMass {
+			grams := units.BaseAmount(ing.MetricAmount, ing.MetricUnit, units.KindMass)
+			if density := grams / ing.BaseAmount; density < 0.1 || density > 3.0 {
+				amt, unit := units.ExpressInSystem(ing.BaseAmount, units.KindVolume, units.SystemMetric)
+				ing.MetricAmount = amt
+				ing.MetricUnit = unit
+			}
+		}
+	}
+}
+
 // Compiled regexes for unit system detection.
 var (
 	// Matches metric units: "250g", "100 mL", "2 kg", "500ml", etc.
@@ -1171,6 +1214,27 @@ func detectUnitSystem(ingredients []string) string {
 		return "metric"
 	}
 	return "us_customary"
+}
+
+// DetectUnitSystemFromIngredients detects the measurement system from manual
+// ingredient entries, returning ok=false when no line carries any unit marker
+// at all (so the caller can fall back to a user preference instead of
+// defaulting to us_customary). This keeps a metric user's "2 cups" recipe
+// labeled us_customary while a unit-less "2 eggs" recipe defers to preference.
+func DetectUnitSystemFromIngredients(ings models.Ingredients) (string, bool) {
+	lines := make([]string, 0, len(ings))
+	hasMarker := false
+	for _, ing := range ings {
+		line := ing.OriginalText
+		if line == "" {
+			line = strings.TrimSpace(fmt.Sprintf("%v %s %s", ing.Amount, ing.Unit, ing.Name))
+		}
+		lines = append(lines, line)
+		if metricRe.MatchString(line) || usRe.MatchString(line) {
+			hasMarker = true
+		}
+	}
+	return detectUnitSystem(lines), hasMarker
 }
 
 // parseJSONLDInstructions extracts instruction strings from various JSON-LD formats.

--- a/internal/service/ingredient_parse.go
+++ b/internal/service/ingredient_parse.go
@@ -80,15 +80,15 @@ var unitAliases = map[string]string{
 // used). The unit is optional; when no known unit token follows the quantity,
 // unit is returned empty. Lines without a leading numeric quantity (e.g.
 // "a pinch of salt") return ok=false and should keep their original text.
-func ParseIngredientLine(s string) (amount float64, unit string, name string, ok bool) {
+func ParseIngredientLine(s string) (amount float64, amountHigh float64, unit string, name string, ok bool) {
 	tokens := strings.Fields(strings.TrimSpace(s))
 	if len(tokens) == 0 {
-		return 0, "", "", false
+		return 0, 0, "", "", false
 	}
 
-	amount, consumed, ok := parseQuantity(tokens)
+	amount, amountHigh, consumed, ok := parseQuantity(tokens)
 	if !ok || amount <= 0 {
-		return 0, "", "", false
+		return 0, 0, "", "", false
 	}
 	rest := tokens[consumed:]
 
@@ -103,38 +103,41 @@ func ParseIngredientLine(s string) (amount float64, unit string, name string, ok
 	name = strings.Join(rest, " ")
 	name = strings.TrimSpace(strings.TrimPrefix(name, "of "))
 	if name == "" {
-		return 0, "", "", false
+		return 0, 0, "", "", false
 	}
-	return amount, unit, name, true
+	return amount, amountHigh, unit, name, true
 }
 
 // parseQuantity parses a leading quantity from the token stream, returning the
 // value and the number of tokens consumed. It handles plain numbers, ASCII and
 // unicode fractions, mixed numbers ("1 1/2", "1½"), and ranges ("1-2",
 // "1 to 2") where the low value is kept.
-func parseQuantity(tokens []string) (float64, int, bool) {
+func parseQuantity(tokens []string) (low float64, high float64, consumed int, ok bool) {
 	first, ok := parseNumberToken(tokens[0])
 	if !ok {
-		return 0, 0, false
+		return 0, 0, 0, false
 	}
-	consumed := 1
+	low = first
+	consumed = 1
 
 	// Mixed number across tokens: "1 1/2", "1 ½"
 	if len(tokens) > consumed {
 		if frac, fracOK := parseFractionToken(tokens[consumed]); fracOK {
-			first += frac
+			low += frac
 			consumed++
 		}
 	}
 
-	// Range across tokens: "1 - 2", "1 to 2" — keep the low value.
+	// Range across tokens: "1 - 2", "1 to 2" — keep the low value as the
+	// primary amount and capture the high bound.
 	if len(tokens) > consumed+1 && isRangeSeparator(tokens[consumed]) {
-		if _, highOK := parseNumberToken(tokens[consumed+1]); highOK {
+		if h, highOK := parseNumberToken(tokens[consumed+1]); highOK {
+			high = h
 			consumed += 2
 		}
 	}
 
-	return first, consumed, true
+	return low, high, consumed, true
 }
 
 // isRangeSeparator reports whether a token separates the low and high values
@@ -153,6 +156,8 @@ func parseNumberToken(tok string) (float64, bool) {
 	if tok == "" {
 		return 0, false
 	}
+
+	tok = normalizeDecimalToken(tok)
 
 	// Hyphenated token: mixed number ("1-1/2") or range ("1-2").
 	for _, sep := range []string{"-", "–", "—"} {
@@ -197,6 +202,26 @@ func parseNumberToken(tok string) (float64, bool) {
 		return 0, false
 	}
 	return v, true
+}
+
+// normalizeDecimalToken folds a European decimal comma ("1,5" -> "1.5") or a
+// thousands grouping ("1,000" -> "1000") into a plain parseable number, so a
+// metric source recipe's quantities are not silently zeroed. Only a single
+// comma in an otherwise all-digit, period-free token is touched; three trailing
+// digits are read as grouping, fewer as a decimal fraction.
+func normalizeDecimalToken(tok string) string {
+	if strings.Count(tok, ",") != 1 || strings.Contains(tok, ".") {
+		return tok
+	}
+	i := strings.IndexByte(tok, ',')
+	intPart, fracPart := tok[:i], tok[i+1:]
+	if !isWholeIntegerToken(intPart) || !isWholeIntegerToken(fracPart) {
+		return tok
+	}
+	if len(fracPart) == 3 {
+		return intPart + fracPart
+	}
+	return intPart + "." + fracPart
 }
 
 // isWholeIntegerToken reports whether a token is a plain whole integer

--- a/internal/service/ingredient_parse_test.go
+++ b/internal/service/ingredient_parse_test.go
@@ -75,7 +75,7 @@ func TestParseIngredientLine(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			amount, unit, name, ok := ParseIngredientLine(tt.input)
+			amount, _, unit, name, ok := ParseIngredientLine(tt.input)
 			if ok != tt.wantOK {
 				t.Fatalf("ParseIngredientLine(%q) ok = %v, want %v", tt.input, ok, tt.wantOK)
 			}
@@ -92,5 +92,42 @@ func TestParseIngredientLine(t *testing.T) {
 				t.Errorf("ParseIngredientLine(%q) name = %q, want %q", tt.input, name, tt.wantName)
 			}
 		})
+	}
+}
+
+func TestParseIngredientLine_CapturesRangeHigh(t *testing.T) {
+	cases := []struct {
+		input    string
+		wantLow  float64
+		wantHigh float64
+	}{
+		{"2 - 3 cups stock", 2, 3},
+		{"1 to 2 tsp vanilla", 1, 2},
+		{"2 cups flour", 2, 0}, // scalar: no high bound
+	}
+	for _, c := range cases {
+		low, high, _, _, ok := ParseIngredientLine(c.input)
+		if !ok || !almostEqual(low, c.wantLow) || !almostEqual(high, c.wantHigh) {
+			t.Errorf("ParseIngredientLine(%q) = %v..%v ok=%v; want %v..%v", c.input, low, high, ok, c.wantLow, c.wantHigh)
+		}
+	}
+}
+
+func TestParseIngredientLine_DecimalComma(t *testing.T) {
+	cases := []struct {
+		input      string
+		wantAmount float64
+		wantUnit   string
+	}{
+		{"1,5 L water", 1.5, "L"},
+		{"0,5 kg flour", 0.5, "kg"},
+		{"250,5 g sugar", 250.5, "g"},
+		{"1,000 g rice", 1000, "g"}, // thousands grouping
+	}
+	for _, c := range cases {
+		amount, _, unit, _, ok := ParseIngredientLine(c.input)
+		if !ok || !almostEqual(amount, c.wantAmount) || unit != c.wantUnit {
+			t.Errorf("ParseIngredientLine(%q) = %v %q ok=%v; want %v %q", c.input, amount, unit, ok, c.wantAmount, c.wantUnit)
+		}
 	}
 }

--- a/internal/service/normalize_test.go
+++ b/internal/service/normalize_test.go
@@ -1,0 +1,76 @@
+package service
+
+import (
+	"math"
+	"testing"
+
+	"github.com/windoze95/saltybytes-api/internal/models"
+	"github.com/windoze95/saltybytes-api/internal/units"
+)
+
+func TestNormalizeIngredients_SetsMeasureFields(t *testing.T) {
+	def := &models.RecipeDef{Ingredients: models.Ingredients{
+		{Name: "flour", Unit: "cup", Amount: 2, MetricUnit: "g", MetricAmount: 240},
+		{Name: "beef", Unit: "g", Amount: 500},
+		{Name: "egg", Unit: "pieces", Amount: 3},
+		{Name: "salt", Unit: "pinch", Amount: 1},
+	}}
+	normalizeIngredients(def)
+
+	if k := def.Ingredients[0].MeasureKind; k != units.KindVolume {
+		t.Errorf("flour kind = %q; want volume", k)
+	}
+	if b := def.Ingredients[0].BaseAmount; math.Abs(b-473.176) > 0.1 {
+		t.Errorf("flour base = %v; want ~473.18 mL", b)
+	}
+	if k := def.Ingredients[1].MeasureKind; k != units.KindMass {
+		t.Errorf("beef kind = %q; want mass", k)
+	}
+	if def.Ingredients[2].MeasureKind != units.KindCount || def.Ingredients[2].BaseAmount != 3 {
+		t.Errorf("egg = %q/%v; want count/3", def.Ingredients[2].MeasureKind, def.Ingredients[2].BaseAmount)
+	}
+	if def.Ingredients[3].MeasureKind != units.KindImprecise || def.Ingredients[3].BaseAmount != 0 {
+		t.Errorf("salt = %q/%v; want imprecise/0", def.Ingredients[3].MeasureKind, def.Ingredients[3].BaseAmount)
+	}
+}
+
+func TestNormalizeIngredients_DensityGuard(t *testing.T) {
+	// Legit density (flour ~0.5 g/mL) is preserved.
+	legit := &models.RecipeDef{Ingredients: models.Ingredients{
+		{Name: "flour", Unit: "cup", Amount: 2, MetricUnit: "g", MetricAmount: 240},
+	}}
+	normalizeIngredients(legit)
+	if legit.Ingredients[0].MetricUnit != "g" || legit.Ingredients[0].MetricAmount != 240 {
+		t.Errorf("legit metric pair was altered: %v %v", legit.Ingredients[0].MetricAmount, legit.Ingredients[0].MetricUnit)
+	}
+
+	// Order-of-magnitude hallucination (2 cups -> 5000 g, ~10.6 g/mL) is
+	// rejected in favor of an exact same-dimension metric volume.
+	bogus := &models.RecipeDef{Ingredients: models.Ingredients{
+		{Name: "flour", Unit: "cup", Amount: 2, MetricUnit: "g", MetricAmount: 5000},
+	}}
+	normalizeIngredients(bogus)
+	if bogus.Ingredients[0].MetricUnit != "mL" {
+		t.Errorf("bogus metric pair not rejected: got %v %v; want mL volume",
+			bogus.Ingredients[0].MetricAmount, bogus.Ingredients[0].MetricUnit)
+	}
+}
+
+// The canonical recipe must be byte-identical regardless of who imported it:
+// normalization takes no user input.
+func TestNormalizeIngredients_UserAgnostic(t *testing.T) {
+	mk := func() *models.RecipeDef {
+		return &models.RecipeDef{Ingredients: models.Ingredients{
+			{Name: "flour", Unit: "cup", Amount: 2, MetricUnit: "g", MetricAmount: 240},
+			{Name: "milk", Unit: "mL", Amount: 250},
+		}}
+	}
+	a, b := mk(), mk()
+	normalizeIngredients(a)
+	normalizeIngredients(b)
+	for i := range a.Ingredients {
+		if a.Ingredients[i] != b.Ingredients[i] {
+			t.Errorf("ingredient %d differs across runs: %+v vs %+v", i, a.Ingredients[i], b.Ingredients[i])
+		}
+	}
+}

--- a/internal/service/recipe.go
+++ b/internal/service/recipe.go
@@ -285,12 +285,13 @@ func recipeResultToRecipeDef(r *ai.RecipeResult) models.RecipeDef {
 			Name:         ing.Name,
 			Unit:         ing.Unit,
 			Amount:       ing.Amount,
+			AmountHigh:   ing.AmountHigh,
 			MetricUnit:   ing.MetricUnit,
 			MetricAmount: ing.MetricAmount,
 			OriginalText: ing.OriginalText,
 		}
 	}
-	return models.RecipeDef{
+	def := models.RecipeDef{
 		Title:             r.Title,
 		Ingredients:       ingredients,
 		Instructions:      r.Instructions,
@@ -302,6 +303,8 @@ func recipeResultToRecipeDef(r *ai.RecipeResult) models.RecipeDef {
 		SourceURL:         r.SourceURL,
 		UnitSystem:        r.UnitSystem,
 	}
+	normalizeIngredients(&def)
+	return def
 }
 
 // validateRecipeFields validates that the Recipe's required fields are populated.

--- a/internal/units/spec.go
+++ b/internal/units/spec.go
@@ -1,0 +1,407 @@
+// Package units is the single source of truth for SaltyBytes' unit handling:
+// canonical unit metadata (dimension, measurement system, factor to a base
+// unit), measure-kind classification, base-quantity normalization, and
+// deterministic display conversion.
+//
+// The conversion model is SAME-DIMENSION-FIRST: mass<->mass and volume<->volume
+// are always exact, and crossing dimensions (volume<->mass) is the exception.
+// We only ever cross dimensions in the US->metric direction, and only by
+// trusting the AI-provided density-aware metric equivalent (metric_unit /
+// metric_amount). There is deliberately NO hand-maintained ingredient-density
+// table: a metric-source ingredient shown to a US viewer is rendered with an
+// exact same-dimension unit (g -> oz/lb, mL -> tsp/cup), never a guessed cup
+// count. This eliminates the entire class of density-guessing errors.
+//
+// This Go package is the canonical reference; the Flutter app mirrors these
+// constants and rules in lib/core/utils/unit_converter.dart, pinned by the same
+// golden vectors in both test suites.
+package units
+
+import (
+	"math"
+	"strings"
+)
+
+// Measure kinds. Count and Imprecise units are never converted.
+const (
+	KindMass      = "mass"
+	KindVolume    = "volume"
+	KindCount     = "count"
+	KindImprecise = "imprecise"
+)
+
+// Measurement systems, matching models.RecipeDef.UnitSystem values.
+const (
+	SystemUS     = "us_customary"
+	SystemMetric = "metric"
+)
+
+type unitMeta struct {
+	dim    string  // KindMass | KindVolume
+	system string  // SystemUS | SystemMetric
+	factor float64 // amount * factor = base magnitude (g for mass, mL for volume)
+}
+
+// meta holds the canonical-unit metadata. Keys are the canonical unit enum used
+// by the create_recipe Claude tool and the ingredient parser.
+var meta = map[string]unitMeta{
+	// US customary volume (base mL)
+	"tsp":   {KindVolume, SystemUS, 4.92892},
+	"tbsp":  {KindVolume, SystemUS, 14.7868},
+	"fl oz": {KindVolume, SystemUS, 29.5735},
+	"cup":   {KindVolume, SystemUS, 236.588},
+	"pt":    {KindVolume, SystemUS, 473.176},
+	"qt":    {KindVolume, SystemUS, 946.353},
+	"gal":   {KindVolume, SystemUS, 3785.41},
+	// US customary mass (base g)
+	"oz": {KindMass, SystemUS, 28.3495},
+	"lb": {KindMass, SystemUS, 453.592},
+	// metric volume (base mL)
+	"mL": {KindVolume, SystemMetric, 1},
+	"L":  {KindVolume, SystemMetric, 1000},
+	// metric mass (base g)
+	"mg": {KindMass, SystemMetric, 0.001},
+	"g":  {KindMass, SystemMetric, 1},
+	"kg": {KindMass, SystemMetric, 1000},
+}
+
+// aliases maps lowercase unit spellings (plurals, abbreviations, long forms) to
+// the canonical unit enum. This is the single source of truth; the ingredient
+// line parser resolves tokens through Canonical.
+var aliases = map[string]string{
+	// volume — US customary
+	"tsp": "tsp", "tsps": "tsp", "teaspoon": "tsp", "teaspoons": "tsp",
+	"tbsp": "tbsp", "tbsps": "tbsp", "tbs": "tbsp", "tbl": "tbsp", "tblsp": "tbsp",
+	"tablespoon": "tbsp", "tablespoons": "tbsp",
+	"cup": "cup", "cups": "cup", "c": "cup",
+	"pt": "pt", "pts": "pt", "pint": "pt", "pints": "pt",
+	"qt": "qt", "qts": "qt", "quart": "qt", "quarts": "qt",
+	"gal": "gal", "gals": "gal", "gallon": "gal", "gallons": "gal",
+	"floz": "fl oz",
+	// weight — US customary
+	"oz": "oz", "ozs": "oz", "ounce": "oz", "ounces": "oz",
+	"lb": "lb", "lbs": "lb", "pound": "lb", "pounds": "lb",
+	// metric volume
+	"ml": "mL", "mls": "mL", "milliliter": "mL", "milliliters": "mL",
+	"millilitre": "mL", "millilitres": "mL", "cc": "mL",
+	"cl": "cl", "centiliter": "cl", "centilitre": "cl",
+	"dl": "dl", "deciliter": "dl", "decilitre": "dl",
+	"l": "L", "liter": "L", "liters": "L", "litre": "L", "litres": "L",
+	// metric weight
+	"mg": "mg", "mgs": "mg", "milligram": "mg", "milligrams": "mg",
+	"g": "g", "gram": "g", "grams": "g", "gr": "g",
+	"kg": "kg", "kgs": "kg", "kilogram": "kg", "kilograms": "kg", "kilo": "kg", "kilos": "kg",
+	// small measures
+	"pinch": "pinch", "pinches": "pinch",
+	"dash": "dash", "dashes": "dash",
+	"drop": "drop", "drops": "drop",
+	"bushel": "bushel", "bushels": "bushel",
+	// countable descriptors — collapse to the canonical "pieces"
+	"piece": "pieces", "pieces": "pieces", "pc": "pieces", "pcs": "pieces",
+	"clove": "pieces", "cloves": "pieces",
+	"can": "pieces", "cans": "pieces",
+	"slice": "pieces", "slices": "pieces",
+	"stick": "pieces", "sticks": "pieces",
+	"stalk": "pieces", "stalks": "pieces",
+	"sprig": "pieces", "sprigs": "pieces",
+	"head": "pieces", "heads": "pieces",
+	"bunch": "pieces", "bunches": "pieces",
+	"package": "pieces", "packages": "pieces", "pkg": "pieces", "pkgs": "pieces",
+	"ear": "pieces", "ears": "pieces",
+	"fillet": "pieces", "fillets": "pieces",
+}
+
+// cl and dl are non-canonical metric volumes we accept on input and fold into
+// mL so the rest of the pipeline only deals with the canonical enum.
+var inputOnlyFactor = map[string]float64{
+	"cl": 10,
+	"dl": 100,
+}
+
+// liquidNames are ingredient-name substrings that mark an "oz" measurement as a
+// fluid (volume) ounce rather than a weight ounce. Kept deliberately to
+// unambiguous liquids — words like "cream" (cream cheese, sour cream) or
+// "syrup"/"sauce" (often sold by weight) are excluded; the AI metric dimension
+// is the primary signal and the name lexicon only a no-metric fallback.
+var liquidNames = []string{
+	"water", "milk", "stock", "broth", "wine", "juice", "oil",
+	"vinegar", "beer", "coffee", "tea", "buttermilk",
+	"liqueur", "rum", "vodka", "whiskey", "brandy", "soda",
+}
+
+// Canonical resolves a unit spelling (any case) to its canonical enum value.
+func Canonical(token string) (string, bool) {
+	t := strings.ToLower(strings.TrimSpace(token))
+	if t == "" {
+		return "", false
+	}
+	c, ok := aliases[t]
+	return c, ok
+}
+
+func isLiquidName(name string) bool {
+	n := strings.ToLower(name)
+	for _, l := range liquidNames {
+		if strings.Contains(n, l) {
+			return true
+		}
+	}
+	return false
+}
+
+// canonicalize resolves a possibly-aliased unit to its canonical form, leaving
+// already-canonical units untouched.
+func canonicalize(unit string) string {
+	if _, ok := meta[unit]; ok {
+		return unit
+	}
+	if c, ok := Canonical(unit); ok {
+		return c
+	}
+	return unit
+}
+
+// DimensionOf returns KindMass or KindVolume for a measurable unit, or "" for
+// count/imprecise/unknown units.
+func DimensionOf(unit string) string {
+	if m, ok := meta[canonicalize(unit)]; ok {
+		return m.dim
+	}
+	return ""
+}
+
+// SystemOf returns SystemUS or SystemMetric for a measurable unit, or "" for
+// count/imprecise/unknown units (which belong to no system).
+func SystemOf(unit string) string {
+	if m, ok := meta[canonicalize(unit)]; ok {
+		return m.system
+	}
+	return ""
+}
+
+// MeasureKind classifies an ingredient. name and metricUnit disambiguate "oz"
+// (weight vs fluid ounce): an oz is fluid when its metric equivalent is a
+// volume or the ingredient name reads as a liquid.
+func MeasureKind(unit, name, metricUnit string) string {
+	u := canonicalize(unit)
+	if u == "oz" {
+		// Trust the AI metric dimension first; fall back to the name lexicon.
+		switch DimensionOf(metricUnit) {
+		case KindVolume:
+			return KindVolume
+		case KindMass:
+			return KindMass
+		}
+		if isLiquidName(name) {
+			return KindVolume
+		}
+		return KindMass
+	}
+	if m, ok := meta[u]; ok {
+		return m.dim
+	}
+	switch u {
+	case "pieces":
+		return KindCount
+	case "pinch", "dash", "drop", "bushel":
+		return KindImprecise
+	}
+	return KindImprecise
+}
+
+// BaseAmount converts an amount to its base magnitude in the ingredient's own
+// dimension: grams for mass, mL for volume, the amount itself for count.
+// kind is the resolved MeasureKind (so a fluid "oz" uses the fl-oz factor).
+// Returns 0 for imprecise units.
+func BaseAmount(amount float64, unit, kind string) float64 {
+	u := canonicalize(unit)
+	switch kind {
+	case KindCount:
+		return amount
+	case KindImprecise:
+		return 0
+	}
+	if u == "oz" && kind == KindVolume {
+		return amount * meta["fl oz"].factor
+	}
+	if f, ok := inputOnlyFactor[strings.ToLower(unit)]; ok {
+		return amount * f
+	}
+	if m, ok := meta[u]; ok {
+		return amount * m.factor
+	}
+	return 0
+}
+
+// Quantity is a value view of an ingredient measurement for conversion.
+type Quantity struct {
+	Amount       float64
+	Unit         string
+	Kind         string  // resolved MeasureKind
+	BaseAmount   float64 // base magnitude in the source dimension (0 = derive)
+	MetricUnit   string  // AI-provided density-aware metric equivalent
+	MetricAmount float64
+}
+
+// ToViewer renders a quantity in the viewer's measurement system, returning the
+// converted amount/unit and ok=true when a useful alternate exists. It returns
+// ok=false when no conversion is needed or possible (count/imprecise units, or
+// the ingredient is already in the viewer's system).
+//
+// Cross-dimension density is only applied US->metric, and only via the
+// AI-provided metric pair. Every other conversion is exact same-dimension.
+func ToViewer(q Quantity, viewer string) (float64, string, bool) {
+	if q.Kind == KindCount || q.Kind == KindImprecise || q.Kind == "" {
+		return 0, "", false
+	}
+	src := SystemOf(q.Unit)
+	if src == "" || src == viewer {
+		return 0, "", false
+	}
+
+	base := q.BaseAmount
+	if base == 0 {
+		base = BaseAmount(q.Amount, q.Unit, q.Kind)
+	}
+	if base <= 0 {
+		return 0, "", false
+	}
+
+	// US -> metric may cross dimensions via the density-aware AI metric pair.
+	if viewer == SystemMetric && src == SystemUS {
+		if q.MetricUnit != "" && q.MetricAmount > 0 {
+			return q.MetricAmount, canonicalize(q.MetricUnit), true
+		}
+	}
+
+	amount, unit := ExpressInSystem(base, q.Kind, viewer)
+	if amount <= 0 {
+		return 0, "", false
+	}
+	return amount, unit, true
+}
+
+// ExpressInSystem picks a cooking-friendly unit and amount for a base magnitude
+// in the given system and dimension. Used for both same-dimension conversion
+// and re-expressing a scaled primary in its own system.
+func ExpressInSystem(base float64, kind, system string) (float64, string) {
+	switch kind {
+	case KindMass:
+		if system == SystemMetric {
+			return metricMass(base)
+		}
+		return usMass(base)
+	case KindVolume:
+		if system == SystemMetric {
+			return metricVolume(base)
+		}
+		return usVolume(base)
+	}
+	return 0, ""
+}
+
+// Scale multiplies a quantity by factor and re-expresses it in its own
+// (source) system with a cooking-friendly unit. Count/imprecise units scale
+// their amount but keep their unit. Rounding happens once, here.
+func Scale(q Quantity, factor float64) (float64, string) {
+	if factor <= 0 {
+		return q.Amount, q.Unit
+	}
+	if q.Kind == KindCount || q.Kind == KindImprecise || q.Kind == "" || SystemOf(q.Unit) == "" {
+		return roundCount(q.Amount * factor), q.Unit
+	}
+	base := q.BaseAmount
+	if base == 0 {
+		base = BaseAmount(q.Amount, q.Unit, q.Kind)
+	}
+	return ExpressInSystem(base*factor, q.Kind, SystemOf(q.Unit))
+}
+
+// --- system-specific unit selection -----------------------------------------
+
+func usVolume(ml float64) (float64, string) {
+	switch {
+	case ml < 14.7868: // under 1 tbsp
+		return snapCookingFraction(ml / meta["tsp"].factor), "tsp"
+	case ml < 0.25*meta["cup"].factor: // under 1/4 cup
+		return snapCookingFraction(ml / meta["tbsp"].factor), "tbsp"
+	case ml < 4.5*meta["cup"].factor: // up to ~4 cups
+		return snapCookingFraction(ml / meta["cup"].factor), "cup"
+	case ml < 4*meta["qt"].factor:
+		return snapCookingFraction(ml / meta["qt"].factor), "qt"
+	default:
+		return round1(ml / meta["gal"].factor), "gal"
+	}
+}
+
+func usMass(g float64) (float64, string) {
+	if g >= meta["lb"].factor {
+		return round1(g / meta["lb"].factor), "lb"
+	}
+	return round1(g / meta["oz"].factor), "oz"
+}
+
+func metricVolume(ml float64) (float64, string) {
+	if ml >= 1000 {
+		return round2(ml / 1000), "L"
+	}
+	return roundMetricSmall(ml), "mL"
+}
+
+func metricMass(g float64) (float64, string) {
+	if g >= 1000 {
+		return round2(g / 1000), "kg"
+	}
+	return roundMetricSmall(g), "g"
+}
+
+// --- rounding / snapping -----------------------------------------------------
+
+// cookingFractions are the eighths and thirds/sixths cooks actually use.
+var cookingFractions = []float64{
+	0, 1.0 / 8, 1.0 / 6, 1.0 / 4, 1.0 / 3, 3.0 / 8, 1.0 / 2,
+	5.0 / 8, 2.0 / 3, 3.0 / 4, 5.0 / 6, 7.0 / 8, 1,
+}
+
+// snapCookingFraction snaps a value to the nearest whole + common cooking
+// fraction (1/8 granularity plus thirds/sixths).
+func snapCookingFraction(x float64) float64 {
+	if x <= 0 {
+		return 0
+	}
+	whole := math.Floor(x)
+	frac := x - whole
+	best := 0.0
+	bestDist := math.MaxFloat64
+	for _, f := range cookingFractions {
+		if d := math.Abs(frac - f); d < bestDist {
+			bestDist = d
+			best = f
+		}
+	}
+	return whole + best
+}
+
+func round1(x float64) float64 { return math.Round(x*10) / 10 }
+func round2(x float64) float64 { return math.Round(x*100) / 100 }
+
+// roundCount rounds discrete counts to a half when small, whole when larger,
+// so scaling never yields "1.5 cans" style noise on big counts.
+func roundCount(x float64) float64 {
+	if x < 4 {
+		return math.Round(x*2) / 2
+	}
+	return math.Round(x)
+}
+
+// roundMetricSmall rounds a sub-1000 metric magnitude to a tidy value: whole
+// numbers, or the nearest 5 once we are into the hundreds.
+func roundMetricSmall(x float64) float64 {
+	if x >= 100 {
+		return math.Round(x/5) * 5
+	}
+	if x >= 10 {
+		return math.Round(x)
+	}
+	return round1(x)
+}

--- a/internal/units/spec_test.go
+++ b/internal/units/spec_test.go
@@ -1,0 +1,184 @@
+package units
+
+import (
+	"math"
+	"testing"
+)
+
+func approx(a, b float64) bool { return math.Abs(a-b) < 0.05 }
+
+func TestCanonical(t *testing.T) {
+	cases := map[string]string{
+		"grams": "g", "Grams": "g", "ml": "mL", "ML": "mL",
+		"tablespoons": "tbsp", "CUPS": "cup", "pounds": "lb",
+		"cloves": "pieces", "sticks": "pieces", "dl": "dl",
+	}
+	for in, want := range cases {
+		if got, ok := Canonical(in); !ok || got != want {
+			t.Errorf("Canonical(%q) = %q,%v; want %q", in, got, ok, want)
+		}
+	}
+	if _, ok := Canonical("frobnicate"); ok {
+		t.Error("Canonical(frobnicate) should not resolve")
+	}
+}
+
+func TestMeasureKind(t *testing.T) {
+	cases := []struct {
+		unit, name, metric, want string
+	}{
+		{"cup", "flour", "g", KindVolume},
+		{"g", "flour", "", KindMass},
+		{"kg", "beef", "", KindMass},
+		{"mL", "milk", "", KindVolume},
+		{"pieces", "egg", "", KindCount},
+		{"clove", "garlic", "", KindCount},
+		{"pinch", "salt", "", KindImprecise},
+		{"", "salt to taste", "", KindImprecise},
+		// oz disambiguation
+		{"oz", "cream cheese", "g", KindMass},   // metric=g -> weight
+		{"oz", "milk", "mL", KindVolume},        // metric=mL -> fluid
+		{"oz", "water", "", KindVolume},         // liquid name, no metric
+		{"oz", "chocolate chips", "", KindMass}, // default weight
+		{"oz", "sour cream", "", KindMass},      // "cream" must NOT read as fluid
+	}
+	for _, c := range cases {
+		if got := MeasureKind(c.unit, c.name, c.metric); got != c.want {
+			t.Errorf("MeasureKind(%q,%q,%q) = %q; want %q", c.unit, c.name, c.metric, got, c.want)
+		}
+	}
+}
+
+func TestBaseAmount(t *testing.T) {
+	cases := []struct {
+		amount     float64
+		unit, kind string
+		want       float64
+	}{
+		{2, "cup", KindVolume, 473.176},
+		{200, "g", KindMass, 200},
+		{8, "oz", KindMass, 226.796},
+		{8, "oz", KindVolume, 236.588}, // fluid oz factor
+		{1, "kg", KindMass, 1000},
+		{1, "L", KindVolume, 1000},
+		{2, "pieces", KindCount, 2},
+		{1, "pinch", KindImprecise, 0},
+		{5, "dl", KindVolume, 500}, // input-only metric unit
+	}
+	for _, c := range cases {
+		if got := BaseAmount(c.amount, c.unit, c.kind); !approx(got, c.want) {
+			t.Errorf("BaseAmount(%v,%q,%q) = %v; want %v", c.amount, c.unit, c.kind, got, c.want)
+		}
+	}
+}
+
+func TestToViewer(t *testing.T) {
+	cases := []struct {
+		name       string
+		q          Quantity
+		viewer     string
+		wantOK     bool
+		wantAmount float64
+		wantUnit   string
+	}{
+		{
+			name:   "US cup to metric uses AI density pair",
+			q:      Quantity{Amount: 2, Unit: "cup", Kind: KindVolume, BaseAmount: 473.176, MetricUnit: "g", MetricAmount: 240},
+			viewer: SystemMetric, wantOK: true, wantAmount: 240, wantUnit: "g",
+		},
+		{
+			name:   "US cup to metric without pair falls to same-dimension mL",
+			q:      Quantity{Amount: 2, Unit: "cup", Kind: KindVolume, BaseAmount: 473.176},
+			viewer: SystemMetric, wantOK: true, wantAmount: 475, wantUnit: "mL",
+		},
+		{
+			name:   "metric grams to US is exact ounces, never cups",
+			q:      Quantity{Amount: 200, Unit: "g", Kind: KindMass, BaseAmount: 200},
+			viewer: SystemUS, wantOK: true, wantAmount: 7.1, wantUnit: "oz",
+		},
+		{
+			name:   "metric grams chicken to US is pounds, never cups",
+			q:      Quantity{Amount: 500, Unit: "g", Kind: KindMass, BaseAmount: 500},
+			viewer: SystemUS, wantOK: true, wantAmount: 1.1, wantUnit: "lb",
+		},
+		{
+			name:   "metric mL to US cup",
+			q:      Quantity{Amount: 240, Unit: "mL", Kind: KindVolume, BaseAmount: 240},
+			viewer: SystemUS, wantOK: true, wantAmount: 1, wantUnit: "cup",
+		},
+		{
+			name:   "small metric mL to US tsp",
+			q:      Quantity{Amount: 10, Unit: "mL", Kind: KindVolume, BaseAmount: 10},
+			viewer: SystemUS, wantOK: true, wantAmount: 2, wantUnit: "tsp",
+		},
+		{
+			name:   "same system needs no conversion",
+			q:      Quantity{Amount: 2, Unit: "cup", Kind: KindVolume, BaseAmount: 473.176},
+			viewer: SystemUS, wantOK: false,
+		},
+		{
+			name:   "count never converts",
+			q:      Quantity{Amount: 3, Unit: "pieces", Kind: KindCount},
+			viewer: SystemMetric, wantOK: false,
+		},
+		{
+			name:   "imprecise never converts",
+			q:      Quantity{Amount: 1, Unit: "pinch", Kind: KindImprecise},
+			viewer: SystemMetric, wantOK: false,
+		},
+	}
+	for _, c := range cases {
+		amt, unit, ok := ToViewer(c.q, c.viewer)
+		if ok != c.wantOK {
+			t.Errorf("%s: ok = %v; want %v", c.name, ok, c.wantOK)
+			continue
+		}
+		if !ok {
+			continue
+		}
+		if !approx(amt, c.wantAmount) || unit != c.wantUnit {
+			t.Errorf("%s: = %v %q; want %v %q", c.name, amt, unit, c.wantAmount, c.wantUnit)
+		}
+	}
+}
+
+func TestScale(t *testing.T) {
+	cases := []struct {
+		name       string
+		q          Quantity
+		factor     float64
+		wantAmount float64
+		wantUnit   string
+	}{
+		{"8 tbsp doubled is 1 cup", Quantity{Amount: 8, Unit: "tbsp", Kind: KindVolume, BaseAmount: 118.294}, 2, 1, "cup"},
+		{"1/3 cup tripled is 1 cup", Quantity{Amount: 1.0 / 3, Unit: "cup", Kind: KindVolume, BaseAmount: 236.588 / 3}, 3, 1, "cup"},
+		{"3 eggs halved is 1.5 pieces", Quantity{Amount: 3, Unit: "pieces", Kind: KindCount}, 0.5, 1.5, "pieces"},
+		{"200 g doubled is 400 g", Quantity{Amount: 200, Unit: "g", Kind: KindMass, BaseAmount: 200}, 2, 400, "g"},
+	}
+	for _, c := range cases {
+		amt, unit := Scale(c.q, c.factor)
+		if !approx(amt, c.wantAmount) || unit != c.wantUnit {
+			t.Errorf("%s: = %v %q; want %v %q", c.name, amt, unit, c.wantAmount, c.wantUnit)
+		}
+	}
+}
+
+func TestExpressInSystem(t *testing.T) {
+	cases := []struct {
+		base       float64
+		kind, sys  string
+		wantAmount float64
+		wantUnit   string
+	}{
+		{473.176, KindVolume, SystemUS, 2, "cup"},
+		{1000, KindVolume, SystemMetric, 1, "L"},
+		{1500, KindMass, SystemMetric, 1.5, "kg"},
+		{28.3495, KindMass, SystemUS, 1, "oz"},
+	}
+	for _, c := range cases {
+		amt, unit := ExpressInSystem(c.base, c.kind, c.sys)
+		if !approx(amt, c.wantAmount) || unit != c.wantUnit {
+			t.Errorf("ExpressInSystem(%v,%q,%q) = %v %q; want %v %q", c.base, c.kind, c.sys, amt, unit, c.wantAmount, c.wantUnit)
+		}
+	}
+}


### PR DESCRIPTION
Evolves the just-merged source-units approach (#78/#39) into the definitive US/metric engine, per the design eval in `docs/unit-system-architecture.md`. Keeps the contract (source units primary, viewer's system shown alongside, user-agnostic canonical); replaces the mechanics.

## Core idea: same-dimension-first
Conversion is exact same-dimension by default (mass↔mass, volume↔volume). Crossing dimensions (volume↔mass) is the exception and only ever happens **US→metric**, using the AI-provided density-aware metric pair. A metric-source ingredient shown to a US viewer renders an exact same-dimension unit (`200 g → 7 oz`, `500 g → 1.1 lb`, `240 mL → 1 cup`) — never a guessed cup count. **No hand-maintained density table** (the eval's #1 risk, eliminated).

## What's here
- **`internal/units`** — canonical spec: unit metadata, `MeasureKind` (incl. oz weight/fluid disambiguation via the AI metric dimension + a tight liquid lexicon), `BaseAmount`, `ToViewer`, `Scale`. Thorough table tests.
- **Model** — additive `measure_kind` / `base_amount` / `amount_high` (omitempty jsonb; dashboard untouched). `normalizeIngredients` populates them + a **physical-density sanity guard** (rejects `2 cups flour = 5000 g`-style hallucinations → exact metric volume). Wired into every RecipeDef construction point; takes no user input and detaches shared slices, so the canonical stays byte-identical regardless of importer.
- **Extraction** — `original_text` + `amount_high` added to the `create_recipe` tool and prompts; parser now captures range highs and European decimal commas (`1,5 L`, previously zeroed).
- **Derivation** — `fork` + `regenerate` prompts preserve the parent's source units (was: force requester's system — the bug from #78 reintroduced one step later). `generate` stays native-to-user.
- **Manual / vision** — manual detects the system from entered units before personalization fallback; vision uses `ensureUnitSystem`.

## Tests
Full `go test ./...` green (deploy gate). New: units spec, normalize + density-guard + user-agnostic-canonical invariants, range + decimal-comma parsing.

## Notes
- Migration is additive; display tolerates absent fields (legacy rows render as today until lazily backfilled on canonical materialize). A one-shot backfill is a deferred follow-up.
- Pre-existing flaky `-race` in `TestFinishStreamedRecipe_BackgroundImageGeneration` (background goroutine, unrelated; passes in isolation; deploy gate doesn't run `-race`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)