### PR TITLE
Video import PR2b: ffmpeg frame sampling + ffmpeg in Docker image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -18,7 +18,13 @@ WORKDIR /app/cmd/api
 RUN go build -o /saltybytes-api .
 
 # Stage 2: Runtime
-FROM gcr.io/distroless/base-debian12
+FROM debian:12-slim
+
+# ffmpeg powers video-link import frame extraction; ca-certificates is needed
+# for outbound HTTPS (it ships in distroless but not debian-slim).
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends ca-certificates ffmpeg \
+    && rm -rf /var/lib/apt/lists/*
 
 # Copy the binary and config files from the builder
 COPY --from=builder /saltybytes-api /saltybytes-api

--- a/internal/video/frames.go
+++ b/internal/video/frames.go
@@ -1,0 +1,187 @@
+package video
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"io"
+	"net/http"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"sort"
+	"strconv"
+	"time"
+)
+
+const (
+	// DefaultMaxFrames bounds frames sampled per video — the master cost dial
+	// (~$0.0048/frame on Sonnet). Lower it to cut spend, raise it for coverage.
+	DefaultMaxFrames = 30
+	// minSceneFrames: if scene detection yields fewer than this (e.g. a static
+	// talking-head clip with no cuts), fall back to even time sampling.
+	minSceneFrames = 6
+	// maxVideoBytes caps the downloaded source video.
+	maxVideoBytes = 120 * 1024 * 1024
+	// frameWidth scales frames down; keeps Claude image input at standard
+	// resolution (avoids the ~3x high-res token cost) while staying legible.
+	frameWidth = 640
+)
+
+// FrameSampler downloads a video and samples representative JPEG frames via
+// ffmpeg — preferring scene changes (to catch quick on-screen text and flashy
+// cuts), falling back to even time sampling. The downloaded source video is
+// always deleted before returning (we do not retain source media).
+type FrameSampler struct {
+	MaxFrames int
+	HTTP      *http.Client
+	// runFFmpeg is a test seam; nil uses the real ffmpeg binary.
+	runFFmpeg func(ctx context.Context, args []string) error
+	// download is a test seam; nil downloads over HTTP.
+	download func(ctx context.Context, mediaURL, dest string) error
+}
+
+// NewFrameSampler returns a sampler with sensible defaults.
+func NewFrameSampler() *FrameSampler {
+	return &FrameSampler{MaxFrames: DefaultMaxFrames, HTTP: &http.Client{Timeout: 90 * time.Second}}
+}
+
+func (s *FrameSampler) maxFrames() int {
+	if s.MaxFrames > 0 {
+		return s.MaxFrames
+	}
+	return DefaultMaxFrames
+}
+
+// Sample downloads mediaURL and returns up to MaxFrames JPEG frames.
+func (s *FrameSampler) Sample(ctx context.Context, mediaURL string, durationMS int) ([][]byte, error) {
+	dir, err := os.MkdirTemp("", "vidframes-*")
+	if err != nil {
+		return nil, err
+	}
+	defer os.RemoveAll(dir) // removes the downloaded video and all extracted frames
+
+	videoPath := filepath.Join(dir, "video.mp4")
+	dl := s.download
+	if dl == nil {
+		dl = s.httpDownload
+	}
+	if err := dl(ctx, mediaURL, videoPath); err != nil {
+		return nil, fmt.Errorf("download video: %w", err)
+	}
+
+	run := s.runFFmpeg
+	if run == nil {
+		run = realFFmpeg
+	}
+	mf := s.maxFrames()
+
+	// Primary: scene-change frames.
+	scenePattern := filepath.Join(dir, "scene_%04d.jpg")
+	if err := run(ctx, sceneArgs(videoPath, scenePattern, mf)); err == nil {
+		if frames := readFrames(dir, "scene_*.jpg", mf); len(frames) >= minSceneFrames {
+			return frames, nil
+		}
+	}
+
+	// Fallback: even time sampling across the whole duration.
+	evenPattern := filepath.Join(dir, "even_%04d.jpg")
+	if err := run(ctx, evenArgs(videoPath, evenPattern, durationMS, mf)); err != nil {
+		return nil, fmt.Errorf("ffmpeg frame extraction: %w", err)
+	}
+	frames := readFrames(dir, "even_*.jpg", mf)
+	if len(frames) == 0 {
+		return nil, errors.New("no frames extracted from video")
+	}
+	return frames, nil
+}
+
+// computeFPS returns the sampling rate (frames/sec) for even sampling so that a
+// video of the given duration yields about maxFrames frames, clamped to a sane
+// range for very short or very long videos.
+func computeFPS(durationMS, maxFrames int) float64 {
+	fps := 0.5 // ~1 frame / 2s when duration is unknown
+	if durSec := float64(durationMS) / 1000.0; durSec > 1 {
+		fps = float64(maxFrames) / durSec
+	}
+	if fps > 2 {
+		fps = 2 // never more than 2 fps
+	}
+	if fps < 0.1 {
+		fps = 0.1 // at least 1 frame / 10s
+	}
+	return fps
+}
+
+func sceneArgs(inPath, outPattern string, maxFrames int) []string {
+	return []string{
+		"-hide_banner", "-loglevel", "error", "-i", inPath,
+		"-vf", fmt.Sprintf("select='gt(scene,0.2)',scale=%d:-1", frameWidth),
+		"-vsync", "vfr", "-frames:v", strconv.Itoa(maxFrames), outPattern,
+	}
+}
+
+func evenArgs(inPath, outPattern string, durationMS, maxFrames int) []string {
+	return []string{
+		"-hide_banner", "-loglevel", "error", "-i", inPath,
+		"-vf", fmt.Sprintf("fps=%.4f,scale=%d:-1", computeFPS(durationMS, maxFrames), frameWidth),
+		"-frames:v", strconv.Itoa(maxFrames), outPattern,
+	}
+}
+
+func readFrames(dir, glob string, cap int) [][]byte {
+	matches, _ := filepath.Glob(filepath.Join(dir, glob))
+	sort.Strings(matches)
+	if len(matches) > cap {
+		matches = matches[:cap]
+	}
+	frames := make([][]byte, 0, len(matches))
+	for _, p := range matches {
+		b, err := os.ReadFile(p)
+		if err == nil && len(b) > 0 {
+			frames = append(frames, b)
+		}
+	}
+	return frames
+}
+
+func realFFmpeg(ctx context.Context, args []string) error {
+	out, err := exec.CommandContext(ctx, "ffmpeg", args...).CombinedOutput()
+	if err != nil {
+		return fmt.Errorf("ffmpeg failed: %w (%s)", err, string(out))
+	}
+	return nil
+}
+
+func (s *FrameSampler) httpDownload(ctx context.Context, mediaURL, dest string) error {
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, mediaURL, nil)
+	if err != nil {
+		return err
+	}
+	client := s.HTTP
+	if client == nil {
+		client = http.DefaultClient
+	}
+	resp, err := client.Do(req)
+	if err != nil {
+		return err
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		return fmt.Errorf("download returned status %d", resp.StatusCode)
+	}
+
+	f, err := os.Create(dest)
+	if err != nil {
+		return err
+	}
+	defer f.Close()
+	n, err := io.Copy(f, io.LimitReader(resp.Body, maxVideoBytes))
+	if err != nil {
+		return err
+	}
+	if n == 0 {
+		return errors.New("downloaded an empty video")
+	}
+	return nil
+}

--- a/internal/video/frames_test.go
+++ b/internal/video/frames_test.go
@@ -1,0 +1,118 @@
+package video
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestComputeFPS(t *testing.T) {
+	cases := []struct {
+		durationMS, maxFrames int
+		want                  float64
+	}{
+		{45000, 30, 30.0 / 45.0}, // ~0.667 fps
+		{0, 30, 0.5},             // unknown duration → default
+		{5000, 30, 2.0},          // short (30/5=6) → clamped to 2 fps max
+		{600000, 30, 0.1},        // 10 min → clamped to 0.1 fps min
+	}
+	for _, tc := range cases {
+		got := computeFPS(tc.durationMS, tc.maxFrames)
+		if (got-tc.want) > 0.0001 || (tc.want-got) > 0.0001 {
+			t.Errorf("computeFPS(%d,%d) = %.4f, want %.4f", tc.durationMS, tc.maxFrames, got, tc.want)
+		}
+	}
+}
+
+// fakeFFmpeg returns a runFFmpeg that writes `count` dummy JPEGs matching the
+// output pattern's prefix (scene_ or even_) into the temp dir.
+func fakeFFmpeg(t *testing.T, sceneCount, evenCount int) func(ctx context.Context, args []string) error {
+	t.Helper()
+	return func(ctx context.Context, args []string) error {
+		outPattern := args[len(args)-1]
+		dir := filepath.Dir(outPattern)
+		base := filepath.Base(outPattern) // e.g. "scene_%04d.jpg"
+		prefix := strings.SplitN(base, "_", 2)[0]
+		n := evenCount
+		if prefix == "scene" {
+			n = sceneCount
+		}
+		for i := 1; i <= n; i++ {
+			p := filepath.Join(dir, fmt.Sprintf("%s_%04d.jpg", prefix, i))
+			if err := os.WriteFile(p, []byte{0xFF, 0xD8, 0xFF, byte(i)}, 0o600); err != nil {
+				return err
+			}
+		}
+		return nil
+	}
+}
+
+func writeFakeVideo(ctx context.Context, _ string, dest string) error {
+	return os.WriteFile(dest, []byte("fake video bytes"), 0o600)
+}
+
+func TestFrameSampler_UsesSceneFrames(t *testing.T) {
+	s := NewFrameSampler()
+	s.MaxFrames = 20
+	s.download = writeFakeVideo
+	s.runFFmpeg = fakeFFmpeg(t, 12, 99) // 12 scene frames (>= minSceneFrames) → used
+
+	frames, err := s.Sample(context.Background(), "https://x/v.mp4", 45000)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(frames) != 12 {
+		t.Errorf("got %d frames, want 12 (scene path)", len(frames))
+	}
+}
+
+func TestFrameSampler_FallsBackToEven(t *testing.T) {
+	s := NewFrameSampler()
+	s.MaxFrames = 20
+	s.download = writeFakeVideo
+	s.runFFmpeg = fakeFFmpeg(t, 2, 15) // only 2 scene frames (< min) → fall back to 15 even
+
+	frames, err := s.Sample(context.Background(), "https://x/v.mp4", 45000)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(frames) != 15 {
+		t.Errorf("got %d frames, want 15 (even fallback)", len(frames))
+	}
+}
+
+func TestFrameSampler_CapsFrames(t *testing.T) {
+	s := NewFrameSampler()
+	s.MaxFrames = 10
+	s.download = writeFakeVideo
+	s.runFFmpeg = fakeFFmpeg(t, 50, 50) // ffmpeg over-produces → capped to MaxFrames
+
+	frames, err := s.Sample(context.Background(), "https://x/v.mp4", 45000)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(frames) != 10 {
+		t.Errorf("got %d frames, want 10 (capped)", len(frames))
+	}
+}
+
+func TestFrameSampler_DownloadError(t *testing.T) {
+	s := NewFrameSampler()
+	s.download = func(ctx context.Context, url, dest string) error { return fmt.Errorf("boom") }
+	s.runFFmpeg = fakeFFmpeg(t, 10, 10)
+	if _, err := s.Sample(context.Background(), "https://x/v.mp4", 1000); err == nil {
+		t.Fatal("expected error on download failure")
+	}
+}
+
+func TestFrameSampler_NoFrames(t *testing.T) {
+	s := NewFrameSampler()
+	s.download = writeFakeVideo
+	s.runFFmpeg = fakeFFmpeg(t, 0, 0) // nothing produced
+	if _, err := s.Sample(context.Background(), "https://x/v.mp4", 1000); err == nil {
+		t.Fatal("expected error when no frames extracted")
+	}
+}


### PR DESCRIPTION
## What

PR 2b of the premium video-link import pipeline. Adds **frame extraction** and the one infra change (ffmpeg in the runtime image).

- **`FrameSampler`** (`internal/video/frames.go`) — downloads the video's media URL and samples up to `MaxFrames` (default **30**) JPEG frames via ffmpeg. **Scene-change detection** (`select='gt(scene,0.2)'`) catches quick on-screen text and flashy cuts; falls back to **even time-sampling** across the full duration when a clip has too few cuts. Frames scaled to 640px (keeps Claude image input at standard resolution → avoids the ~3× high-res token cost). **The downloaded source video is always deleted** before returning — no source media retained. Exec + download seams → fully unit-tested offline.
- **Dockerfile** — runtime base **distroless → `debian:12-slim`** + `ffmpeg` + `ca-certificates`. Validated with a local `docker build` (ffmpeg 5.1 present, image assembles & runs).

## Cost control

The **frame cap is the master cost dial** (~$0.0048/frame on Sonnet, $0.0016 on Haiku). 30 frames ≈ $0.14 Sonnet for the AI step; standard-res scaling keeps it there.

## Tests

`computeFPS` clamping, scene-vs-even selection, frame cap, download-error and no-frames paths (all via seams). `go test ./... -count=1` → green (12 packages). Local `docker build` confirms the image builds with ffmpeg.

## Next

**PR2c:** async job + `POST /v1/recipes/import/video` + poll endpoint, fanning `VideoMeta` (frames + transcript + caption) into `ExtractRecipesFromMedia`, with the premium gate, `VideoExtractionCache`, cost metering, and the daily-budget kill switch — plus the ECS key + a real end-to-end TikTok test.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BU4UWZutHd1AnK3XAf7H19
