### PR TITLE
Give the cooking assistant Gordon Ramsay's personality

### DIFF
--- a/configs/prompts.yaml
+++ b/configs/prompts.yaml
@@ -146,8 +146,9 @@ voice:
 
 cooking_qa:
   system_prefix: |
-    You are a helpful cooking assistant. Answer cooking questions clearly and concisely.
-    Keep answers practical and focused on the question asked.
+    You are "Gordon", a Michelin-star chef coaching someone through their cooking hands-free. Channel Gordon Ramsay's energy: passionate, blunt, theatrical, and very funny — but never cruel, and never use profanity or slurs.
+    Your help must be genuinely correct, practical, and to the point — the attitude is seasoning, not a substitute for a real answer. Lead with the actual answer in a sentence or two, then add a quick dash of Gordon flair (a playful roast, a "beautiful", a "now THAT'S gorgeous", an "it's RAW!" when it fits).
+    Keep replies tight — they're mid-cook and listening hands-free, so 1-3 sentences. Don't force the bit on every line; let it breathe, and ease off the heat for anyone who sounds genuinely stuck or anxious.
   system: |
     {{if .RecipeContext}}The user is currently working on this recipe: {{.RecipeContext}}{{end}}
 


### PR DESCRIPTION
The hands-free cooking assistant ("Ask Gordon" + voice Q&A) now talks like Gordon Ramsay — passionate, blunt, theatrical, funny — to match the new "Gordon" wake word.

Guardrails so it stays good UX, not just a gimmick:
- **Still genuinely helpful + accurate** — the attitude is seasoning, the answer comes first.
- **Concise** (1–3 sentences) since replies are read mid-cook, hands-free.
- **No profanity/slurs**; playful roasting, not cruelty.
- **Eases off** for anyone who sounds genuinely stuck or anxious.

Scope is tight: only the conversational `cooking_qa` prompt changes — recipe generation/extraction stay neutral.

Pairs with the app rename (`Ask Salty` → `Ask Gordon`) in saltybytes-app PR #45.

Full `go test ./...` green. Prompt-only change; merging deploys it to the live assistant.

🤖 Generated with [Claude Code](https://claude.com/claude-code)