### PR TITLE
Clean up unit-system loose ends (dead code + duplicate alias table)

### DIFF
--- a/internal/service/ingredient_parse.go
+++ b/internal/service/ingredient_parse.go
@@ -3,6 +3,8 @@ package service
 import (
 	"strconv"
 	"strings"
+
+	"github.com/windoze95/saltybytes-api/internal/units"
 )
 
 // unicodeFractions maps single-rune vulgar fractions to their decimal values.
@@ -25,52 +27,6 @@ var unicodeFractions = map[rune]float64{
 	'⅞': 7.0 / 8,
 	'⅑': 1.0 / 9,
 	'⅒': 1.0 / 10,
-}
-
-// unitAliases maps lowercase unit spellings (plurals, abbreviations, long
-// forms) to the canonical unit enum used by the create_recipe Claude tool
-// schema: pieces, tsp, tbsp, fl oz, cup, pt, qt, gal, oz, lb, mL, L, mg, g,
-// kg, pinch, dash, drop, bushel.
-// "T"/"t" are handled case-sensitively before this table is consulted.
-var unitAliases = map[string]string{
-	// volume — US customary
-	"tsp": "tsp", "tsps": "tsp", "teaspoon": "tsp", "teaspoons": "tsp",
-	"tbsp": "tbsp", "tbsps": "tbsp", "tbs": "tbsp", "tbl": "tbsp", "tblsp": "tbsp",
-	"tablespoon": "tbsp", "tablespoons": "tbsp",
-	"cup": "cup", "cups": "cup", "c": "cup",
-	"pt": "pt", "pts": "pt", "pint": "pt", "pints": "pt",
-	"qt": "qt", "qts": "qt", "quart": "qt", "quarts": "qt",
-	"gal": "gal", "gals": "gal", "gallon": "gal", "gallons": "gal",
-	"floz": "fl oz",
-	// weight — US customary
-	"oz": "oz", "ozs": "oz", "ounce": "oz", "ounces": "oz",
-	"lb": "lb", "lbs": "lb", "pound": "lb", "pounds": "lb",
-	// metric volume
-	"ml": "mL", "mls": "mL", "milliliter": "mL", "milliliters": "mL",
-	"millilitre": "mL", "millilitres": "mL", "cc": "mL",
-	"l": "L", "liter": "L", "liters": "L", "litre": "L", "litres": "L",
-	// metric weight
-	"mg": "mg", "mgs": "mg", "milligram": "mg", "milligrams": "mg",
-	"g": "g", "gram": "g", "grams": "g", "gr": "g",
-	"kg": "kg", "kgs": "kg", "kilogram": "kg", "kilograms": "kg", "kilo": "kg", "kilos": "kg",
-	// small measures
-	"pinch": "pinch", "pinches": "pinch",
-	"dash": "dash", "dashes": "dash",
-	"drop": "drop", "drops": "drop",
-	"bushel": "bushel", "bushels": "bushel",
-	// countable descriptors — collapse to the canonical "pieces"
-	"piece": "pieces", "pieces": "pieces", "pc": "pieces", "pcs": "pieces",
-	"clove": "pieces", "cloves": "pieces",
-	"can": "pieces", "cans": "pieces",
-	"slice": "pieces", "slices": "pieces",
-	"stick": "pieces", "sticks": "pieces",
-	"stalk": "pieces", "stalks": "pieces",
-	"sprig": "pieces", "sprigs": "pieces",
-	"head": "pieces", "heads": "pieces",
-	"bunch": "pieces", "bunches": "pieces",
-	"package": "pieces", "packages": "pieces", "pkg": "pieces", "pkgs": "pieces",
-	"ear": "pieces", "ears": "pieces",
-	"fillet": "pieces", "fillets": "pieces",
 }
 
 // ParseIngredientLine deterministically parses a free-form ingredient line
@@ -288,7 +244,7 @@ func matchUnit(tokens []string) (string, int) {
 		return "", 0
 	}
 
