### PR TITLE
Multi-source import: multiple images + PDFs → multiple recipes

### DIFF
--- a/internal/ai/anthropic.go
+++ b/internal/ai/anthropic.go
@@ -73,73 +73,104 @@ func NewAnthropicLightProvider(apiKey string, model string, prompts *config.Prom
 
 // createRecipeTool builds the Claude tool definition that mirrors the existing
 // OpenAI create_recipe function-call schema.
+// recipeProperties is the JSON-schema property set describing a single recipe.
+// It is shared by the create_recipe (single) and extract_recipes (array) tools.
+func recipeProperties(summaryPrompt string) map[string]interface{} {
+	return map[string]interface{}{
+		"title": map[string]interface{}{
+			"type":        "string",
+			"description": "Title of the recipe or meal",
+		},
+		"ingredients": map[string]interface{}{
+			"type":        "array",
+			"description": "List of ingredients used in the recipe",
+			"items": map[string]interface{}{
+				"type": "object",
+				"properties": map[string]interface{}{
+					"name":          map[string]interface{}{"type": "string", "description": "Name of the ingredient, do not include unit or amount in this field"},
+					"unit":          map[string]interface{}{"type": "string", "description": "Unit for the ingredient, comply with UnitSystem specified.", "enum": []string{"pieces", "tsp", "tbsp", "fl oz", "cup", "pt", "qt", "gal", "oz", "lb", "mL", "L", "mg", "g", "kg", "pinch", "dash", "drop", "bushel"}},
+					"amount":        map[string]interface{}{"type": "number", "description": "Amount of the ingredient"},
+					"amount_high":   map[string]interface{}{"type": "number", "description": "Upper bound when the source gives a range (e.g. '2-3 cups' -> amount 2, amount_high 3). Omit or 0 for a single amount."},
+					"metric_unit":   map[string]interface{}{"type": "string", "description": "Metric equivalent unit. Always metric (g, kg, mL, L, mg). Duplicate primary if already metric.", "enum": []string{"mg", "g", "kg", "mL", "L"}},
+					"metric_amount": map[string]interface{}{"type": "number", "description": "Metric equivalent amount. Use accurate cooking conversions (1 cup flour=120g, 1 cup butter=227g, 1 cup water=240mL). Round to practical amounts."},
+					"original_text": map[string]interface{}{"type": "string", "description": "The verbatim ingredient line as written in the source (e.g. '1 1/2 cups all-purpose flour, sifted'). Copy it exactly; leave empty only when generating an original recipe with no source text."},
+				},
+			},
+		},
+		"instructions": map[string]interface{}{
+			"type":        "array",
+			"description": "Steps to prepare the recipe (no numbering)",
+			"items":       map[string]interface{}{"type": "string"},
+		},
+		"cook_time": map[string]interface{}{
+			"type":        "number",
+			"description": "Total time to prepare the recipe(s) in minutes",
+		},
+		"image_prompt": map[string]interface{}{
+			"type":        "string",
+			"description": "Prompt to generate an image for the recipe, this should be relevant to the recipe and not the user request",
+		},
+		"hashtags": map[string]interface{}{
+			"type":        "array",
+			"description": "Provide a lengthy and thorough list (ten or more) of hashtags relevant to the recipe, not the prompting. Alphanumeric characters only. No '#'. Exclude terms like 'recipe', 'homemade', 'DIY', or similar words. Use camelCase formatting if more than one word (first letter is always lowercase).",
+			"items":       map[string]interface{}{"type": "string"},
+		},
+		"linked_recipe_suggestions": map[string]interface{}{
+			"type":        "array",
+			"description": "Provide a list of recipe suggestions (just the titles) based on: 1. Homemade versions of store-bought ingredients used in this recipe. 2. Something that would pair well with this recipe.",
+			"items":       map[string]interface{}{"type": "string"},
+		},
+		"recipe_summary": map[string]interface{}{
+			"type":        "string",
+			"description": summaryPrompt,
+		},
+		"portions": map[string]interface{}{
+			"type":        "number",
+			"description": "Number of portions this recipe makes",
+		},
+		"portion_size": map[string]interface{}{
+			"type":        "string",
+			"description": "Description of a single portion size",
+		},
+		"unit_system": map[string]interface{}{
+			"type":        "string",
+			"description": "The measurement system used in the recipe",
+			"enum":        []string{"us_customary", "metric"},
+		},
+	}
+}
+
 func createRecipeTool(summaryPrompt string) anthropic.ToolUnionParam {
 	return anthropic.ToolUnionParam{
 		OfTool: &anthropic.ToolParam{
 			Name:        "create_recipe",
 			Description: anthropic.String("Create a structured recipe definition with all required fields."),
 			InputSchema: anthropic.ToolInputSchemaParam{
+				Type:       "object",
+				Properties: recipeProperties(summaryPrompt),
+			},
+		},
+	}
+}
+
+// createMultiRecipeTool builds a tool that returns an array of recipes, for
+// multimodal extraction where the provided images/documents may collectively
+// contain more than one recipe.
+func createMultiRecipeTool(summaryPrompt string) anthropic.ToolUnionParam {
+	return anthropic.ToolUnionParam{
+		OfTool: &anthropic.ToolParam{
+			Name:        "extract_recipes",
+			Description: anthropic.String("Extract every distinct recipe found across the provided images and documents. Return one entry per recipe."),
+			InputSchema: anthropic.ToolInputSchemaParam{
 				Type: "object",
 				Properties: map[string]interface{}{
-					"title": map[string]interface{}{
-						"type":        "string",
-						"description": "Title of the recipe or meal",
-					},
-					"ingredients": map[string]interface{}{
+					"recipes": map[string]interface{}{
 						"type":        "array",
-						"description": "List of ingredients used in the recipe",
+						"description": "Every distinct recipe found across all provided inputs, one entry per recipe.",
 						"items": map[string]interface{}{
-							"type": "object",
-							"properties": map[string]interface{}{
-								"name":          map[string]interface{}{"type": "string", "description": "Name of the ingredient, do not include unit or amount in this field"},
-								"unit":          map[string]interface{}{"type": "string", "description": "Unit for the ingredient, comply with UnitSystem specified.", "enum": []string{"pieces", "tsp", "tbsp", "fl oz", "cup", "pt", "qt", "gal", "oz", "lb", "mL", "L", "mg", "g", "kg", "pinch", "dash", "drop", "bushel"}},
-								"amount":        map[string]interface{}{"type": "number", "description": "Amount of the ingredient"},
-								"amount_high":   map[string]interface{}{"type": "number", "description": "Upper bound when the source gives a range (e.g. '2-3 cups' -> amount 2, amount_high 3). Omit or 0 for a single amount."},
-								"metric_unit":   map[string]interface{}{"type": "string", "description": "Metric equivalent unit. Always metric (g, kg, mL, L, mg). Duplicate primary if already metric.", "enum": []string{"mg", "g", "kg", "mL", "L"}},
-								"metric_amount": map[string]interface{}{"type": "number", "description": "Metric equivalent amount. Use accurate cooking conversions (1 cup flour=120g, 1 cup butter=227g, 1 cup water=240mL). Round to practical amounts."},
-								"original_text": map[string]interface{}{"type": "string", "description": "The verbatim ingredient line as written in the source (e.g. '1 1/2 cups all-purpose flour, sifted'). Copy it exactly; leave empty only when generating an original recipe with no source text."},
-							},
+							"type":       "object",
+							"properties": recipeProperties(summaryPrompt),
 						},
-					},
-					"instructions": map[string]interface{}{
-						"type":        "array",
-						"description": "Steps to prepare the recipe (no numbering)",
-						"items":       map[string]interface{}{"type": "string"},
-					},
-					"cook_time": map[string]interface{}{
-						"type":        "number",
-						"description": "Total time to prepare the recipe(s) in minutes",
-					},
-					"image_prompt": map[string]interface{}{
-						"type":        "string",
-						"description": "Prompt to generate an image for the recipe, this should be relevant to the recipe and not the user request",
-					},
-					"hashtags": map[string]interface{}{
-						"type":        "array",
-						"description": "Provide a lengthy and thorough list (ten or more) of hashtags relevant to the recipe, not the prompting. Alphanumeric characters only. No '#'. Exclude terms like 'recipe', 'homemade', 'DIY', or similar words. Use camelCase formatting if more than one word (first letter is always lowercase).",
-						"items":       map[string]interface{}{"type": "string"},
-					},
-					"linked_recipe_suggestions": map[string]interface{}{
-						"type":        "array",
-						"description": "Provide a list of recipe suggestions (just the titles) based on: 1. Homemade versions of store-bought ingredients used in this recipe. 2. Something that would pair well with this recipe.",
-						"items":       map[string]interface{}{"type": "string"},
-					},
-					"recipe_summary": map[string]interface{}{
-						"type":        "string",
-						"description": summaryPrompt,
-					},
-					"portions": map[string]interface{}{
-						"type":        "number",
-						"description": "Number of portions this recipe makes",
-					},
-					"portion_size": map[string]interface{}{
-						"type":        "string",
-						"description": "Description of a single portion size",
-					},
-					"unit_system": map[string]interface{}{
-						"type":        "string",
-						"description": "The measurement system used in the recipe",
-						"enum":        []string{"us_customary", "metric"},
 					},
 				},
 			},
@@ -170,6 +201,11 @@ type ingredientToolRes struct {
 	MetricUnit   string  `json:"metric_unit"`
 	MetricAmount float64 `json:"metric_amount"`
 	OriginalText string  `json:"original_text"`
+}
+
+// multiRecipeToolResult is the JSON structure returned by the extract_recipes tool.
+type multiRecipeToolResult struct {
+	Recipes []recipeToolResult `json:"recipes"`
 }
 
 // analyzeAllergensTool builds the Claude tool definition for allergen analysis.
@@ -555,6 +591,29 @@ func extractRecipeFromToolUse(msg *anthropic.Message) (*RecipeResult, error) {
 				return nil, NewAIError(FailureContentParse, fmt.Errorf("failed to unmarshal recipe: %w", err), "failed to parse recipe tool result")
 			}
 			return toolResultToRecipeResult(&tr), nil
+		}
+	}
+	return nil, NewAIError(FailureContentEmpty, errors.New("no tool_use block found in Claude response"), "no tool_use block in response")
+}
+
+// extractRecipesFromToolUse parses the extract_recipes tool call into one or
+// more RecipeResults.
+func extractRecipesFromToolUse(msg *anthropic.Message) ([]*RecipeResult, error) {
+	for _, block := range msg.Content {
+		if block.Type == "tool_use" {
+			raw, err := json.Marshal(block.Input)
+			if err != nil {
+				return nil, NewAIError(FailureContentParse, fmt.Errorf("failed to marshal tool input: %w", err), "failed to parse recipes tool result")
+			}
+			var tr multiRecipeToolResult
+			if err := json.Unmarshal(raw, &tr); err != nil {
+				return nil, NewAIError(FailureContentParse, fmt.Errorf("failed to unmarshal recipes: %w", err), "failed to parse recipes tool result")
+			}
+			results := make([]*RecipeResult, 0, len(tr.Recipes))
+			for i := range tr.Recipes {
+				results = append(results, toolResultToRecipeResult(&tr.Recipes[i]))
+			}
+			return results, nil
 		}
 	}
 	return nil, NewAIError(FailureContentEmpty, errors.New("no tool_use block found in Claude response"), "no tool_use block in response")
@@ -1368,6 +1427,97 @@ func (p *AnthropicProvider) ExtractRecipeFromImage(ctx context.Context, imageDat
 		}
 		result.PromptVersion = config.PromptVersion(p.prompts)
 		return result, nil
+	})
+}
+
+// ExtractRecipesFromMedia extracts every distinct recipe found across the
+// provided images and/or PDF documents in a single Claude request.
+func (p *AnthropicProvider) ExtractRecipesFromMedia(ctx context.Context, media []MediaInput, unitSystem string, requirements string) ([]*RecipeResult, error) {
+	op := AIOperation{
+		Name:      "ExtractRecipesFromMedia",
+		Provider:  "anthropic",
+		Model:     string(p.model),
+		StartTime: time.Now(),
+	}
+
+	return runWithMiddleware(ctx, p.middleware, op, func(ctx context.Context) ([]*RecipeResult, error) {
+		sysSuffix, err := config.RenderPrompt(p.prompts.Recipe.Import.Vision.System, map[string]interface{}{
+			"UnitSystem":   unitSystem,
+			"Requirements": requirements,
+		})
+		if err != nil {
+			return nil, fmt.Errorf("render system prompt: %w", err)
+		}
+
+		blocks := make([]anthropic.ContentBlockParamUnion, 0, len(media)+1)
+		for _, m := range media {
+			if m.Kind == MediaPDF {
+				blocks = append(blocks, anthropic.ContentBlockParamUnion{
+					OfRequestDocumentBlock: &anthropic.DocumentBlockParam{
+						Source: anthropic.DocumentBlockParamSourceUnion{
+							OfBase64PDFSource: &anthropic.Base64PDFSourceParam{
+								Data: base64.StdEncoding.EncodeToString(m.Data),
+							},
+						},
+					},
+				})
+				continue
+			}
+			blocks = append(blocks, anthropic.ContentBlockParamUnion{
+				OfRequestImageBlock: &anthropic.ImageBlockParam{
+					Source: anthropic.ImageBlockParamSourceUnion{
+						OfBase64ImageSource: &anthropic.Base64ImageSourceParam{
+							MediaType: anthropic.Base64ImageSourceMediaType(detectImageMediaType(m.Data)),
+							Data:      base64.StdEncoding.EncodeToString(m.Data),
+						},
+					},
+				},
+			})
+		}
+		blocks = append(blocks, anthropic.NewTextBlock("These images and/or documents contain one or more recipes. Extract EVERY distinct recipe you find across all of them, returning one entry per recipe. If an item shows a prepared dish with no written recipe, infer a reasonable recipe for it."))
+
+		summaryDesc := p.prompts.Recipe.Summarize.Recipe
+		tool := createMultiRecipeTool(summaryDesc)
+
+		params := anthropic.MessageNewParams{
+			Model:     p.model,
+			MaxTokens: 16000,
+			System:    buildCachedSystemPrompt(p.prompts.Recipe.Import.Vision.SystemPrefix, sysSuffix),
+			Messages: []anthropic.MessageParam{
+				newUserMessage(blocks...),
+			},
+			Tools: []anthropic.ToolUnionParam{tool},
+			ToolChoice: anthropic.ToolChoiceUnionParam{
+				OfToolChoiceTool: &anthropic.ToolChoiceToolParam{
+					Name: "extract_recipes",
+				},
+			},
+		}
+
+		resp, err := p.createMessageWithRetry(ctx, params)
+		if err != nil {
+			return nil, err
+		}
+
+		results, err := extractRecipesFromToolUse(resp)
+		if err != nil {
+			return nil, err
+		}
+
+		pv := config.PromptVersion(p.prompts)
+		valid := make([]*RecipeResult, 0, len(results))
+		for _, r := range results {
+			if err := validateRecipeResult(r); err != nil {
+				logger.Get().Warn("skipping invalid extracted recipe", zap.String("title", r.Title), zap.Error(err))
+				continue
+			}
+			r.PromptVersion = pv
+			valid = append(valid, r)
+		}
+		if len(valid) == 0 {
+			return nil, NewAIError(FailureContentQuality, errors.New("no valid recipes extracted from media"), "no recipes found in the provided files")
+		}
+		return valid, nil
 	})
 }
 

