### PR TITLE
v1 hardening: gate localhost WS origin behind a flag; document ID_HEADER

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -3,8 +3,15 @@ DATABASE_URL=postgres://user:password@localhost:5432/saltybytes_db?sslmode=disab
 
 # Server
 PORT=8080
-JWT_SECRET_KEY=
+JWT_SECRET_KEY=             # Secret for signing/verifying auth JWTs (required)
+# Shared secret that gates the API to the official client. The app sends it as
+# the X-SaltyBytes-Identifier header (built in via the SALTYBYTES_ID define);
+# requests without a matching value are rejected. Required — set to a long random string.
 ID_HEADER=
+
+# Set to "true" ONLY for local development to allow http://localhost browser
+# origins on the cooking WebSocket. Leave unset/false in production.
+ALLOW_DEV_ORIGINS=
 
 # AWS (S3 image storage)
 AWS_REGION=us-east-2

--- a/internal/ws/cooking.go
+++ b/internal/ws/cooking.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"net/http"
+	"os"
 	"strconv"
 	"strings"
 	"time"
@@ -144,8 +145,10 @@ var upgrader = websocket.Upgrader{
 			"https://api.saltybytes.ai":
 			return true
 		}
-		// Allow localhost for development
-		if strings.HasPrefix(origin, "http://localhost:") || origin == "http://localhost" {
+		// Allow localhost only when dev origins are explicitly enabled. Defaults
+		// off, so production never accepts a localhost browser origin.
+		if os.Getenv("ALLOW_DEV_ORIGINS") == "true" &&
+			(strings.HasPrefix(origin, "http://localhost:") || origin == "http://localhost") {
 			return true
 		}
 		return false

--- a/internal/ws/cooking_test.go
+++ b/internal/ws/cooking_test.go
@@ -708,6 +708,15 @@ func TestHandleVoiceTranscript_AudioFormatPassedToSpeechProvider(t *testing.T) {
 // --- CheckOrigin tests ---
 
 func TestCheckOrigin(t *testing.T) {
+	check := func(origin string) bool {
+		req := httptest.NewRequest(http.MethodGet, "/v1/ws/cook/1", nil)
+		if origin != "" {
+			req.Header.Set("Origin", origin)
+		}
+		return upgrader.CheckOrigin(req)
+	}
+
+	// Allowed/blocked regardless of the dev-origins flag.
 	cases := []struct {
 		origin string
 		want   bool
@@ -716,20 +725,23 @@ func TestCheckOrigin(t *testing.T) {
 		{"https://saltybytes.ai", true},
 		{"https://www.saltybytes.ai", true},
 		{"https://api.saltybytes.ai", true},
-		{"http://localhost", true},
-		{"http://localhost:3000", true},
 		{"https://evil.example.com", false},
 		{"http://saltybytes.ai.evil.com", false},
 	}
-
 	for _, tc := range cases {
-		req := httptest.NewRequest(http.MethodGet, "/v1/ws/cook/1", nil)
-		if tc.origin != "" {
-			req.Header.Set("Origin", tc.origin)
-		}
-		if got := upgrader.CheckOrigin(req); got != tc.want {
+		if got := check(tc.origin); got != tc.want {
 			t.Errorf("CheckOrigin(origin=%q) = %v, want %v", tc.origin, got, tc.want)
 		}
+	}
+
+	// localhost is rejected by default (production) and accepted only when dev
+	// origins are explicitly enabled.
+	if check("http://localhost:3000") {
+		t.Error("localhost origin should be rejected when ALLOW_DEV_ORIGINS is unset")
+	}
+	t.Setenv("ALLOW_DEV_ORIGINS", "true")
+	if !check("http://localhost") || !check("http://localhost:3000") {
+		t.Error("localhost origin should be accepted when ALLOW_DEV_ORIGINS=true")
 	}
 }
 


### PR DESCRIPTION
Two items from the v1 release audit.

- **WS localhost origin**: `CheckOrigin` accepted any `http://localhost:*` origin unconditionally — dev convenience that shouldn't be live in prod. Now gated behind `ALLOW_DEV_ORIGINS` (defaults off), so production rejects localhost browser origins. The cooking socket is already token-authenticated (`?token=`), so this is defense-in-depth, not a fix for an open hole. The Flutter app sends no `Origin` and the prod domains stay whitelisted, so nothing user-facing changes. `TestCheckOrigin` updated to cover both states.
- **`ID_HEADER` docs**: it's a required shared secret that gates the API to the official client (`X-SaltyBytes-Identifier`), but `.env.example` left it blank and unexplained — an onboarding/fresh-deploy trap. Documented it, plus the new `ALLOW_DEV_ORIGINS` toggle.

Full `go test ./...` green.

### Deliberately not changed
- The `upgrade` endpoint's 501 — the app **depends** on that exact response to show its "not yet available" message; changing the status/envelope would break it.
- Context/S3 error-detail wrapping (audit "should-fix") — these are internal "should never happen" paths or get logged, not blockers; left to avoid churning handlers for negligible gain.

🤖 Generated with [Claude Code](https://claude.com/claude-code)