### PR TITLE
Video import PR2a: ScrapeCreators client (platform detect + TikTok)

### DIFF
--- a/internal/video/scrapecreators.go
+++ b/internal/video/scrapecreators.go
@@ -1,0 +1,176 @@
+// Package video handles importing recipes from social/video links by acquiring
+// the video's caption, transcript, and downloadable media via the ScrapeCreators
+// API, then (in later layers) sampling frames and extracting the recipe.
+package video
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+	"strings"
+)
+
+// Platform identifies a supported source platform.
+type Platform string
+
+// Supported platforms.
+const (
+	PlatformTikTok    Platform = "tiktok"
+	PlatformInstagram Platform = "instagram"
+	PlatformYouTube   Platform = "youtube"
+	PlatformFacebook  Platform = "facebook"
+	PlatformPinterest Platform = "pinterest"
+)
+
+// DetectPlatform classifies a URL by host. ok is false for unsupported hosts.
+func DetectPlatform(rawURL string) (Platform, bool) {
+	u, err := url.Parse(rawURL)
+	if err != nil || u.Hostname() == "" {
+		return "", false
+	}
+	h := strings.ToLower(u.Hostname())
+	switch {
+	case strings.Contains(h, "tiktok.com"):
+		return PlatformTikTok, true
+	case strings.Contains(h, "instagram.com"):
+		return PlatformInstagram, true
+	case strings.Contains(h, "youtube.com"), strings.Contains(h, "youtu.be"):
+		return PlatformYouTube, true
+	case strings.Contains(h, "facebook.com"), strings.Contains(h, "fb.watch"), strings.Contains(h, "fb.com"):
+		return PlatformFacebook, true
+	case strings.Contains(h, "pinterest.com"), strings.Contains(h, "pin.it"):
+		return PlatformPinterest, true
+	}
+	return "", false
+}
+
+// VideoMeta is the normalized result of a ScrapeCreators lookup.
+type VideoMeta struct {
+	Platform   Platform
+	VideoID    string
+	Caption    string
+	Transcript string // may be empty; falls back to audio transcription downstream
+	MediaURL   string // downloadable video URL, no-watermark preferred
+	DurationMS int
+}
+
+const scrapeCreatorsBaseURL = "https://api.scrapecreators.com"
+
+// ScrapeCreatorsClient fetches video metadata, media URLs, and transcripts.
+type ScrapeCreatorsClient struct {
+	apiKey  string
+	baseURL string
+	// httpDo is a test seam; nil uses http.DefaultClient.
+	httpDo func(req *http.Request) (*http.Response, error)
+}
+
+// NewScrapeCreatorsClient creates a client for the given API key.
+func NewScrapeCreatorsClient(apiKey string) *ScrapeCreatorsClient {
+	return &ScrapeCreatorsClient{apiKey: apiKey, baseURL: scrapeCreatorsBaseURL}
+}
+
+func (c *ScrapeCreatorsClient) get(ctx context.Context, path string, q url.Values) ([]byte, error) {
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, c.baseURL+path+"?"+q.Encode(), nil)
+	if err != nil {
+		return nil, err
+	}
+	req.Header.Set("x-api-key", c.apiKey)
+
+	doer := c.httpDo
+	if doer == nil {
+		doer = http.DefaultClient.Do
+	}
+	resp, err := doer(req)
+	if err != nil {
+		return nil, fmt.Errorf("scrapecreators request failed: %w", err)
+	}
+	defer resp.Body.Close()
+
+	body, err := io.ReadAll(io.LimitReader(resp.Body, 8*1024*1024))
+	if err != nil {
+		return nil, fmt.Errorf("read scrapecreators response: %w", err)
+	}
+	if resp.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("scrapecreators %s returned status %d", path, resp.StatusCode)
+	}
+	return body, nil
+}
+
+// FetchVideo resolves a supported video URL to normalized metadata (caption,
+// transcript, downloadable media URL).
+func (c *ScrapeCreatorsClient) FetchVideo(ctx context.Context, rawURL string) (*VideoMeta, error) {
+	platform, ok := DetectPlatform(rawURL)
+	if !ok {
+		return nil, fmt.Errorf("unsupported video platform for url")
+	}
+	switch platform {
+	case PlatformTikTok:
+		return c.fetchTikTok(ctx, rawURL)
+	default:
+		return nil, fmt.Errorf("platform %q not yet supported", platform)
+	}
+}
+
+// tiktokVideoResponse is the subset of the /v2/tiktok/video response we use.
+type tiktokVideoResponse struct {
+	Success     bool   `json:"success"`
+	Transcript  string `json:"transcript"`
+	AwemeDetail struct {
+		AwemeID string `json:"aweme_id"`
+		Desc    string `json:"desc"`
+		Video   struct {
+			Duration                int  `json:"duration"`
+			HasWatermark            bool `json:"has_watermark"`
+			DownloadNoWatermarkAddr struct {
+				URLList []string `json:"url_list"`
+			} `json:"download_no_watermark_addr"`
+			PlayAddr struct {
+				URLList []string `json:"url_list"`
+			} `json:"play_addr"`
+		} `json:"video"`
+	} `json:"aweme_detail"`
+}
+
+func (c *ScrapeCreatorsClient) fetchTikTok(ctx context.Context, rawURL string) (*VideoMeta, error) {
+	q := url.Values{}
+	q.Set("url", rawURL)
+	q.Set("get_transcript", "true")
+
+	body, err := c.get(ctx, "/v2/tiktok/video", q)
+	if err != nil {
+		return nil, err
+	}
+	var r tiktokVideoResponse
+	if err := json.Unmarshal(body, &r); err != nil {
+		return nil, fmt.Errorf("parse tiktok response: %w", err)
+	}
+	if r.AwemeDetail.AwemeID == "" {
+		return nil, fmt.Errorf("tiktok response missing video detail")
+	}
+
+	media := firstNonEmpty(r.AwemeDetail.Video.DownloadNoWatermarkAddr.URLList)
+	if media == "" {
+		media = firstNonEmpty(r.AwemeDetail.Video.PlayAddr.URLList)
+	}
+
+	return &VideoMeta{
+		Platform:   PlatformTikTok,
+		VideoID:    r.AwemeDetail.AwemeID,
+		Caption:    r.AwemeDetail.Desc,
+		Transcript: r.Transcript,
+		MediaURL:   media,
+		DurationMS: r.AwemeDetail.Video.Duration,
+	}, nil
+}
+
+func firstNonEmpty(list []string) string {
+	for _, s := range list {
+		if s != "" {
+			return s
+		}
+	}
+	return ""
+}