--- a/internal/ai/provider.go
+++ b/internal/ai/provider.go
@@ -20,9 +20,27 @@ type TextProvider interface {
 	DietaryInterview(ctx context.Context, messages []Message, memberName string) (*DietaryInterviewResult, error)
 }
 
-// VisionProvider handles image-based recipe extraction (Claude).
+// MediaKind identifies whether a MediaInput is a raster image or a PDF document.
+type MediaKind string
+
+const (
+	MediaImage MediaKind = "image"
+	MediaPDF   MediaKind = "pdf"
+)
+
+// MediaInput is a single image or PDF document supplied for recipe extraction.
+type MediaInput struct {
+	Data []byte
+	Kind MediaKind
+}
+
+// VisionProvider handles image- and document-based recipe extraction (Claude).
 type VisionProvider interface {
 	ExtractRecipeFromImage(ctx context.Context, imageData []byte, unitSystem string, requirements string) (*RecipeResult, error)
+	// ExtractRecipesFromMedia extracts every distinct recipe found across the
+	// given images and/or PDF documents in a single request, returning one
+	// RecipeResult per recipe.
+	ExtractRecipesFromMedia(ctx context.Context, media []MediaInput, unitSystem string, requirements string) ([]*RecipeResult, error)
 }
 
 // ImageProvider handles image generation (DALL-E 3).