-	if canonical, ok := unitAliases[lower]; ok {
+	if canonical, ok := units.Canonical(lower); ok {
 		return canonical, 1
 	}
 	return "", 0

--- a/internal/units/spec.go
+++ b/internal/units/spec.go
@@ -84,8 +84,6 @@ var aliases = map[string]string{
 	// metric volume
 	"ml": "mL", "mls": "mL", "milliliter": "mL", "milliliters": "mL",
 	"millilitre": "mL", "millilitres": "mL", "cc": "mL",
-	"cl": "cl", "centiliter": "cl", "centilitre": "cl",
-	"dl": "dl", "deciliter": "dl", "decilitre": "dl",
 	"l": "L", "liter": "L", "liters": "L", "litre": "L", "litres": "L",
 	// metric weight
 	"mg": "mg", "mgs": "mg", "milligram": "mg", "milligrams": "mg",
@@ -109,13 +107,6 @@ var aliases = map[string]string{
 	"package": "pieces", "packages": "pieces", "pkg": "pieces", "pkgs": "pieces",
 	"ear": "pieces", "ears": "pieces",
 	"fillet": "pieces", "fillets": "pieces",
-}
-
-// cl and dl are non-canonical metric volumes we accept on input and fold into
-// mL so the rest of the pipeline only deals with the canonical enum.
-var inputOnlyFactor = map[string]float64{
-	"cl": 10,
-	"dl": 100,
 }
 
 // liquidNames are ingredient-name substrings that mark an "oz" measurement as a
@@ -224,9 +215,6 @@ func BaseAmount(amount float64, unit, kind string) float64 {
 	if u == "oz" && kind == KindVolume {
 		return amount * meta["fl oz"].factor
 	}
-	if f, ok := inputOnlyFactor[strings.ToLower(unit)]; ok {
-		return amount * f
-	}
 	if m, ok := meta[u]; ok {
 		return amount * m.factor
 	}
@@ -300,23 +288,6 @@ func ExpressInSystem(base float64, kind, system string) (float64, string) {
 	return 0, ""
 }
 
-// Scale multiplies a quantity by factor and re-expresses it in its own
-// (source) system with a cooking-friendly unit. Count/imprecise units scale
-// their amount but keep their unit. Rounding happens once, here.
-func Scale(q Quantity, factor float64) (float64, string) {
-	if factor <= 0 {
-		return q.Amount, q.Unit
-	}
-	if q.Kind == KindCount || q.Kind == KindImprecise || q.Kind == "" || SystemOf(q.Unit) == "" {
-		return roundCount(q.Amount * factor), q.Unit
-	}
-	base := q.BaseAmount
-	if base == 0 {
-		base = BaseAmount(q.Amount, q.Unit, q.Kind)
-	}
-	return ExpressInSystem(base*factor, q.Kind, SystemOf(q.Unit))
-}
-
 // --- system-specific unit selection -----------------------------------------
 
 func usVolume(ml float64) (float64, string) {
@@ -384,15 +355,6 @@ func snapCookingFraction(x float64) float64 {
 
 func round1(x float64) float64 { return math.Round(x*10) / 10 }
 func round2(x float64) float64 { return math.Round(x*100) / 100 }
-
-// roundCount rounds discrete counts to a half when small, whole when larger,
-// so scaling never yields "1.5 cans" style noise on big counts.
-func roundCount(x float64) float64 {
-	if x < 4 {
-		return math.Round(x*2) / 2
-	}
-	return math.Round(x)
-}
 
 // roundMetricSmall rounds a sub-1000 metric magnitude to a tidy value: whole
 // numbers, or the nearest 5 once we are into the hundreds.

--- a/internal/units/spec_test.go
+++ b/internal/units/spec_test.go
@@ -11,7 +11,7 @@ func TestCanonical(t *testing.T) {
 	cases := map[string]string{
 		"grams": "g", "Grams": "g", "ml": "mL", "ML": "mL",
 		"tablespoons": "tbsp", "CUPS": "cup", "pounds": "lb",
-		"cloves": "pieces", "sticks": "pieces", "dl": "dl",
+		"cloves": "pieces", "sticks": "pieces",
 	}
 	for in, want := range cases {
 		if got, ok := Canonical(in); !ok || got != want {
@@ -63,7 +63,6 @@ func TestBaseAmount(t *testing.T) {
 		{1, "L", KindVolume, 1000},
 		{2, "pieces", KindCount, 2},
 		{1, "pinch", KindImprecise, 0},
-		{5, "dl", KindVolume, 500}, // input-only metric unit
 	}
 	for _, c := range cases {
 		if got := BaseAmount(c.amount, c.unit, c.kind); !approx(got, c.want) {
@@ -136,27 +135,6 @@ func TestToViewer(t *testing.T) {
 		if !ok {
 			continue
 		}
-		if !approx(amt, c.wantAmount) || unit != c.wantUnit {
-			t.Errorf("%s: = %v %q; want %v %q", c.name, amt, unit, c.wantAmount, c.wantUnit)
-		}
-	}
-}
-
-func TestScale(t *testing.T) {
-	cases := []struct {
-		name       string
-		q          Quantity
-		factor     float64
-		wantAmount float64
-		wantUnit   string
-	}{
-		{"8 tbsp doubled is 1 cup", Quantity{Amount: 8, Unit: "tbsp", Kind: KindVolume, BaseAmount: 118.294}, 2, 1, "cup"},
-		{"1/3 cup tripled is 1 cup", Quantity{Amount: 1.0 / 3, Unit: "cup", Kind: KindVolume, BaseAmount: 236.588 / 3}, 3, 1, "cup"},
-		{"3 eggs halved is 1.5 pieces", Quantity{Amount: 3, Unit: "pieces", Kind: KindCount}, 0.5, 1.5, "pieces"},
-		{"200 g doubled is 400 g", Quantity{Amount: 200, Unit: "g", Kind: KindMass, BaseAmount: 200}, 2, 400, "g"},
-	}
-	for _, c := range cases {
-		amt, unit := Scale(c.q, c.factor)
 		if !approx(amt, c.wantAmount) || unit != c.wantUnit {
 			t.Errorf("%s: = %v %q; want %v %q", c.name, amt, unit, c.wantAmount, c.wantUnit)
 		}


### PR DESCRIPTION
Post-merge tidy of the unit-system engine — removing things I didn't want sitting in production.

- **Dead code:** drop `units.Scale` + `roundCount` (zero callers — server-side scaling is a future client concern and returns with its UI consumer) and the half-wired `cl`/`dl` input units (the parser never produced them and `measureKind` misclassified them as imprecise).
- **Duplicate alias table:** the ingredient parser now resolves tokens through `units.Canonical`; the near-identical service-local `unitAliases` map is deleted. One source of truth. `units.Canonical` is a content-superset, so parser behavior is unchanged (its tests pass untouched).

Full `go test ./...` green.

### Deliberately left
- The inert `recipe.import.text`/`url` duplicate prompt blocks (dead but correct; not worth a fragile 28-line YAML match).
- The pre-existing `-race` flake in `TestFinishStreamedRecipe_BackgroundImageGeneration` — it's a cross-test background-goroutine/global-S3-stub lifecycle issue in the streaming harness (the mock repo itself is already mutex-safe), unrelated to units and not run by the deploy gate. Worth a separate focused fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)