### PR TITLE
Voice import: spoken audio → recipe (Whisper → text extraction)

### DIFF
--- a/internal/handlers/import.go
+++ b/internal/handlers/import.go
@@ -6,6 +6,7 @@ import (
 	"io"
 	"net/http"
 	"net/url"
+	"path/filepath"
 	"strings"
 
 	"github.com/gin-gonic/gin"
@@ -191,6 +192,52 @@ func (h *ImportHandler) ImportFromFiles(c *gin.Context) {
 	}
 
 	c.JSON(http.StatusOK, gin.H{"recipes": recipes})
+}
+
+// ImportFromVoice handles POST /v1/recipes/import/voice — a spoken-audio recipe,
+// transcribed via Whisper and extracted from the transcript.
+func (h *ImportHandler) ImportFromVoice(c *gin.Context) {
+	user, err := util.GetUserFromContext(c)
+	if err != nil {
+		c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
+		return
+	}
+
+	file, header, err := c.Request.FormFile("audio")
+	if err != nil {
+		c.JSON(http.StatusBadRequest, gin.H{"error": "Audio file is required (field 'audio')"})
+		return
+	}
+	defer file.Close()
+
+	audioData, err := io.ReadAll(io.LimitReader(file, 25*1024*1024)) // 25MB (Whisper file limit)
+	if err != nil {
+		c.JSON(http.StatusBadRequest, gin.H{"error": "Failed to read audio data"})
+		return
+	}
+	if len(audioData) == 0 {
+		c.JSON(http.StatusBadRequest, gin.H{"error": "Audio file is empty"})
+		return
+	}
+
+	format := strings.TrimSpace(c.PostForm("format"))
+	if format == "" {
+		format = filepath.Ext(header.Filename)
+	}
+
+	recipeResponse, err := h.Service.ImportFromVoice(c.Request.Context(), audioData, format, user)
+	if err != nil {
+		logger.Get().Error("failed to import recipe from voice", zap.Error(err))
+		var extractErr *service.ExtractionError
+		if errors.As(err, &extractErr) {
+			c.JSON(http.StatusUnprocessableEntity, gin.H{"error": extractErr.Message, "code": extractErr.Code})
+			return
+		}
+		c.JSON(http.StatusInternalServerError, gin.H{"error": "Failed to import recipe from voice"})
+		return
+	}
+
+	c.JSON(http.StatusOK, gin.H{"recipe": recipeResponse})
 }
 
 // ImportFromText handles POST /v1/recipes/import/text

--- a/internal/handlers/import_handler_test.go
+++ b/internal/handlers/import_handler_test.go
@@ -439,3 +439,64 @@ func TestImportFromFiles_Handler_NoFiles(t *testing.T) {
 		t.Errorf("status = %d, want %d. body: %s", w.Code, http.StatusBadRequest, w.Body.String())
 	}
 }
+
+func TestImportFromVoice_Handler_Success(t *testing.T) {
+	repo := testutil.NewMockRecipeRepo()
+	text := &testutil.MockTextProvider{
+		ExtractRecipeFromTextFunc: func(ctx context.Context, transcript, unitSystem string) (*ai.RecipeResult, error) {
+			return testutil.TestRecipeResult(), nil
+		},
+	}
+	importSvc := newImportService(repo, text)
+	importSvc.SpeechProvider = &testutil.MockSpeechProvider{
+		TranscribeAudioFunc: func(ctx context.Context, audioData []byte, format string) (string, error) {
+			return "recipe transcript text", nil
+		},
+	}
+	handler := NewImportHandler(importSvc)
+
+	user := testutil.TestUser()
+	r := gin.New()
+	r.POST("/recipes/import/voice", setUser(user), handler.ImportFromVoice)
+
+	var buf bytes.Buffer
+	mw := multipart.NewWriter(&buf)
+	part, _ := mw.CreateFormFile("audio", "note.m4a")
+	part.Write([]byte("fake audio bytes"))
+	mw.Close()
+
+	req := httptest.NewRequest("POST", "/recipes/import/voice", &buf)
+	req.Header.Set("Content-Type", mw.FormDataContentType())
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("status = %d, want %d. body: %s", w.Code, http.StatusOK, w.Body.String())
+	}
+	if len(repo.Recipes) != 1 {
+		t.Errorf("expected 1 recipe saved, got %d", len(repo.Recipes))
+	}
+}
+
+func TestImportFromVoice_Handler_MissingAudio(t *testing.T) {
+	repo := testutil.NewMockRecipeRepo()
+	importSvc := newImportService(repo, nil)
+	importSvc.SpeechProvider = &testutil.MockSpeechProvider{}
+	handler := NewImportHandler(importSvc)
+
+	user := testutil.TestUser()
+	r := gin.New()
+	r.POST("/recipes/import/voice", setUser(user), handler.ImportFromVoice)
+
+	var buf bytes.Buffer
+	mw := multipart.NewWriter(&buf)
+	mw.Close()
+	req := httptest.NewRequest("POST", "/recipes/import/voice", &buf)
+	req.Header.Set("Content-Type", mw.FormDataContentType())
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, req)
+
+	if w.Code != http.StatusBadRequest {
+		t.Errorf("status = %d, want %d", w.Code, http.StatusBadRequest)
+	}
+}