--- a/internal/handlers/import.go
+++ b/internal/handlers/import.go
@@ -2,6 +2,7 @@ package handlers
 
 import (
 	"errors"
+	"fmt"
 	"io"
 	"net/http"
 	"net/url"
@@ -107,6 +108,89 @@ func (h *ImportHandler) ImportFromPhoto(c *gin.Context) {
 	}
 
 	c.JSON(http.StatusOK, gin.H{"recipe": recipeResponse})
+}
+
+// ImportFromFiles handles POST /v1/recipes/import/files — one or more images
+// and/or PDF documents in a single request, each yielding one or more recipes.
+func (h *ImportHandler) ImportFromFiles(c *gin.Context) {
+	user, err := util.GetUserFromContext(c)
+	if err != nil {
+		c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
+		return
+	}
+
+	const (
+		maxFiles      = 10
+		maxPerFile    = 10 * 1024 * 1024 // 10MB per file
+		maxTotalBytes = 28 * 1024 * 1024 // keep the Claude request under its 32MB ceiling
+	)
+
+	form, err := c.MultipartForm()
+	if err != nil {
+		c.JSON(http.StatusBadRequest, gin.H{"error": "Invalid multipart form: " + err.Error()})
+		return
+	}
+	headers := form.File["files"]
+	if len(headers) == 0 {
+		c.JSON(http.StatusBadRequest, gin.H{"error": "At least one file is required (field 'files')"})
+		return
+	}
+	if len(headers) > maxFiles {
+		c.JSON(http.StatusBadRequest, gin.H{"error": fmt.Sprintf("Too many files (max %d)", maxFiles)})
+		return
+	}
+
+	var files []service.FileInput
+	var total int
+	for _, fh := range headers {
+		f, err := fh.Open()
+		if err != nil {
+			c.JSON(http.StatusBadRequest, gin.H{"error": "Failed to read an uploaded file"})
+			return
+		}
+		data, err := io.ReadAll(io.LimitReader(f, maxPerFile+1))
+		f.Close()
+		if err != nil {
+			c.JSON(http.StatusBadRequest, gin.H{"error": "Failed to read an uploaded file"})
+			return
+		}
+		if len(data) == 0 {
+			continue
+		}
+		if len(data) > maxPerFile {
+			c.JSON(http.StatusBadRequest, gin.H{"error": fmt.Sprintf("File %q exceeds the %dMB limit", fh.Filename, maxPerFile/(1024*1024))})
+			return
+		}
+		total += len(data)
+		if total > maxTotalBytes {
+			c.JSON(http.StatusBadRequest, gin.H{"error": "Total upload size is too large"})
+			return
+		}
+		files = append(files, service.FileInput{Data: data})
+	}
+
+	if len(files) == 0 {
+		c.JSON(http.StatusBadRequest, gin.H{"error": "No non-empty files provided"})
+		return
+	}
+
+	recipes, err := h.Service.ImportFromFiles(c.Request.Context(), files, user)
+	if err != nil {
+		logger.Get().Error("failed to import recipes from files", zap.Error(err))
+		var extractErr *service.ExtractionError
+		if errors.As(err, &extractErr) {
+			status := http.StatusUnprocessableEntity
+			if extractErr.Code == "unsupported_file" || extractErr.Code == "no_files" {
+				status = http.StatusBadRequest
+			}
+			c.JSON(status, gin.H{"error": extractErr.Message, "code": extractErr.Code})
+			return
+		}
+		c.JSON(http.StatusInternalServerError, gin.H{"error": "Failed to import recipes from files"})
+		return
+	}
+
+	c.JSON(http.StatusOK, gin.H{"recipes": recipes})
 }
 
 // ImportFromText handles POST /v1/recipes/import/text

