### PR TITLE
Remove canonical cache auto-refresh (sweep + on-read TTL)

### DIFF
--- a/internal/repository/canonical_recipe.go
+++ b/internal/repository/canonical_recipe.go
@@ -1,7 +1,6 @@
 package repository
 
 import (
-	"fmt"
 	"time"
 
 	"github.com/windoze95/saltybytes-api/internal/models"
@@ -55,15 +54,4 @@ func (r *CanonicalRecipeRepository) IncrementHitCount(id uint) error {
 			"hit_count":        gorm.Expr("hit_count + 1"),
 			"last_accessed_at": time.Now(),
 		}).Error
-}
-
-// GetStaleEntries returns canonical entries whose FetchedAt is older than maxAge.
-func (r *CanonicalRecipeRepository) GetStaleEntries(maxAge time.Duration) ([]models.CanonicalRecipe, error) {
-	cutoff := time.Now().Add(-maxAge)
-	var entries []models.CanonicalRecipe
-	err := r.DB.Where("fetched_at < ?", cutoff).Find(&entries).Error
-	if err != nil {
-		return nil, fmt.Errorf("failed to get stale canonical entries: %w", err)
-	}
-	return entries, nil
 }

--- a/internal/repository/interfaces.go
+++ b/internal/repository/interfaces.go
@@ -47,7 +47,6 @@ type CanonicalRecipeRepo interface {
 	GetByNormalizedURL(normalizedURL string) (*models.CanonicalRecipe, error)
 	Upsert(entry *models.CanonicalRecipe) error
 	IncrementHitCount(id uint) error
-	GetStaleEntries(maxAge time.Duration) ([]models.CanonicalRecipe, error)
 }
 
 // SearchCacheRepo is the interface for search cache repository operations.

