### PR TITLE
Video-import foundation: cache, async-job model, premium quota + kill switch

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -37,6 +37,13 @@ type EnvVars struct {
 	GoogleSearchCX  string `env:"GOOGLE_SEARCH_CX" optional:"true"`
 	BraveSearchKey  string `env:"BRAVE_SEARCH_KEY" optional:"true"`
 	FirecrawlAPIKey string `env:"FIRECRAWL_API_KEY" optional:"true"`
+	// ScrapeCreatorsAPIKey enables video-link import (TikTok/Instagram/YouTube/
+	// Facebook/Pinterest). When empty, video import is disabled.
+	ScrapeCreatorsAPIKey string `env:"SCRAPECREATORS_API_KEY" optional:"true"`
+	// VideoImportDailyBudgetUSD is the global daily spend ceiling for fresh video
+	// extractions; once the day's metered cost exceeds it, fresh extractions are
+	// refused (cache hits still serve). The kill switch.
+	VideoImportDailyBudgetUSD float64 `env:"VIDEO_IMPORT_DAILY_BUDGET_USD" envDefault:"25" optional:"true"`
 }
 
 // LoadConfig parses environment variables into the Config struct.

--- a/internal/db/db.go
+++ b/internal/db/db.go
@@ -60,6 +60,8 @@ func connectToDatabaseWithRetry(databaseURL string) (*gorm.DB, error) {
 		&models.AllergenAnalysis{},
 		&models.SearchCache{},
 		&models.CanonicalRecipe{},
+		&models.VideoExtractionCache{},
+		&models.VideoImport{},
 	); migrateErr != nil {
 		return nil, fmt.Errorf("database auto-migration failed: %w", migrateErr)
 	}

--- a/internal/models/user.go
+++ b/internal/models/user.go
@@ -91,6 +91,7 @@ type Subscription struct {
 	AllergenAnalysesUsed int `gorm:"default:0"`
 	WebSearchesUsed      int `gorm:"default:0"`
 	AIGenerationsUsed    int `gorm:"default:0"`
+	VideoImportsUsed     int `gorm:"default:0"`
 	MonthlyResetAt       time.Time
 }
 
@@ -116,6 +117,16 @@ func (s *Subscription) CanUseAIGeneration() bool {
 		return true
 	}
 	return s.AIGenerationsUsed < 50
+}
+
+// CanUseVideoImport checks if the user can import a recipe from a video link.
+// Both tiers are capped (premium included) to bound per-video AI cost:
+// free = 2/month, premium = 20/month.
+func (s *Subscription) CanUseVideoImport() bool {
+	if s.Tier == TierPremium {
+		return s.VideoImportsUsed < 20
+	}
+	return s.VideoImportsUsed < 2
 }
 
 // IsValidSubscriptionTier checks if the SubscriptionTier is valid.

--- a/internal/models/video_import.go
+++ b/internal/models/video_import.go
@@ -1,0 +1,48 @@
+package models
+
+import (
+	"time"
+
+	"gorm.io/gorm"
+)
+
+// VideoExtractionCache is the per-video master copy of a recipe extracted from a
+// social/video link, keyed by platform+video ID so a viral video is processed
+// once and served from cache to everyone else (the primary cost control).
+type VideoExtractionCache struct {
+	gorm.Model
+	VideoKey       string    `gorm:"uniqueIndex;size:512;not null"` // "<platform>:<video_id>"
+	Platform       string    `gorm:"size:32;not null"`
+	OriginalURL    string    `gorm:"size:2048;not null"`
+	RecipeData     RecipeDef `gorm:"type:jsonb;not null"`
+	HitCount       int       `gorm:"default:0"`
+	LastAccessedAt time.Time `gorm:"index;not null"`
+	FetchedAt      time.Time `gorm:"index;not null"`
+	PromptVersion  string    `gorm:"size:16"`
+}
+
+// VideoImportStatus is the lifecycle state of an async video-import job.
+type VideoImportStatus string
+
+// VideoImportStatus values.
+const (
+	VideoImportQueued     VideoImportStatus = "queued"
+	VideoImportProcessing VideoImportStatus = "processing"
+	VideoImportDone       VideoImportStatus = "done"
+	VideoImportFailed     VideoImportStatus = "failed"
+)
+
+// VideoImport is an async job tracking one video-link import. CostUSD meters the
+// metered spend (0 for cache hits) and powers the daily-budget kill switch.
+type VideoImport struct {
+	gorm.Model
+	UserID    uint              `gorm:"index;not null"`
+	SourceURL string            `gorm:"size:2048;not null"`
+	Platform  string            `gorm:"size:32"`
+	VideoKey  string            `gorm:"index;size:512"`
+	Status    VideoImportStatus `gorm:"type:text;not null;default:'queued'"`
+	RecipeID  *uint             `gorm:"index"`
+	CostUSD   float64           `gorm:"default:0"`
+	CacheHit  bool              `gorm:"default:false"`
+	Error     string            `gorm:"size:512"`
+}