--- a/internal/video/scrapecreators_test.go
+++ b/internal/video/scrapecreators_test.go
@@ -1,0 +1,132 @@
+package video
+
+import (
+	"context"
+	"io"
+	"net/http"
+	"strings"
+	"testing"
+)
+
+func TestDetectPlatform(t *testing.T) {
+	cases := []struct {
+		url  string
+		want Platform
+		ok   bool
+	}{
+		{"https://www.tiktok.com/@chef/video/7499229683859426602", PlatformTikTok, true},
+		{"https://vm.tiktok.com/ABC123/", PlatformTikTok, true},
+		{"https://www.instagram.com/reel/Cabc123/", PlatformInstagram, true},
+		{"https://www.youtube.com/watch?v=dQw4w9WgXcQ", PlatformYouTube, true},
+		{"https://youtu.be/dQw4w9WgXcQ", PlatformYouTube, true},
+		{"https://www.youtube.com/shorts/abc123", PlatformYouTube, true},
+		{"https://www.facebook.com/reel/123", PlatformFacebook, true},
+		{"https://fb.watch/xyz/", PlatformFacebook, true},
+		{"https://www.pinterest.com/pin/12345/", PlatformPinterest, true},
+		{"https://pin.it/abc", PlatformPinterest, true},
+		{"https://example.com/recipe", "", false},
+		{"not a url at all", "", false},
+		{"", "", false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.url, func(t *testing.T) {
+			got, ok := DetectPlatform(tc.url)
+			if ok != tc.ok || got != tc.want {
+				t.Errorf("DetectPlatform(%q) = (%q, %v), want (%q, %v)", tc.url, got, ok, tc.want, tc.ok)
+			}
+		})
+	}
+}
+
+func TestFetchVideo_TikTok(t *testing.T) {
+	const fixture = `{
+		"success": true,
+		"credits_remaining": 999,
+		"transcript": "First mix the flour and eggs, then cook on a griddle.",
+		"aweme_detail": {
+			"aweme_id": "7499229683859426602",
+			"desc": "easy fluffy pancakes #recipe #breakfast",
+			"video": {
+				"duration": 45000,
+				"has_watermark": false,
+				"download_no_watermark_addr": {"url_list": ["https://cdn.example/nowm.mp4"]},
+				"play_addr": {"url_list": ["https://cdn.example/play.mp4"]}
+			}
+		}
+	}`
+
+	c := NewScrapeCreatorsClient("test-key")
+	var gotKey, gotURL string
+	c.httpDo = func(req *http.Request) (*http.Response, error) {
+		gotKey = req.Header.Get("x-api-key")
+		gotURL = req.URL.String()
+		return &http.Response{StatusCode: 200, Body: io.NopCloser(strings.NewReader(fixture))}, nil
+	}
+
+	m, err := c.FetchVideo(context.Background(), "https://www.tiktok.com/@chef/video/7499229683859426602")
+	if err != nil {
+		t.Fatalf("FetchVideo error: %v", err)
+	}
+	if gotKey != "test-key" {
+		t.Errorf("x-api-key header = %q, want test-key", gotKey)
+	}
+	if !strings.Contains(gotURL, "/v2/tiktok/video") || !strings.Contains(gotURL, "get_transcript=true") {
+		t.Errorf("request URL = %q, want /v2/tiktok/video with get_transcript=true", gotURL)
+	}
+	if m.Platform != PlatformTikTok {
+		t.Errorf("platform = %q, want tiktok", m.Platform)
+	}
+	if m.VideoID != "7499229683859426602" {
+		t.Errorf("video id = %q", m.VideoID)
+	}
+	if m.Caption != "easy fluffy pancakes #recipe #breakfast" {
+		t.Errorf("caption = %q", m.Caption)
+	}
+	if m.Transcript == "" {
+		t.Error("expected a transcript")
+	}
+	if m.MediaURL != "https://cdn.example/nowm.mp4" {
+		t.Errorf("media url = %q, want the no-watermark url", m.MediaURL)
+	}
+	if m.DurationMS != 45000 {
+		t.Errorf("duration = %d, want 45000", m.DurationMS)
+	}
+}
+
+func TestFetchVideo_TikTok_FallsBackToPlayAddr(t *testing.T) {
+	const fixture = `{
+		"aweme_detail": {
+			"aweme_id": "1",
+			"desc": "x",
+			"video": {"has_watermark": false, "play_addr": {"url_list": ["https://cdn.example/play.mp4"]}}
+		}
+	}`
+	c := NewScrapeCreatorsClient("k")
+	c.httpDo = func(req *http.Request) (*http.Response, error) {
+		return &http.Response{StatusCode: 200, Body: io.NopCloser(strings.NewReader(fixture))}, nil
+	}
+	m, err := c.FetchVideo(context.Background(), "https://www.tiktok.com/@x/video/1")
+	if err != nil {
+		t.Fatalf("error: %v", err)
+	}
+	if m.MediaURL != "https://cdn.example/play.mp4" {
+		t.Errorf("media url = %q, want play_addr fallback", m.MediaURL)
+	}
+}
+
+func TestFetchVideo_UnsupportedPlatform(t *testing.T) {
+	c := NewScrapeCreatorsClient("k")
+	if _, err := c.FetchVideo(context.Background(), "https://example.com/v/1"); err == nil {
+		t.Fatal("expected error for unsupported platform")
+	}
+}
+
+func TestFetchVideo_HTTPError(t *testing.T) {
+	c := NewScrapeCreatorsClient("k")
+	c.httpDo = func(req *http.Request) (*http.Response, error) {
+		return &http.Response{StatusCode: 402, Body: io.NopCloser(strings.NewReader("payment required"))}, nil
+	}
+	if _, err := c.FetchVideo(context.Background(), "https://www.tiktok.com/@x/video/1"); err == nil {
+		t.Fatal("expected error on non-200 status")
+	}
+}