--- a/internal/router/router.go
+++ b/internal/router/router.go
@@ -145,6 +145,7 @@ func SetupRouter(cfg *config.Config, database *gorm.DB) *gin.Engine {
 		apiProtected.POST("/recipes/import/url", middleware.AttachUserToContext(userService), importHandler.ImportFromURL)
 		apiProtected.POST("/recipes/import/photo", middleware.AttachUserToContext(userService), importHandler.ImportFromPhoto)
 		apiProtected.POST("/recipes/import/files", middleware.AttachUserToContext(userService), importHandler.ImportFromFiles)
+		apiProtected.POST("/recipes/import/voice", middleware.AttachUserToContext(userService), importHandler.ImportFromVoice)
 		apiProtected.POST("/recipes/import/text", middleware.AttachUserToContext(userService), importHandler.ImportFromText)
 		apiProtected.POST("/recipes/import/manual", middleware.AttachUserToContext(userService), importHandler.ImportManual)
 		apiProtected.POST("/recipes/import/canonical", middleware.AttachUserToContext(userService), importHandler.ImportFromCanonical)
@@ -230,6 +231,7 @@ func SetupRouter(cfg *config.Config, database *gorm.DB) *gin.Engine {
 	hub := ws.NewHub()
 	go hub.Run()
 	speechProvider := ai.NewWhisperProvider(cfg.EnvVars.OpenAIAPIKey)
+	importService.SpeechProvider = speechProvider
 	voiceService := service.NewVoiceService(cfg, textProvider, speechProvider)
 	cookingHandler := ws.NewCookingHandler(hub, cfg.EnvVars.JwtSecretKey, voiceService, recipeRepo)
 	r.GET("/v1/ws/cook/:recipe_id", cookingHandler.HandleCookingSession)

--- a/internal/service/import.go
+++ b/internal/service/import.go
@@ -42,6 +42,7 @@ type ImportService struct {
 	RecipeService   *RecipeService
 	TextProvider    ai.TextProvider
 	VisionProvider  ai.VisionProvider
+	SpeechProvider  ai.SpeechProvider
 	PreviewProvider ai.TextProvider
 	CanonicalRepo   repository.CanonicalRecipeRepo
 	Policy          *ImportPolicy
@@ -693,6 +694,40 @@ func (s *ImportService) ImportFromText(ctx context.Context, text string, user *m
 	if err != nil {
 		log.Error("text extraction failed", zap.Error(err))
 		return nil, fmt.Errorf("failed to extract recipe from text: %w", err)
+	}
+
+	def := recipeResultToRecipeDef(result)
+	ensureUnitSystem(&def)
+	resp, _, err := s.createImportedRecipe(ctx, &def, user, models.RecipeTypeImportCopypasta, "", "", nil, result.Hashtags, result.PromptVersion)
+	return resp, err
+}
+
+// ImportFromVoice transcribes spoken audio and extracts a recipe from the
+// transcript, then saves it.
+func (s *ImportService) ImportFromVoice(ctx context.Context, audioData []byte, format string, user *models.User) (*RecipeResponse, error) {
+	log := logger.Get().With(zap.Uint("user_id", user.ID))
+
+	if s.SpeechProvider == nil {
+		return nil, fmt.Errorf("no speech provider configured")
+	}
+	if s.TextProvider == nil {
+		return nil, fmt.Errorf("no AI text provider configured")
+	}
+
+	transcript, err := s.SpeechProvider.TranscribeAudio(ctx, audioData, format)
+	if err != nil {
+		log.Error("voice transcription failed", zap.Error(err))
+		return nil, &ExtractionError{Code: "transcription_failed", Message: "could not transcribe the audio"}
+	}
+	if strings.TrimSpace(transcript) == "" {
+		return nil, &ExtractionError{Code: "empty_transcript", Message: "no speech detected in the audio"}
+	}
+
+	unitSystem := user.Personalization.UnitSystemText()
+	result, err := s.TextProvider.ExtractRecipeFromText(ctx, transcript, unitSystem)
+	if err != nil {
+		log.Error("voice text extraction failed", zap.Error(err))
+		return nil, fmt.Errorf("failed to extract recipe from transcript: %w", err)
 	}
 
 	def := recipeResultToRecipeDef(result)

--- a/internal/service/import_service_test.go
+++ b/internal/service/import_service_test.go
@@ -461,6 +461,76 @@ func TestImportFromFiles_NoFiles(t *testing.T) {
 	}
 }
 
+func TestImportFromVoice_Success(t *testing.T) {
+	repo := testutil.NewMockRecipeRepo()
+	text := &testutil.MockTextProvider{
+		ExtractRecipeFromTextFunc: func(ctx context.Context, transcript, unitSystem string) (*ai.RecipeResult, error) {
+			if transcript == "" {
+				t.Error("expected a non-empty transcript passed to text extraction")
+			}
+			return testutil.TestRecipeResult(), nil
+		},
+	}
+	svc := newTestImportService(repo, text, nil)
+	svc.SpeechProvider = &testutil.MockSpeechProvider{
+		TranscribeAudioFunc: func(ctx context.Context, audioData []byte, format string) (string, error) {
+			return "Pancakes: mix flour, eggs, and milk, then cook on a griddle.", nil
+		},
+	}
+	user := testutil.TestUser()
+
+	resp, err := svc.ImportFromVoice(context.Background(), []byte("fake-audio"), "m4a", user)
+	if err != nil {
+		t.Fatalf("ImportFromVoice error: %v", err)
+	}
+	if resp == nil {
+		t.Fatal("expected a recipe response")
+	}
+	if len(repo.Recipes) != 1 {
+		t.Errorf("expected 1 recipe saved, got %d", len(repo.Recipes))
+	}
+}
+
+func TestImportFromVoice_EmptyTranscript(t *testing.T) {
+	repo := testutil.NewMockRecipeRepo()
+	svc := newTestImportService(repo, &testutil.MockTextProvider{}, nil)
+	svc.SpeechProvider = &testutil.MockSpeechProvider{
+		TranscribeAudioFunc: func(ctx context.Context, audioData []byte, format string) (string, error) {
+			return "   ", nil
+		},
+	}
+	user := testutil.TestUser()
+
+	_, err := svc.ImportFromVoice(context.Background(), []byte("x"), "m4a", user)
+	if err == nil {
+		t.Fatal("expected error for an empty transcript")
+	}
+	var extractErr *ExtractionError
+	if !errors.As(err, &extractErr) || extractErr.Code != "empty_transcript" {
+		t.Errorf("expected empty_transcript ExtractionError, got %v", err)
+	}
+}
+
+func TestImportFromVoice_TranscriptionError(t *testing.T) {
+	repo := testutil.NewMockRecipeRepo()
+	svc := newTestImportService(repo, &testutil.MockTextProvider{}, nil)
+	svc.SpeechProvider = &testutil.MockSpeechProvider{
+		TranscribeAudioFunc: func(ctx context.Context, audioData []byte, format string) (string, error) {
+			return "", fmt.Errorf("whisper unavailable")
+		},
+	}
+	user := testutil.TestUser()
+
+	_, err := svc.ImportFromVoice(context.Background(), []byte("x"), "m4a", user)
+	if err == nil {
+		t.Fatal("expected error when transcription fails")
+	}
+	var extractErr *ExtractionError
+	if !errors.As(err, &extractErr) || extractErr.Code != "transcription_failed" {
+		t.Errorf("expected transcription_failed ExtractionError, got %v", err)
+	}
+}
+
 func TestCreateImportedRecipe_CreatesTree(t *testing.T) {
 	repo := testutil.NewMockRecipeRepo()
 	svc := newTestImportService(repo, nil, nil)


### PR DESCRIPTION
## What

**Phase 2 of unified multi-source import** — `POST /v1/recipes/import/voice`. Upload spoken audio (a recipe read or described aloud); it's transcribed via the existing Whisper provider and run through the same text-extraction path, then saved. Voice transcription was previously wired only to cook mode — this reuses it for capture.

## How

- **`service`** — `ImportFromVoice(audio, format)` = `TranscribeAudio` → `ExtractRecipeFromText` → `createImportedRecipe` (mirrors `ImportFromText`). New settable `SpeechProvider` field on `ImportService`, set in the router from the Whisper provider already built for cook mode.
- **`handler` + `router`** — multipart `audio` field (+ optional `format`), 25 MB cap (Whisper's file limit), `ExtractionError` codes → 422. Format defaults from the filename extension; the provider's `audioFilePath` already normalizes/validates it.

## Tests

`ImportFromVoice` service (success, empty transcript, transcription error) + multipart handler (success, missing audio). `go test ./... -count=1` → green (11 packages, 0 failures).

## Follow-ups (not in this PR)

- **Phase 3**: Flutter unified "Add recipes" picker + multi-preview screen, surfacing files + voice alongside the existing options (and an optional no-save preview endpoint).
- Still open: the social/shareable recipe-lineage sharing direction.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BU4UWZutHd1AnK3XAf7H19