--- a/internal/models/video_import_test.go
+++ b/internal/models/video_import_test.go
@@ -1,0 +1,27 @@
+package models
+
+import "testing"
+
+func TestSubscription_CanUseVideoImport(t *testing.T) {
+	cases := []struct {
+		name string
+		tier SubscriptionTier
+		used int
+		want bool
+	}{
+		{"free under cap", TierFree, 1, true},
+		{"free at cap", TierFree, 2, false},
+		{"free over cap", TierFree, 5, false},
+		{"premium under cap", TierPremium, 19, true},
+		{"premium at cap", TierPremium, 20, false},
+		{"premium over cap", TierPremium, 25, false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			s := &Subscription{Tier: tc.tier, VideoImportsUsed: tc.used}
+			if got := s.CanUseVideoImport(); got != tc.want {
+				t.Errorf("CanUseVideoImport(tier=%s, used=%d) = %v, want %v", tc.tier, tc.used, got, tc.want)
+			}
+		})
+	}
+}

--- a/internal/repository/interfaces.go
+++ b/internal/repository/interfaces.go
@@ -49,6 +49,18 @@ type CanonicalRecipeRepo interface {
 	IncrementHitCount(id uint) error
 }
 
+// VideoImportRepo is the interface for the video extraction cache and async
+// video-import jobs.
+type VideoImportRepo interface {
+	GetCacheByVideoKey(videoKey string) (*models.VideoExtractionCache, error)
+	UpsertCache(entry *models.VideoExtractionCache) error
+	IncrementCacheHit(id uint) error
+	CreateImport(job *models.VideoImport) error
+	GetImportByID(id uint) (*models.VideoImport, error)
+	UpdateImport(job *models.VideoImport) error
+	SumImportCostSince(t time.Time) (float64, error)
+}
+
 // SearchCacheRepo is the interface for search cache repository operations.
 type SearchCacheRepo interface {
 	GetByNormalizedQuery(query string) (*models.SearchCache, error)

--- a/internal/repository/user.go
+++ b/internal/repository/user.go
@@ -208,6 +208,7 @@ func (r *UserRepository) ResetSubscriptionUsage(userID uint, nextReset time.Time
 			"allergen_analyses_used": 0,
 			"web_searches_used":      0,
 			"ai_generations_used":    0,
+			"video_imports_used":     0,
 			"monthly_reset_at":       nextReset,
 		})
 	if result.Error != nil {

--- a/internal/repository/video_import.go
+++ b/internal/repository/video_import.go
@@ -1,0 +1,79 @@
+package repository
+
+import (
+	"time"
+
+	"github.com/windoze95/saltybytes-api/internal/models"
+	"gorm.io/gorm"
+	"gorm.io/gorm/clause"
+)
+
+// VideoImportRepository handles the video extraction cache and async import jobs.
+type VideoImportRepository struct {
+	DB *gorm.DB
+}
+
+// NewVideoImportRepository creates a new VideoImportRepository.
+func NewVideoImportRepository(db *gorm.DB) *VideoImportRepository {
+	return &VideoImportRepository{DB: db}
+}
+
+// GetCacheByVideoKey returns the cached extraction for a video key.
+func (r *VideoImportRepository) GetCacheByVideoKey(videoKey string) (*models.VideoExtractionCache, error) {
+	var entry models.VideoExtractionCache
+	if err := r.DB.Where("video_key = ?", videoKey).First(&entry).Error; err != nil {
+		return nil, err
+	}
+	return &entry, nil
+}
+
+// UpsertCache inserts or updates a video extraction cache entry by video key.
+func (r *VideoImportRepository) UpsertCache(entry *models.VideoExtractionCache) error {
+	return r.DB.Clauses(clause.OnConflict{
+		Columns:   []clause.Column{{Name: "video_key"}},
+		DoUpdates: clause.AssignmentColumns([]string{"recipe_data", "original_url", "platform", "fetched_at", "last_accessed_at", "prompt_version"}),
+	}).Create(entry).Error
+}
+
+// IncrementCacheHit atomically bumps the hit count and last-accessed time.
+func (r *VideoImportRepository) IncrementCacheHit(id uint) error {
+	return r.DB.Model(&models.VideoExtractionCache{}).
+		Where("id = ?", id).
+		Updates(map[string]interface{}{
+			"hit_count":        gorm.Expr("hit_count + 1"),
+			"last_accessed_at": time.Now(),
+		}).Error
+}
+
+// CreateImport inserts a new async video-import job.
+func (r *VideoImportRepository) CreateImport(job *models.VideoImport) error {
+	return r.DB.Create(job).Error
+}
+
+// GetImportByID returns a video-import job by ID.
+func (r *VideoImportRepository) GetImportByID(id uint) (*models.VideoImport, error) {
+	var job models.VideoImport
+	if err := r.DB.First(&job, id).Error; err != nil {
+		return nil, err
+	}
+	return &job, nil
+}
+
+// UpdateImport persists changes to a video-import job.
+func (r *VideoImportRepository) UpdateImport(job *models.VideoImport) error {
+	return r.DB.Save(job).Error
+}
+
+// SumImportCostSince returns the total metered cost of video imports created at
+// or after t — used to enforce the global daily budget kill switch.
+func (r *VideoImportRepository) SumImportCostSince(t time.Time) (float64, error) {
+	var total float64
+	err := r.DB.Model(&models.VideoImport{}).
+		Where("created_at >= ?", t).
+		Select("COALESCE(SUM(cost_usd), 0)").
+		Scan(&total).Error
+	return total, err
+}
+
+// Compile-time check that VideoImportRepository satisfies VideoImportRepo.
+var _ VideoImportRepo = (*VideoImportRepository)(nil)

--- a/internal/service/subscription.go
+++ b/internal/service/subscription.go
@@ -83,6 +83,8 @@ func (s *SubscriptionService) IncrementUsage(userID uint, usageType string) erro
 		column = "web_searches_used"
 	case "ai_generation":
 		column = "ai_generations_used"
+	case "video_import":
+		column = "video_imports_used"
 	default:
 		return fmt.Errorf("unknown usage type: %s", usageType)
 	}