### PR DESCRIPTION
## What

PR 2a of the premium video-link import pipeline (foundation merged in #86). New `internal/video` package that acquires a video's caption, transcript, and downloadable media URL via the **ScrapeCreators** API.

- **`DetectPlatform`** — classifies TikTok / Instagram / YouTube / Facebook / Pinterest URLs by host.
- **`ScrapeCreatorsClient.FetchVideo`** → normalized `VideoMeta{VideoID, Caption, Transcript, MediaURL, DurationMS}`. Auth via `x-api-key`. **TikTok implemented and verified against the live API** (`/v2/tiktok/video` with `get_transcript=true` → `aweme_detail.desc`, `.video.download_no_watermark_addr` with `play_addr` fallback, bundled `transcript`). The other four platforms are stubbed (`not yet supported`) for fast-follow — same client shape.
- An `httpDo` request seam keeps it **fully unit-tested offline** (no network, no key).

## Tests

`DetectPlatform` (all 5 platforms + unsupported/garbage), TikTok parse (no-watermark + play_addr fallback), unsupported-platform + HTTP-error paths. `go test ./... -count=1` -> green (12 packages, 0 failures).

## Next

- **PR2b:** ffmpeg frame sampling + Dockerfile -> debian-slim.
- **PR2c:** async job + `POST /v1/recipes/import/video` + poll endpoint, fanning `VideoMeta` (frames + transcript) into `ExtractRecipesFromMedia`, with the premium gate, cache, metering, and daily-budget kill switch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BU4UWZutHd1AnK3XAf7H19