--- a/internal/handlers/import_handler_test.go
+++ b/internal/handlers/import_handler_test.go
@@ -1,9 +1,11 @@
 package handlers
 
 import (
+	"bytes"
 	"context"
 	"encoding/json"
 	"fmt"
+	"mime/multipart"
 	"net/http"
 	"net/http/httptest"
 	"strings"
@@ -367,5 +369,73 @@ func TestImportManual_Handler_InvalidUnitSystem(t *testing.T) {
 	}
 	if len(repo.Recipes) != 0 {
 		t.Errorf("no recipe should be created for invalid unit_system")
+	}
+}
+
+func TestImportFromFiles_Handler_Success(t *testing.T) {
+	repo := testutil.NewMockRecipeRepo()
+	importSvc := newImportService(repo, nil)
+	importSvc.VisionProvider = &testutil.MockVisionProvider{
+		ExtractRecipesFromMediaFunc: func(ctx context.Context, media []ai.MediaInput, unitSystem, requirements string) ([]*ai.RecipeResult, error) {
+			r1 := testutil.TestRecipeResult()
+			r2 := testutil.TestRecipeResult()
+			r2.Title = "Second"
+			return []*ai.RecipeResult{r1, r2}, nil
+		},
+	}
+	handler := NewImportHandler(importSvc)
+
+	user := testutil.TestUser()
+	r := gin.New()
+	r.POST("/recipes/import/files", setUser(user), handler.ImportFromFiles)
+
+	var buf bytes.Buffer
+	mw := multipart.NewWriter(&buf)
+	jpegPart, _ := mw.CreateFormFile("files", "a.jpg")
+	jpegPart.Write([]byte{0xFF, 0xD8, 0xFF, 0xE0, 0x00})
+	pdfPart, _ := mw.CreateFormFile("files", "b.pdf")
+	pdfPart.Write([]byte("%PDF-1.7\nx"))
+	mw.Close()
+
+	req := httptest.NewRequest("POST", "/recipes/import/files", &buf)
+	req.Header.Set("Content-Type", mw.FormDataContentType())
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("status = %d, want %d. body: %s", w.Code, http.StatusOK, w.Body.String())
+	}
+	var resp struct {
+		Recipes []map[string]interface{} `json:"recipes"`
+	}
+	json.Unmarshal(w.Body.Bytes(), &resp)
+	if len(resp.Recipes) != 2 {
+		t.Errorf("expected 2 recipes in response, got %d", len(resp.Recipes))
+	}
+	if len(repo.Recipes) != 2 {
+		t.Errorf("expected 2 recipes saved, got %d", len(repo.Recipes))
+	}
+}
+
+func TestImportFromFiles_Handler_NoFiles(t *testing.T) {
+	repo := testutil.NewMockRecipeRepo()
+	importSvc := newImportService(repo, nil)
+	importSvc.VisionProvider = &testutil.MockVisionProvider{}
+	handler := NewImportHandler(importSvc)
+
+	user := testutil.TestUser()
+	r := gin.New()
+	r.POST("/recipes/import/files", setUser(user), handler.ImportFromFiles)
+
+	var buf bytes.Buffer
+	mw := multipart.NewWriter(&buf)
+	mw.Close()
+	req := httptest.NewRequest("POST", "/recipes/import/files", &buf)
+	req.Header.Set("Content-Type", mw.FormDataContentType())
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, req)
+
+	if w.Code != http.StatusBadRequest {
+		t.Errorf("status = %d, want %d. body: %s", w.Code, http.StatusBadRequest, w.Body.String())
 	}
 }