@@ -104,6 +106,8 @@ func (s *SubscriptionService) CheckLimit(userID uint, usageType string) (bool, e
 		return sub.CanUseWebSearch(), nil
 	case "ai_generation":
 		return sub.CanUseAIGeneration(), nil
+	case "video_import":
+		return sub.CanUseVideoImport(), nil
 	default:
 		return false, fmt.Errorf("unknown usage type: %s", usageType)
 	}


### PR DESCRIPTION
## What

Foundation (PR 1 of ~2) for the premium **"import a recipe from any video link"** feature — TikTok / Instagram Reels / YouTube / Facebook / Pinterest. Lands the **data model, premium gating, and all cost-control scaffolding** with **no external calls yet**, so it's safe and fully testable. The acquisition + extraction pipeline lands in PR2 (needs the ScrapeCreators key).

## Cost-control design (the stop-losses)

- **Process-once cache** — `VideoExtractionCache` keyed by `platform:video_id` (mirrors the proven `CanonicalRecipe` cache). A viral video is extracted once; everyone else is served from cache → amortized cost ≈ $0.
- **Per-user monthly quota** — `VideoImportsUsed` + `CanUseVideoImport()`: **free 2/mo, premium 20/mo** (capped even for premium to bound per-video AI cost). Reuses the existing `Subscription` counter machinery (CheckLimit / IncrementUsage / monthly reset).
- **Daily global budget kill switch** — `VideoImport.CostUSD` meters every import; `SumImportCostSince` + `VIDEO_IMPORT_DAILY_BUDGET_USD` (default $25/day) let PR2 refuse fresh extractions once the day's spend is exceeded (cache hits still serve).
- **Feature flag** — `SCRAPECREATORS_API_KEY` optional; feature stays dark until set in prod (same pattern as Firecrawl).

## Pricing (locked)

Premium **$4.99/mo · $39.99/yr → 20 video imports/month**, free 2/month — market-center, **≥65% margin** after the cache (per-fresh-extraction cost ≈ $0.08–0.20).

## Files

`VideoExtractionCache` + `VideoImport` models, `VideoImportRepository` + `VideoImportRepo` interface, the subscription gating extension, config keys, and the AutoMigrate registration. Unit test covers the `CanUseVideoImport` free/premium caps.

## Tests

`go test ./... -count=1` → green (11 packages, 0 failures).

## Next

**PR2:** ScrapeCreators client + ffmpeg frame sampling + transcript → the existing `ExtractRecipesFromMedia` engine, async job + polling endpoint, metering + kill-switch enforcement, Dockerfile → debian-slim (ffmpeg). Needs the ScrapeCreators API key.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BU4UWZutHd1AnK3XAf7H19