--- a/internal/router/router.go
+++ b/internal/router/router.go
@@ -198,7 +198,6 @@ func SetupRouter(cfg *config.Config, database *gorm.DB) *gin.Engine {
 	searchService := service.NewSearchService(cfg, searchProvider, subService, searchCacheRepo)
 	searchService.EmbedProvider = embedProvider
 	searchService.StartBackgroundTasks()
-	importService.StartCanonicalBackgroundTasks()
 
 	// Backfill missing recipe/canonical embeddings in the background
 	service.StartEmbeddingBackfill(vectorRepo, embedProvider)

--- a/internal/service/canonical.go
+++ b/internal/service/canonical.go
@@ -1,13 +1,9 @@
 package service
 
 import (
-	"time"
-
 	"github.com/windoze95/saltybytes-api/internal/models"
 	"github.com/windoze95/saltybytes-api/internal/repository"
 )
-
-const canonicalTTL = 7 * 24 * time.Hour
 
 // MaterializeCanonical performs copy-on-write: if the recipe references a canonical
 // and has not yet diverged, it copies the canonical's RecipeData into the recipe's

--- a/internal/service/import.go
+++ b/internal/service/import.go
@@ -144,18 +144,17 @@ func (s *ImportService) ImportFromURL(ctx context.Context, rawURL string, user *
 		return nil, fmt.Errorf("URL validation failed: %w", err)
 	}
 
-	// Check canonical cache if available
+	// Serve from the canonical cache when present. Entries never expire; a
+	// cached URL is never automatically re-fetched.
 	if s.CanonicalRepo != nil {
 		normalizedURL, normErr := NormalizeURL(rawURL)
 		if normErr == nil {
 			if canonical, err := s.CanonicalRepo.GetByNormalizedURL(normalizedURL); err == nil {
-				if time.Since(canonical.FetchedAt) < canonicalTTL {
-					log.Info("import from canonical cache hit")
-					go s.CanonicalRepo.IncrementHitCount(canonical.ID)
-					canonicalID := canonical.ID
-					recipeResp, _, createErr := s.createImportedRecipe(ctx, &canonical.RecipeData, user, models.RecipeTypeImportLink, rawURL, "", &canonicalID, nil, canonical.PromptVersion)
-					return recipeResp, createErr
-				}
+				log.Info("import from canonical cache hit")
+				go s.CanonicalRepo.IncrementHitCount(canonical.ID)
+				canonicalID := canonical.ID
+				recipeResp, _, createErr := s.createImportedRecipe(ctx, &canonical.RecipeData, user, models.RecipeTypeImportLink, rawURL, "", &canonicalID, nil, canonical.PromptVersion)
+				return recipeResp, createErr
 			}
 		}
 	}
@@ -649,21 +648,19 @@ func (s *ImportService) PreviewFromURL(ctx context.Context, rawURL string) (*mod
 		return nil, nil, fmt.Errorf("URL validation failed: %w", err)
 	}
 
-	// Check canonical cache if available
+	// Serve from the canonical cache when present. Entries never expire.
 	if s.CanonicalRepo != nil {
 		normalizedURL, normErr := NormalizeURL(rawURL)
 		if normErr == nil {
 			if canonical, err := s.CanonicalRepo.GetByNormalizedURL(normalizedURL); err == nil {
-				if time.Since(canonical.FetchedAt) < canonicalTTL {
-					log.Info("preview canonical cache hit")
-					go s.CanonicalRepo.IncrementHitCount(canonical.ID)
-					data := canonical.RecipeData
-					if data.SourceURL == "" {
-						data.SourceURL = rawURL
-					}
-					canonicalID := canonical.ID
-					return &data, &canonicalID, nil
+				log.Info("preview canonical cache hit")
+				go s.CanonicalRepo.IncrementHitCount(canonical.ID)
+				data := canonical.RecipeData
+				if data.SourceURL == "" {
+					data.SourceURL = rawURL
 				}
+				canonicalID := canonical.ID
+				return &data, &canonicalID, nil
 			}
 		}
 	}
@@ -742,16 +739,14 @@ func (s *ImportService) PreviewFromURLWithMultiCheck(ctx context.Context, rawURL
 		normalizedURL, normErr := NormalizeURL(rawURL)
 		if normErr == nil {
 			if canonical, err := s.CanonicalRepo.GetByNormalizedURL(normalizedURL); err == nil {
-				if time.Since(canonical.FetchedAt) < canonicalTTL {
-					log.Info("preview canonical cache hit")
-					go s.CanonicalRepo.IncrementHitCount(canonical.ID)
-					data := canonical.RecipeData
-					if data.SourceURL == "" {
-						data.SourceURL = rawURL
-					}
-					canonicalID := canonical.ID
-					return &PreviewResult{Recipe: &data, CanonicalID: &canonicalID}, nil
+				log.Info("preview canonical cache hit")
+				go s.CanonicalRepo.IncrementHitCount(canonical.ID)
+				data := canonical.RecipeData
+				if data.SourceURL == "" {
+					data.SourceURL = rawURL
 				}
+				canonicalID := canonical.ID
+				return &PreviewResult{Recipe: &data, CanonicalID: &canonicalID}, nil
 			}
 		}
 	}
@@ -896,63 +891,6 @@ func (s *ImportService) createImportedRecipe(ctx context.Context, recipeDef *mod
 
 	recipeResponse := s.RecipeService.ToRecipeResponse(recipe)
 	return recipeResponse, recipe.ID, nil
-}
-
-// StartCanonicalBackgroundTasks starts periodic refresh goroutines
-// for the canonical recipe cache.
-func (s *ImportService) StartCanonicalBackgroundTasks() {
-	if s.CanonicalRepo == nil {
-		return
-	}
-
-	go func() {
-		ticker := time.NewTicker(30 * time.Minute)
-		defer ticker.Stop()
-		for range ticker.C {
-			s.refreshStaleCanonicals()
-		}
-	}()
-}
-
-func (s *ImportService) refreshStaleCanonicals() {
-	log := logger.Get()
-
-	entries, err := s.CanonicalRepo.GetStaleEntries(canonicalTTL)
-	if err != nil {
-		log.Error("failed to get stale canonical entries", zap.Error(err))
-		return
-	}
-
-	for _, entry := range entries {
-		// Skip multi-recipe card entries — they have _recipe= in the URL
-		// and can't be refreshed by generic extractFromURL (which grabs
-		// the first recipe). They'll be re-extracted when clicked.
-		if strings.Contains(entry.OriginalURL, "_recipe=") {
-			continue
-		}
-
-		ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
-		recipeDef, _, _, method, _, err := s.extractFromURL(ctx, entry.OriginalURL)
-		cancel()
-		if err != nil {
-			log.Warn("failed to refresh canonical entry", zap.String("url", entry.OriginalURL), zap.Error(err))
-			continue
-		}
-
-		now := time.Now()
-		entry.RecipeData = *recipeDef
-		entry.ExtractionMethod = method
-		entry.FetchedAt = now
-		entry.LastAccessedAt = now
-		// The extract context above is already cancelled; bound the embedding
-		// call separately so a stalled provider can't wedge the refresh loop.
-		embedCtx, embedCancel := context.WithTimeout(context.Background(), embeddingCallTimeout)
-		entry.Embedding = s.canonicalEmbedding(embedCtx, recipeDef)
-		embedCancel()
-		if err := s.CanonicalRepo.Upsert(&entry); err != nil {
-			log.Warn("failed to upsert refreshed canonical", zap.String("url", entry.OriginalURL), zap.Error(err))
-		}
-	}
 }
 
 // jsonLDRecipe represents the JSON-LD Recipe schema (subset of fields we care about).

--- a/internal/service/import_service_test.go
+++ b/internal/service/import_service_test.go
@@ -265,34 +265,40 @@ func TestPreviewFromURL_CanonicalCacheHit(t *testing.T) {
 	}
 }
 
-func TestPreviewFromURL_StaleCanonicalSkipped(t *testing.T) {
+func TestPreviewFromURL_OldCanonicalStillServed(t *testing.T) {
 	repo := testutil.NewMockRecipeRepo()
-	stale := testutil.TestStaleCanonicalRecipe()
+	old := testutil.TestOldCanonicalRecipe()
 
 	canonicalRepo := &testutil.MockCanonicalRecipeRepo{
 		GetByNormalizedURLFunc: func(normalizedURL string) (*models.CanonicalRecipe, error) {
-			return stale, nil
+			return old, nil
 		},
 	}
 
 	svc := newTestImportService(repo, nil, nil)
 	svc.CanonicalRepo = canonicalRepo
 
-	// With a stale canonical and no real server to fetch from, this should fail
-	// during extraction — proving the stale cache was skipped.
-	_, _, err := svc.PreviewFromURL(context.Background(), "https://example.com/classic-pancakes")
-	if err == nil {
-		t.Fatal("expected error when stale canonical is skipped and extraction fails")
+	// Canonical entries never expire: even a year-old entry is served straight
+	// from cache and never re-fetched (there is no real server to fetch from).
+	recipeDef, canonicalID, err := svc.PreviewFromURL(context.Background(), "https://example.com/classic-pancakes")
+	if err != nil {
+		t.Fatalf("expected cache hit for old entry, got error: %v", err)
+	}
+	if recipeDef == nil {
+		t.Fatal("expected cached recipe, got nil")
+	}
+	if canonicalID == nil || *canonicalID != old.ID {
+		t.Errorf("canonical_id = %v, want %d", canonicalID, old.ID)
 	}
 }
 
-func TestImportFromURL_StaleCanonicalSkipped(t *testing.T) {
+func TestImportFromURL_OldCanonicalStillServed(t *testing.T) {
 	repo := testutil.NewMockRecipeRepo()
-	stale := testutil.TestStaleCanonicalRecipe()
+	old := testutil.TestOldCanonicalRecipe()
 
 	canonicalRepo := &testutil.MockCanonicalRecipeRepo{
 		GetByNormalizedURLFunc: func(normalizedURL string) (*models.CanonicalRecipe, error) {
-			return stale, nil
+			return old, nil
 		},
 	}
 
@@ -300,11 +306,17 @@ func TestImportFromURL_StaleCanonicalSkipped(t *testing.T) {
 	svc.CanonicalRepo = canonicalRepo
 	user := testutil.TestUser()
 
-	// With a stale canonical and no real server to fetch from, this should fail
-	// during extraction — proving the stale cache was skipped.
-	_, err := svc.ImportFromURL(context.Background(), "https://example.com/classic-pancakes", user)
-	if err == nil {
-		t.Fatal("expected error when stale canonical is skipped and extraction fails")
+	// Old entries never expire: import is served from the cached canonical with
+	// no re-fetch, creating the recipe from cached data.
+	resp, err := svc.ImportFromURL(context.Background(), "https://example.com/classic-pancakes", user)
+	if err != nil {
+		t.Fatalf("expected cache hit for old entry, got error: %v", err)
+	}
+	if resp == nil {
+		t.Fatal("expected recipe response, got nil")
+	}
+	if len(repo.Recipes) != 1 {
+		t.Errorf("recipes in repo = %d, want 1", len(repo.Recipes))
 	}
 }
 

--- a/internal/testutil/fixtures.go
+++ b/internal/testutil/fixtures.go
@@ -105,9 +105,11 @@ func TestCanonicalLinkedRecipe() *models.Recipe {
 	}
 }
 
-// TestStaleCanonicalRecipe creates a test CanonicalRecipe with FetchedAt older than canonicalTTL.
-func TestStaleCanonicalRecipe() *models.CanonicalRecipe {
-	stale := time.Now().Add(-8 * 24 * time.Hour) // 8 days ago
+// TestOldCanonicalRecipe creates a CanonicalRecipe fetched long ago. Canonical
+// entries never expire, so this is used to assert old entries are still served
+// from cache (never re-fetched).
+func TestOldCanonicalRecipe() *models.CanonicalRecipe {
+	old := time.Now().Add(-365 * 24 * time.Hour) // a year ago
 	return &models.CanonicalRecipe{
 		Model:            gorm.Model{ID: 101},
 		NormalizedURL:    "https://example.com/classic-pancakes",
@@ -115,8 +117,8 @@ func TestStaleCanonicalRecipe() *models.CanonicalRecipe {
 		RecipeData:       TestRecipeDef(),
 		ExtractionMethod: models.ExtractionJSONLD,
 		HitCount:         3,
-		LastAccessedAt:   stale,
-		FetchedAt:        stale,
+		LastAccessedAt:   old,
+		FetchedAt:        old,
 	}
 }
 

--- a/internal/testutil/mocks.go
+++ b/internal/testutil/mocks.go
@@ -929,7 +929,6 @@ type MockCanonicalRecipeRepo struct {
 	GetByNormalizedURLFunc func(normalizedURL string) (*models.CanonicalRecipe, error)
 	UpsertFunc             func(entry *models.CanonicalRecipe) error
 	IncrementHitCountFunc  func(id uint) error
-	GetStaleEntriesFunc    func(maxAge time.Duration) ([]models.CanonicalRecipe, error)
 }
 
 func (m *MockCanonicalRecipeRepo) GetByID(id uint) (*models.CanonicalRecipe, error) {
@@ -959,13 +958,6 @@ func (m *MockCanonicalRecipeRepo) IncrementHitCount(id uint) error {
 		return m.IncrementHitCountFunc(id)
 	}
 	return nil
-}
-
-func (m *MockCanonicalRecipeRepo) GetStaleEntries(maxAge time.Duration) ([]models.CanonicalRecipe, error) {
-	if m.GetStaleEntriesFunc != nil {
-		return m.GetStaleEntriesFunc(maxAge)
-	}
-	return nil, nil
 }
 
 // Compile-time interface checks.


### PR DESCRIPTION
## Problem

The app showed **"Website blocked access"** on recipe imports/previews. Root cause: our Firecrawl account was returning HTTP `402` — the free tier (1000 credits/mo) was fully exhausted.

The drain was self-inflicted, not abuse (the app is unreleased). The canonical-cache **background refresh ran every 30 min**, re-scraping entries stale for >7 days. For bot-blocked sites it routed to Firecrawl, but a failed refresh never advanced `FetchedAt`, so the same handful of blocked URLs retried **every 30 min forever** (~5 URLs × 48 cycles/day ≈ 240 Firecrawl calls/day → 1000 credits gone in ~5 days). Logs confirmed it: 124/124 Firecrawl calls in 14h were `402`, across only 4–7 distinct URLs/day.

## Change

Re-fetching imported recipes is wasteful — recipe pages are near-static — so this removes automatic re-fetch entirely:

- **Remove the 30-min background sweep** (`StartCanonicalBackgroundTasks` / `refreshStaleCanonicals`) and its router wiring.
- **Remove the on-read `canonicalTTL` re-fetch** from `ImportFromURL`, `PreviewFromURL`, and `PreviewFromURLWithMultiCheck`. A cached URL is now served permanently; re-extraction happens only on a true cache miss (or manually if a problem is reported).
- **Strip dead code**: the `canonicalTTL` const + orphaned `time` import, and `GetStaleEntries` across the repo interface, implementation, and mock.

## Behavior after

- First time a URL is seen → fetched + extracted once, then cached (the only automatic fetch).
- Every import/preview of that URL thereafter → served from cache regardless of age. Never re-fetched.
- Opening an already-saved recipe → reads the user's own copy; never touches the source.

## Tests

The two `*_StaleCanonicalSkipped` tests become `*_OldCanonicalStillServed`, asserting a year-old entry is served from cache without re-fetching. `go test ./... -count=1` → green (11 packages, 0 failures).

## Follow-up (not in this PR)

Firecrawl credits stay at 0 until the **Jul 15** reset (or a manual top-up); with this loop gone the free tier is sufficient going forward. Optional: a CloudWatch alarm on Firecrawl `402` so exhaustion can't go unnoticed again.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BU4UWZutHd1AnK3XAf7H19