--- a/internal/router/router.go
+++ b/internal/router/router.go
@@ -144,6 +144,7 @@ func SetupRouter(cfg *config.Config, database *gorm.DB) *gin.Engine {
 		// Recipe import routes
 		apiProtected.POST("/recipes/import/url", middleware.AttachUserToContext(userService), importHandler.ImportFromURL)
 		apiProtected.POST("/recipes/import/photo", middleware.AttachUserToContext(userService), importHandler.ImportFromPhoto)
+		apiProtected.POST("/recipes/import/files", middleware.AttachUserToContext(userService), importHandler.ImportFromFiles)
 		apiProtected.POST("/recipes/import/text", middleware.AttachUserToContext(userService), importHandler.ImportFromText)
 		apiProtected.POST("/recipes/import/manual", middleware.AttachUserToContext(userService), importHandler.ImportManual)
 		apiProtected.POST("/recipes/import/canonical", middleware.AttachUserToContext(userService), importHandler.ImportFromCanonical)

--- a/internal/service/import.go
+++ b/internal/service/import.go
@@ -557,6 +557,86 @@ func (s *ImportService) fetchHTML(ctx context.Context, rawURL string) (string, e
 	return string(body), nil
 }
 
+// FileInput is a single uploaded file (image or PDF) for multi-source import.
+type FileInput struct {
+	Data []byte
+}
+
+// maxRecipesPerFileImport bounds how many recipes one multi-file import yields.
+const maxRecipesPerFileImport = 20
+
+// detectMediaKind classifies uploaded bytes as an image or PDF via magic bytes.
+// ok is false for unsupported content.
+func detectMediaKind(data []byte) (kind ai.MediaKind, ok bool) {
+	switch {
+	case len(data) >= 4 && data[0] == 0x25 && data[1] == 0x50 && data[2] == 0x44 && data[3] == 0x46: // %PDF
+		return ai.MediaPDF, true
+	case len(data) >= 3 && data[0] == 0xFF && data[1] == 0xD8 && data[2] == 0xFF: // JPEG
+		return ai.MediaImage, true
+	case len(data) >= 4 && data[0] == 0x89 && data[1] == 0x50 && data[2] == 0x4E && data[3] == 0x47: // PNG
+		return ai.MediaImage, true
+	case len(data) >= 3 && data[0] == 0x47 && data[1] == 0x49 && data[2] == 0x46: // GIF
+		return ai.MediaImage, true
+	case len(data) >= 12 && data[0] == 0x52 && data[1] == 0x49 && data[2] == 0x46 && data[3] == 0x46 &&
+		data[8] == 0x57 && data[9] == 0x45 && data[10] == 0x42 && data[11] == 0x50: // WEBP
+		return ai.MediaImage, true
+	}
+	return "", false
+}
+
+// ImportFromFiles extracts every recipe found across the provided files (images
+// and/or PDFs) and saves each as a recipe for the user.
+func (s *ImportService) ImportFromFiles(ctx context.Context, files []FileInput, user *models.User) ([]*RecipeResponse, error) {
+	log := logger.Get().With(zap.Uint("user_id", user.ID), zap.Int("file_count", len(files)))
+
+	if s.VisionProvider == nil {
+		return nil, fmt.Errorf("no vision provider configured")
+	}
+	if len(files) == 0 {
+		return nil, &ExtractionError{Code: "no_files", Message: "no files provided"}
+	}
+
+	media := make([]ai.MediaInput, 0, len(files))
+	for _, f := range files {
+		kind, ok := detectMediaKind(f.Data)
+		if !ok {
+			return nil, &ExtractionError{Code: "unsupported_file", Message: "unsupported file type; provide images (JPEG, PNG, GIF, WebP) or PDF documents"}
+		}
+		media = append(media, ai.MediaInput{Data: f.Data, Kind: kind})
+	}
+
+	unitSystem := user.Personalization.UnitSystemText()
+	requirements := user.Personalization.Requirements
+
+	results, err := s.VisionProvider.ExtractRecipesFromMedia(ctx, media, unitSystem, requirements)
+	if err != nil {
+		log.Error("multi-file extraction failed", zap.Error(err))
+		return nil, &ExtractionError{Code: "extraction_failed", Message: "could not extract recipes from the provided files"}
+	}
+
+	if len(results) > maxRecipesPerFileImport {
+		log.Warn("capping extracted recipes", zap.Int("found", len(results)), zap.Int("cap", maxRecipesPerFileImport))
+		results = results[:maxRecipesPerFileImport]
+	}
+
+	responses := make([]*RecipeResponse, 0, len(results))
+	for _, result := range results {
+		def := recipeResultToRecipeDef(result)
+		ensureUnitSystem(&def)
+		resp, _, createErr := s.createImportedRecipe(ctx, &def, user, models.RecipeTypeImportVision, "", "", nil, result.Hashtags, result.PromptVersion)
+		if createErr != nil {
+			log.Error("failed to create recipe from file import", zap.String("title", def.Title), zap.Error(createErr))
+			continue
+		}
+		responses = append(responses, resp)
+	}
+
+	if len(responses) == 0 {
+		return nil, &ExtractionError{Code: "extraction_failed", Message: "could not extract any recipes from the provided files"}
+	}
+	return responses, nil
+}
+
 // ImportFromPhoto sends an image to the VisionProvider for recipe extraction.
 func (s *ImportService) ImportFromPhoto(ctx context.Context, imageData []byte, user *models.User) (*RecipeResponse, error) {
 	log := logger.Get().With(zap.Uint("user_id", user.ID))

--- a/internal/service/import_service_test.go
+++ b/internal/service/import_service_test.go
@@ -375,6 +375,92 @@ func TestImportFromCanonical_NotFound(t *testing.T) {
 	}
 }
 
+func TestDetectMediaKind(t *testing.T) {
+	cases := []struct {
+		name string
+		data []byte
+		want ai.MediaKind
+		ok   bool
+	}{
+		{"pdf", []byte("%PDF-1.4"), ai.MediaPDF, true},
+		{"jpeg", []byte{0xFF, 0xD8, 0xFF, 0xE0}, ai.MediaImage, true},
+		{"png", []byte{0x89, 0x50, 0x4E, 0x47, 0x0D, 0x0A}, ai.MediaImage, true},
+		{"gif", []byte{0x47, 0x49, 0x46, 0x38}, ai.MediaImage, true},
+		{"garbage", []byte("hello world"), ai.MediaKind(""), false},
+		{"empty", []byte{}, ai.MediaKind(""), false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			kind, ok := detectMediaKind(tc.data)
+			if ok != tc.ok || kind != tc.want {
+				t.Errorf("detectMediaKind(%s) = (%q, %v), want (%q, %v)", tc.name, kind, ok, tc.want, tc.ok)
+			}
+		})
+	}
+}
+
+func TestImportFromFiles_MultipleRecipes(t *testing.T) {
+	repo := testutil.NewMockRecipeRepo()
+	var gotMedia []ai.MediaInput
+	vision := &testutil.MockVisionProvider{
+		ExtractRecipesFromMediaFunc: func(ctx context.Context, media []ai.MediaInput, unitSystem, requirements string) ([]*ai.RecipeResult, error) {
+			gotMedia = media
+			r1 := testutil.TestRecipeResult()
+			r2 := testutil.TestRecipeResult()
+			r2.Title = "Second Recipe"
+			return []*ai.RecipeResult{r1, r2}, nil
+		},
+	}
+
+	svc := newTestImportService(repo, nil, nil)
+	svc.VisionProvider = vision
+	user := testutil.TestUser()
+
+	jpeg := []byte{0xFF, 0xD8, 0xFF, 0xE0, 0x00, 0x10}
+	pdf := []byte("%PDF-1.7\nfake pdf bytes")
+	resps, err := svc.ImportFromFiles(context.Background(), []FileInput{{Data: jpeg}, {Data: pdf}}, user)
+	if err != nil {
+		t.Fatalf("ImportFromFiles error: %v", err)
+	}
+	if len(resps) != 2 {
+		t.Fatalf("expected 2 recipe responses, got %d", len(resps))
+	}
+	if len(repo.Recipes) != 2 {
+		t.Errorf("expected 2 recipes saved, got %d", len(repo.Recipes))
+	}
+	// The image and the PDF should be classified and forwarded with the right kinds.
+	if len(gotMedia) != 2 || gotMedia[0].Kind != ai.MediaImage || gotMedia[1].Kind != ai.MediaPDF {
+		t.Errorf("media kinds = %+v, want [image pdf]", gotMedia)
+	}
+}
+
+func TestImportFromFiles_UnsupportedFile(t *testing.T) {
+	repo := testutil.NewMockRecipeRepo()
+	svc := newTestImportService(repo, nil, nil)
+	svc.VisionProvider = &testutil.MockVisionProvider{}
+	user := testutil.TestUser()
+
+	_, err := svc.ImportFromFiles(context.Background(), []FileInput{{Data: []byte("definitely not an image or pdf")}}, user)
+	if err == nil {
+		t.Fatal("expected error for unsupported file type")
+	}
+	var extractErr *ExtractionError
+	if !errors.As(err, &extractErr) || extractErr.Code != "unsupported_file" {
+		t.Errorf("expected unsupported_file ExtractionError, got %v", err)
+	}
+}
+
+func TestImportFromFiles_NoFiles(t *testing.T) {
+	repo := testutil.NewMockRecipeRepo()
+	svc := newTestImportService(repo, nil, nil)
+	svc.VisionProvider = &testutil.MockVisionProvider{}
+	user := testutil.TestUser()
+
+	if _, err := svc.ImportFromFiles(context.Background(), nil, user); err == nil {
+		t.Fatal("expected error when no files are provided")
+	}
+}
+
 func TestCreateImportedRecipe_CreatesTree(t *testing.T) {
 	repo := testutil.NewMockRecipeRepo()
 	svc := newTestImportService(repo, nil, nil)

--- a/internal/testutil/mocks.go
+++ b/internal/testutil/mocks.go
@@ -94,7 +94,8 @@ func (m *MockTextProvider) DietaryInterview(ctx context.Context, messages []ai.M
 
 // MockVisionProvider is a mock implementation of ai.VisionProvider.
 type MockVisionProvider struct {
-	ExtractRecipeFromImageFunc func(ctx context.Context, imageData []byte, unitSystem string, requirements string) (*ai.RecipeResult, error)
+	ExtractRecipeFromImageFunc  func(ctx context.Context, imageData []byte, unitSystem string, requirements string) (*ai.RecipeResult, error)
+	ExtractRecipesFromMediaFunc func(ctx context.Context, media []ai.MediaInput, unitSystem string, requirements string) ([]*ai.RecipeResult, error)
 }
 
 func (m *MockVisionProvider) ExtractRecipeFromImage(ctx context.Context, imageData []byte, unitSystem string, requirements string) (*ai.RecipeResult, error) {
@@ -102,6 +103,13 @@ func (m *MockVisionProvider) ExtractRecipeFromImage(ctx context.Context, imageDa
 		return m.ExtractRecipeFromImageFunc(ctx, imageData, unitSystem, requirements)
 	}
 	return nil, fmt.Errorf("ExtractRecipeFromImage not configured")
+}
+
+func (m *MockVisionProvider) ExtractRecipesFromMedia(ctx context.Context, media []ai.MediaInput, unitSystem string, requirements string) ([]*ai.RecipeResult, error) {
+	if m.ExtractRecipesFromMediaFunc != nil {
+		return m.ExtractRecipesFromMediaFunc(ctx, media, unitSystem, requirements)
+	}
+	return nil, fmt.Errorf("ExtractRecipesFromMedia not configured")
 }
 
 // --- MockImageProvider ---


### PR DESCRIPTION
## What

First phase of **unified multi-source import** — `POST /v1/recipes/import/files`. Send several files in one request (a mix of **images and PDF documents**) and it extracts **every distinct recipe found across all of them**, saving each. This closes the core gaps from the import gap-analysis: multi-recipe-per-image, multiple files at once, and document/PDF import.

## How

- **`ai` (Anthropic provider)** — new `VisionProvider.ExtractRecipesFromMedia`: one Claude request with N image content blocks + native PDF `document` blocks and a new `extract_recipes` tool returning a `recipes[]` array. The single-recipe schema is now shared via `recipeProperties()` between `create_recipe` and `extract_recipes` (no duplication). Invalid entries are skipped; `PromptVersion` stamped per recipe.
- **`service`** — `ImportFromFiles` classifies each upload by magic bytes (JPEG/PNG/GIF/WebP → image, `%PDF` → PDF), rejects unsupported types, caps at 20 recipes, and saves each via the existing `createImportedRecipe`.
- **`handler` + `router`** — multipart endpoint (`files` field) with per-file (10 MB), total (<32 MB — under Claude's request ceiling), and count (10) limits; `ExtractionError` codes mapped to 400/422.

## Decisions

- **Sonnet, not Haiku** for this path: 1M context → 600-page PDFs (Haiku's 200K context caps PDFs at 100 pages).
- **Save-all** (extract → create each recipe, return them) rather than a server-side preview cache. A no-save preview variant is a trivial add when the Flutter UI lands (Phase 3) and reuses the same `ExtractRecipesFromMedia`.
- **No `strict` tool schema** — matches the existing forced-`tool_choice` pattern the codebase already relies on, avoiding an `additionalProperties:false`/`required` overhaul of the shared recipe schema.

## Tests

`detectMediaKind` (pdf/jpeg/png/gif/garbage/empty), `ImportFromFiles` service (multi-recipe, unsupported file, no files), and multipart handler (success, no-files). `go test ./... -count=1` → green (11 packages, 0 failures).

## Follow-ups (not in this PR)

- **Phase 2**: voice import (reuse the existing Whisper provider → text path).
- **Phase 3**: Flutter unified "Add recipes" picker + multi-preview screen (+ an optional no-save preview endpoint).
- Still open: the social/shareable recipe-lineage sharing direction.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BU4UWZutHd1AnK3XAf7H19
