### PR TITLE
Assemble video-link import: async pipeline, premium gate, cost controls

### DIFF
--- a/internal/ai/anthropic.go
+++ b/internal/ai/anthropic.go
@@ -1432,7 +1432,7 @@ func (p *AnthropicProvider) ExtractRecipeFromImage(ctx context.Context, imageDat
 
 // ExtractRecipesFromMedia extracts every distinct recipe found across the
 // provided images and/or PDF documents in a single Claude request.
-func (p *AnthropicProvider) ExtractRecipesFromMedia(ctx context.Context, media []MediaInput, unitSystem string, requirements string) ([]*RecipeResult, error) {
+func (p *AnthropicProvider) ExtractRecipesFromMedia(ctx context.Context, media []MediaInput, contextText string, unitSystem string, requirements string) ([]*RecipeResult, error) {
 	op := AIOperation{
 		Name:      "ExtractRecipesFromMedia",
 		Provider:  "anthropic",
@@ -1473,6 +1473,9 @@ func (p *AnthropicProvider) ExtractRecipesFromMedia(ctx context.Context, media [
 					},
 				},
 			})
+		}
+		if contextText != "" {
+			blocks = append(blocks, anthropic.NewTextBlock("The following is the spoken transcript and caption from the source video. Treat it as a primary source of the ingredient quantities and step order; the images above are stills sampled from the same video and often show on-screen text, ingredients, and amounts not spoken aloud. Reconcile the two.\n\n"+contextText))
 		}
 		blocks = append(blocks, anthropic.NewTextBlock("These images and/or documents contain one or more recipes. Extract EVERY distinct recipe you find across all of them, returning one entry per recipe. If an item shows a prepared dish with no written recipe, infer a reasonable recipe for it."))
 

--- a/internal/ai/provider.go
+++ b/internal/ai/provider.go
@@ -39,8 +39,10 @@ type VisionProvider interface {
 	ExtractRecipeFromImage(ctx context.Context, imageData []byte, unitSystem string, requirements string) (*RecipeResult, error)
 	// ExtractRecipesFromMedia extracts every distinct recipe found across the
 	// given images and/or PDF documents in a single request, returning one
-	// RecipeResult per recipe.
-	ExtractRecipesFromMedia(ctx context.Context, media []MediaInput, unitSystem string, requirements string) ([]*RecipeResult, error)
+	// RecipeResult per recipe. contextText, when non-empty, supplies additional
+	// source text (e.g. a video's transcript and caption) that the model should
+	// treat as a primary source of steps and quantities alongside the media.
+	ExtractRecipesFromMedia(ctx context.Context, media []MediaInput, contextText string, unitSystem string, requirements string) ([]*RecipeResult, error)
 }
 
 // ImageProvider handles image generation (DALL-E 3).

--- a/internal/handlers/import.go
+++ b/internal/handlers/import.go
@@ -7,6 +7,7 @@ import (
 	"net/http"
 	"net/url"
 	"path/filepath"
+	"strconv"
 	"strings"
 
 	"github.com/gin-gonic/gin"
@@ -22,6 +23,9 @@ import (
 type ImportHandler struct {
 	Service       *service.ImportService
 	MultiResolver *service.MultiRecipeResolver // nil-safe; set for multi-recipe detection
+	// SubService gates the premium video-import endpoint by subscription usage
+	// when set (nil skips gating, e.g. in isolated tests).
+	SubService *service.SubscriptionService
 }
 
 // NewImportHandler creates a new ImportHandler.
@@ -238,6 +242,121 @@ func (h *ImportHandler) ImportFromVoice(c *gin.Context) {
 	}
 
 	c.JSON(http.StatusOK, gin.H{"recipe": recipeResponse})
+}
+
+// videoImportResponse serializes an async video-import job for the client.
+func videoImportResponse(job *models.VideoImport) gin.H {
+	resp := gin.H{
+		"id":        job.ID,
+		"status":    job.Status,
+		"platform":  job.Platform,
+		"cache_hit": job.CacheHit,
+	}
+	if job.RecipeID != nil {
+		resp["recipe_id"] = *job.RecipeID
+	}
+	if job.Error != "" {
+		resp["error"] = job.Error
+	}
+	return resp
+}
+
+// ImportFromVideo handles POST /v1/recipes/import/video — a premium, paywalled
+// import from a social/video link (TikTok, Instagram, YouTube, Facebook,
+// Pinterest). It returns a queued job immediately; the client polls
+// GetVideoImportStatus until the job is done and a recipe_id is present.
+func (h *ImportHandler) ImportFromVideo(c *gin.Context) {
+	user, err := util.GetUserFromContext(c)
+	if err != nil {
+		c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
+		return
+	}
+
+	var request struct {
+		URL string `json:"url" binding:"required"`
+	}
+	if err := c.BindJSON(&request); err != nil {
+		c.JSON(http.StatusBadRequest, gin.H{"error": "Invalid request: " + err.Error()})
+		return
+	}
+
+	url := strings.TrimSpace(request.URL)
+	if url == "" {
+		c.JSON(http.StatusBadRequest, gin.H{"error": "URL is required"})
+		return
+	}
+
+	// Subscription gate: free tier gets a small monthly allotment, premium more.
+	if h.SubService != nil {
+		allowed, err := h.SubService.CheckLimit(user.ID, "video_import")
+		if err != nil {
+			logger.Get().Error("failed to check video import limit", zap.Uint("user_id", user.ID), zap.Error(err))
+			c.JSON(http.StatusInternalServerError, gin.H{"error": "Failed to check subscription limits"})
+			return
+		}
+		if !allowed {
+			c.JSON(http.StatusForbidden, gin.H{
+				"error": "Video import limit reached; upgrade to premium for more video imports",
+				"code":  "video_limit_reached",
+			})
+			return
+		}
+	}
+
+	job, err := h.Service.StartVideoImport(c.Request.Context(), url, user)
+	if err != nil {
+		logger.Get().Error("failed to start video import", zap.String("url", url), zap.Error(err))
+		var extractErr *service.ExtractionError
+		if errors.As(err, &extractErr) {
+			status := http.StatusUnprocessableEntity
+			switch extractErr.Code {
+			case "unsupported_platform":
+				status = http.StatusBadRequest
+			case "video_unavailable":
+				status = http.StatusServiceUnavailable
+			}
+			c.JSON(status, gin.H{"error": extractErr.Message, "code": extractErr.Code})
+			return
+		}
+		c.JSON(http.StatusInternalServerError, gin.H{"error": "Failed to start video import"})
+		return
+	}
+
+	// Count the accepted job against the user's monthly quota. Done after the
+	// job is created so a rejected request (bad platform, feature off) is free.
+	if h.SubService != nil {
+		if err := h.SubService.IncrementUsage(user.ID, "video_import"); err != nil {
+			logger.Get().Error("failed to increment video import usage", zap.Uint("user_id", user.ID), zap.Error(err))
+		}
+	}
+
+	c.JSON(http.StatusAccepted, gin.H{"job": videoImportResponse(job)})
+}
+
+// GetVideoImportStatus handles GET /v1/recipes/import/video/:id — polling for an
+// async video-import job. Only the job's owner may read it.
+func (h *ImportHandler) GetVideoImportStatus(c *gin.Context) {
+	user, err := util.GetUserFromContext(c)
+	if err != nil {
+		c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
+		return
+	}
+
+	id, err := strconv.ParseUint(c.Param("id"), 10, 64)
+	if err != nil || id == 0 {
+		c.JSON(http.StatusBadRequest, gin.H{"error": "Invalid job id"})
+		return
+	}
+
+	job, err := h.Service.GetVideoImport(uint(id))
+	// Return 404 both when the job is missing and when it belongs to another
+	// user, so a caller cannot probe for others' job IDs.
+	if err != nil || job == nil || job.UserID != user.ID {
+		c.JSON(http.StatusNotFound, gin.H{"error": "Video import job not found"})
+		return
+	}
+
+	c.JSON(http.StatusOK, gin.H{"job": videoImportResponse(job)})
 }
 
 // ImportFromText handles POST /v1/recipes/import/text

--- a/internal/handlers/import_handler_test.go
+++ b/internal/handlers/import_handler_test.go
@@ -376,7 +376,7 @@ func TestImportFromFiles_Handler_Success(t *testing.T) {
 	repo := testutil.NewMockRecipeRepo()
 	importSvc := newImportService(repo, nil)
 	importSvc.VisionProvider = &testutil.MockVisionProvider{
-		ExtractRecipesFromMediaFunc: func(ctx context.Context, media []ai.MediaInput, unitSystem, requirements string) ([]*ai.RecipeResult, error) {
+		ExtractRecipesFromMediaFunc: func(ctx context.Context, media []ai.MediaInput, contextText, unitSystem, requirements string) ([]*ai.RecipeResult, error) {
 			r1 := testutil.TestRecipeResult()
 			r2 := testutil.TestRecipeResult()
 			r2.Title = "Second"

--- a/internal/handlers/import_video_handler_test.go
+++ b/internal/handlers/import_video_handler_test.go
@@ -1,0 +1,237 @@
+package handlers
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strconv"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/gin-gonic/gin"
+	"github.com/windoze95/saltybytes-api/internal/ai"
+	"github.com/windoze95/saltybytes-api/internal/config"
+	"github.com/windoze95/saltybytes-api/internal/models"
+	"github.com/windoze95/saltybytes-api/internal/service"
+	"github.com/windoze95/saltybytes-api/internal/testutil"
+	"github.com/windoze95/saltybytes-api/internal/video"
+	"gorm.io/gorm"
+)
+
+// --- fakes implementing the service video interfaces ---
+
+type fakeVideoFetcher struct{ meta *video.VideoMeta }
+
+func (f *fakeVideoFetcher) FetchVideo(ctx context.Context, rawURL string) (*video.VideoMeta, error) {
+	return f.meta, nil
+}
+
+type fakeFrameSampler struct{}
+
+func (f *fakeFrameSampler) Sample(ctx context.Context, mediaURL string, durationMS int) ([][]byte, error) {
+	return [][]byte{{0xFF, 0xD8, 0x01}, {0xFF, 0xD8, 0x02}}, nil
+}
+
+// videoEnabledHandler builds an ImportHandler whose service has the video
+// dependencies wired with fakes, plus a SubscriptionService for gating.
+func videoEnabledHandler(repo *testutil.MockRecipeRepo, vrepo *testutil.MockVideoImportRepo, userRepo *testutil.MockUserRepo) *ImportHandler {
+	importSvc := newImportService(repo, nil)
+	importSvc.VideoRepo = vrepo
+	importSvc.VideoFetcher = &fakeVideoFetcher{meta: &video.VideoMeta{
+		Platform:   video.PlatformTikTok,
+		VideoID:    "7499229683859426602",
+		Caption:    "pancakes #recipe",
+		Transcript: "Mix flour and eggs.",
+		// Public TEST-NET-3 IP literal (RFC 5737): passes the SSRF guard offline
+		// (LookupHost short-circuits IP literals, so no DNS query is made).
+		MediaURL:   "https://203.0.113.10/v.mp4",
+		DurationMS: 30000,
+	}}
+	importSvc.VideoFrameSampler = &fakeFrameSampler{}
+	importSvc.VisionProvider = &testutil.MockVisionProvider{
+		ExtractRecipesFromMediaFunc: func(ctx context.Context, media []ai.MediaInput, contextText, unitSystem, requirements string) ([]*ai.RecipeResult, error) {
+			return []*ai.RecipeResult{testutil.TestRecipeResult()}, nil
+		},
+	}
+	handler := NewImportHandler(importSvc)
+	if userRepo != nil {
+		handler.SubService = service.NewSubscriptionService(&config.Config{}, userRepo)
+	}
+	return handler
+}
+
+func freeUserWithVideoUsage(used int) (*models.User, *testutil.MockUserRepo) {
+	user := testutil.TestUser()
+	user.Subscription = &models.Subscription{
+		Model:            gorm.Model{ID: 1},
+		UserID:           user.ID,
+		Tier:             models.TierFree,
+		VideoImportsUsed: used,
+		MonthlyResetAt:   time.Now().Add(time.Hour),
+	}
+	userRepo := testutil.NewMockUserRepo()
+	userRepo.Users[user.ID] = user
+	return user, userRepo
+}
+
+func TestImportFromVideo_FreeUserAtLimit_403(t *testing.T) {
+	repo := testutil.NewMockRecipeRepo()
+	vrepo := testutil.NewMockVideoImportRepo()
+	user, userRepo := freeUserWithVideoUsage(2) // free limit is 2
+	handler := videoEnabledHandler(repo, vrepo, userRepo)
+
+	r := gin.New()
+	r.POST("/recipes/import/video", setUser(user), handler.ImportFromVideo)
+
+	req := httptest.NewRequest("POST", "/recipes/import/video", strings.NewReader(`{"url":"https://www.tiktok.com/@chef/video/7499229683859426602"}`))
+	req.Header.Set("Content-Type", "application/json")
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, req)
+
+	if w.Code != http.StatusForbidden {
+		t.Errorf("status = %d, want 403. body: %s", w.Code, w.Body.String())
+	}
+}
+
+func TestImportFromVideo_Unconfigured_503(t *testing.T) {
+	repo := testutil.NewMockRecipeRepo()
+	// No video deps wired on the service → StartVideoImport returns video_unavailable.
+	importSvc := newImportService(repo, nil)
+	handler := NewImportHandler(importSvc)
+
+	user := testutil.TestUser()
+	r := gin.New()
+	r.POST("/recipes/import/video", setUser(user), handler.ImportFromVideo)
+
+	req := httptest.NewRequest("POST", "/recipes/import/video", strings.NewReader(`{"url":"https://www.tiktok.com/@chef/video/123"}`))
+	req.Header.Set("Content-Type", "application/json")
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, req)
+
+	if w.Code != http.StatusServiceUnavailable {
+		t.Errorf("status = %d, want 503. body: %s", w.Code, w.Body.String())
+	}
+}
+
+func TestImportFromVideo_UnsupportedPlatform_400(t *testing.T) {
+	repo := testutil.NewMockRecipeRepo()
+	vrepo := testutil.NewMockVideoImportRepo()
+	user, userRepo := freeUserWithVideoUsage(0)
+	handler := videoEnabledHandler(repo, vrepo, userRepo)
+
+	r := gin.New()
+	r.POST("/recipes/import/video", setUser(user), handler.ImportFromVideo)
+
+	req := httptest.NewRequest("POST", "/recipes/import/video", strings.NewReader(`{"url":"https://example.com/not-a-video"}`))
+	req.Header.Set("Content-Type", "application/json")
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, req)
+
+	if w.Code != http.StatusBadRequest {
+		t.Errorf("status = %d, want 400. body: %s", w.Code, w.Body.String())
+	}
+}
+
+func TestImportFromVideo_Accepted_AndPoll(t *testing.T) {
+	repo := testutil.NewMockRecipeRepo()
+	vrepo := testutil.NewMockVideoImportRepo()
+	user, userRepo := freeUserWithVideoUsage(0)
+	handler := videoEnabledHandler(repo, vrepo, userRepo)
+
+	r := gin.New()
+	r.POST("/recipes/import/video", setUser(user), handler.ImportFromVideo)
+	r.GET("/recipes/import/video/:id", setUser(user), handler.GetVideoImportStatus)
+
+	// Accept the job.
+	req := httptest.NewRequest("POST", "/recipes/import/video", strings.NewReader(`{"url":"https://www.tiktok.com/@chef/video/7499229683859426602"}`))
+	req.Header.Set("Content-Type", "application/json")
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, req)
+
+	if w.Code != http.StatusAccepted {
+		t.Fatalf("status = %d, want 202. body: %s", w.Code, w.Body.String())
+	}
+	var accepted struct {
+		Job struct {
+			ID     uint   `json:"id"`
+			Status string `json:"status"`
+		} `json:"job"`
+	}
+	if err := json.Unmarshal(w.Body.Bytes(), &accepted); err != nil {
+		t.Fatalf("decode accepted body: %v", err)
+	}
+	if accepted.Job.ID == 0 {
+		t.Fatal("expected a job id in the 202 response")
+	}
+
+	// The accepted job should have consumed one unit of quota.
+	if user.Subscription.VideoImportsUsed != 1 {
+		t.Errorf("VideoImportsUsed = %d, want 1 after accepting a job", user.Subscription.VideoImportsUsed)
+	}
+
+	// Poll the status endpoint until the async job completes.
+	path := "/recipes/import/video/" + itoa(accepted.Job.ID)
+	deadline := time.Now().Add(3 * time.Second)
+	var lastStatus string
+	for time.Now().Before(deadline) {
+		gw := httptest.NewRecorder()
+		greq := httptest.NewRequest("GET", path, nil)
+		r.ServeHTTP(gw, greq)
+		if gw.Code != http.StatusOK {
+			t.Fatalf("poll status = %d, want 200. body: %s", gw.Code, gw.Body.String())
+		}
+		var polled struct {
+			Job struct {
+				Status   string `json:"status"`
+				RecipeID uint   `json:"recipe_id"`
+			} `json:"job"`
+		}
+		json.Unmarshal(gw.Body.Bytes(), &polled)
+		lastStatus = polled.Job.Status
+		if polled.Job.Status == string(models.VideoImportDone) {
+			if polled.Job.RecipeID == 0 {
+				t.Error("completed job should carry a recipe_id")
+			}
+			return
+		}
+		if polled.Job.Status == string(models.VideoImportFailed) {
+			t.Fatalf("job failed unexpectedly: %s", gw.Body.String())
+		}
+		time.Sleep(5 * time.Millisecond)
+	}
+	t.Fatalf("job did not complete; last status %q", lastStatus)
+}
+
+func TestGetVideoImportStatus_NotOwner_404(t *testing.T) {
+	repo := testutil.NewMockRecipeRepo()
+	vrepo := testutil.NewMockVideoImportRepo()
+	owner, userRepo := freeUserWithVideoUsage(0)
+	handler := videoEnabledHandler(repo, vrepo, userRepo)
+
+	// A job owned by `owner`.
+	job := &models.VideoImport{UserID: owner.ID, SourceURL: "https://www.tiktok.com/@x/video/1", Platform: "tiktok", Status: models.VideoImportDone}
+	if err := vrepo.CreateImport(job); err != nil {
+		t.Fatalf("seed job: %v", err)
+	}
+
+	// Another user tries to read it.
+	other := testutil.TestUser()
+	other.ID = owner.ID + 999
+
+	r := gin.New()
+	r.GET("/recipes/import/video/:id", setUser(other), handler.GetVideoImportStatus)
+
+	greq := httptest.NewRequest("GET", "/recipes/import/video/"+itoa(job.ID), nil)
+	gw := httptest.NewRecorder()
+	r.ServeHTTP(gw, greq)
+
+	if gw.Code != http.StatusNotFound {
+		t.Errorf("status = %d, want 404 for non-owner. body: %s", gw.Code, gw.Body.String())
+	}
+}
+
+func itoa(u uint) string {
+	return strconv.FormatUint(uint64(u), 10)
+}

--- a/internal/models/recipe.go
+++ b/internal/models/recipe.go
@@ -55,6 +55,7 @@ const (
 	RecipeTypeCopycat         RecipeType = "copycat"
 	RecipeTypeImportVision    RecipeType = "import_vision"
 	RecipeTypeImportLink      RecipeType = "import_link"
+	RecipeTypeImportVideo     RecipeType = "import_video"
 	RecipeTypeImportCopypasta RecipeType = "import_text"
 	RecipeTypeManualEntry     RecipeType = "user_input"
 	RecipeTypeRemix           RecipeType = "remix"

--- a/internal/router/router.go
+++ b/internal/router/router.go
@@ -12,6 +12,7 @@ import (
 	"github.com/windoze95/saltybytes-api/internal/middleware"
 	"github.com/windoze95/saltybytes-api/internal/repository"
 	"github.com/windoze95/saltybytes-api/internal/service"
+	"github.com/windoze95/saltybytes-api/internal/video"
 	"github.com/windoze95/saltybytes-api/internal/ws"
 	"go.uber.org/zap"
 	"gorm.io/gorm"
@@ -88,7 +89,19 @@ func SetupRouter(cfg *config.Config, database *gorm.DB) *gin.Engine {
 	// Portion estimation for imports that lack a serving count (cheap Haiku task)
 	importService.Normalize = service.NewNormalizeService(cfg, previewProvider)
 	importHandler := handlers.NewImportHandler(importService)
+	importHandler.SubService = subService
 	// MultiResolver is wired later after search setup; set via field
+
+	// Video-link import (premium). Stays dark until a ScrapeCreators API key is
+	// configured, so the endpoint returns 503 until the feature is switched on.
+	if cfg.EnvVars.ScrapeCreatorsAPIKey != "" {
+		importService.VideoRepo = repository.NewVideoImportRepository(database)
+		importService.VideoFetcher = video.NewScrapeCreatorsClient(cfg.EnvVars.ScrapeCreatorsAPIKey)
+		importService.VideoFrameSampler = video.NewFrameSampler()
+		logger.Get().Info("video-link import enabled")
+	} else {
+		logger.Get().Info("video-link import disabled (no ScrapeCreators API key configured)")
+	}
 
 	// Group for API routes that don't require token verification
 	apiPublic := r.Group("/v1")
@@ -146,6 +159,8 @@ func SetupRouter(cfg *config.Config, database *gorm.DB) *gin.Engine {
 		apiProtected.POST("/recipes/import/photo", middleware.AttachUserToContext(userService), importHandler.ImportFromPhoto)
 		apiProtected.POST("/recipes/import/files", middleware.AttachUserToContext(userService), importHandler.ImportFromFiles)
 		apiProtected.POST("/recipes/import/voice", middleware.AttachUserToContext(userService), importHandler.ImportFromVoice)
+		apiProtected.POST("/recipes/import/video", middleware.AttachUserToContext(userService), importHandler.ImportFromVideo)
+		apiProtected.GET("/recipes/import/video/:id", middleware.AttachUserToContext(userService), importHandler.GetVideoImportStatus)
 		apiProtected.POST("/recipes/import/text", middleware.AttachUserToContext(userService), importHandler.ImportFromText)
 		apiProtected.POST("/recipes/import/manual", middleware.AttachUserToContext(userService), importHandler.ImportManual)
 		apiProtected.POST("/recipes/import/canonical", middleware.AttachUserToContext(userService), importHandler.ImportFromCanonical)

--- a/internal/service/import.go
+++ b/internal/service/import.go
@@ -48,6 +48,12 @@ type ImportService struct {
 	Policy          *ImportPolicy
 	Normalize       *NormalizeService // optional; estimates portions when imports lack them
 
+	// Video-link import (premium). All three are nil until a ScrapeCreators key
+	// is configured at startup, which keeps the feature dark by default.
+	VideoRepo         repository.VideoImportRepo
+	VideoFetcher      VideoFetcher
+	VideoFrameSampler VideoFrameSampler
+
 	// Test seams — nil in production, set in tests to bypass real HTTP/Firecrawl calls
 	HTTPFetchOverride      func(ctx context.Context, url string) (body []byte, statusCode int, err error)
 	FirecrawlFetchOverride func(ctx context.Context, url string) (html string, statusCode int, err error)
@@ -609,7 +615,7 @@ func (s *ImportService) ImportFromFiles(ctx context.Context, files []FileInput, 
 	unitSystem := user.Personalization.UnitSystemText()
 	requirements := user.Personalization.Requirements
 
-	results, err := s.VisionProvider.ExtractRecipesFromMedia(ctx, media, unitSystem, requirements)
+	results, err := s.VisionProvider.ExtractRecipesFromMedia(ctx, media, "", unitSystem, requirements)
 	if err != nil {
 		log.Error("multi-file extraction failed", zap.Error(err))
 		return nil, &ExtractionError{Code: "extraction_failed", Message: "could not extract recipes from the provided files"}

--- a/internal/service/import_service_test.go
+++ b/internal/service/import_service_test.go
@@ -403,7 +403,7 @@ func TestImportFromFiles_MultipleRecipes(t *testing.T) {
 	repo := testutil.NewMockRecipeRepo()
 	var gotMedia []ai.MediaInput
 	vision := &testutil.MockVisionProvider{
-		ExtractRecipesFromMediaFunc: func(ctx context.Context, media []ai.MediaInput, unitSystem, requirements string) ([]*ai.RecipeResult, error) {
+		ExtractRecipesFromMediaFunc: func(ctx context.Context, media []ai.MediaInput, contextText, unitSystem, requirements string) ([]*ai.RecipeResult, error) {
 			gotMedia = media
 			r1 := testutil.TestRecipeResult()
 			r2 := testutil.TestRecipeResult()

--- a/internal/service/import_video.go
+++ b/internal/service/import_video.go
@@ -1,0 +1,250 @@
+package service
+
+import (
+	"context"
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/windoze95/saltybytes-api/internal/ai"
+	"github.com/windoze95/saltybytes-api/internal/logger"
+	"github.com/windoze95/saltybytes-api/internal/models"
+	"github.com/windoze95/saltybytes-api/internal/video"
+	"go.uber.org/zap"
+)
+
+// VideoFetcher resolves a supported social/video URL to its caption, transcript,
+// and a downloadable media URL. Satisfied by *video.ScrapeCreatorsClient.
+type VideoFetcher interface {
+	FetchVideo(ctx context.Context, rawURL string) (*video.VideoMeta, error)
+}
+
+// VideoFrameSampler downloads a video and returns representative JPEG frames.
+// Satisfied by *video.FrameSampler.
+type VideoFrameSampler interface {
+	Sample(ctx context.Context, mediaURL string, durationMS int) ([][]byte, error)
+}
+
+const (
+	// sonnetCostPerFrame approximates one standard-resolution frame on Sonnet
+	// (~1600 input tokens × $3/MTok). Frames dominate the cost of a fresh video
+	// import, so this is the master figure behind the daily budget.
+	sonnetCostPerFrame = 0.0048
+	// videoTextOverheadUSD is a conservative flat allowance for the transcript/
+	// caption input tokens plus the extraction's output tokens.
+	videoTextOverheadUSD = 0.02
+	// videoProcessTimeout bounds the whole async pipeline for one fresh import.
+	videoProcessTimeout = 5 * time.Minute
+)
+
+// estimateVideoCost approximates the metered spend of a fresh video extraction.
+// It is intentionally an over-estimate so the daily-budget kill switch trips
+// early rather than late. Cache hits cost nothing and are recorded as 0.
+func estimateVideoCost(numFrames int) float64 {
+	return float64(numFrames)*sonnetCostPerFrame + videoTextOverheadUSD
+}
+
+// videoImportConfigured reports whether the video-import dependencies are wired.
+// Video import stays dark until a ScrapeCreators key is configured at startup.
+func (s *ImportService) videoImportConfigured() bool {
+	return s.VideoRepo != nil && s.VideoFetcher != nil && s.VideoFrameSampler != nil
+}
+
+// StartVideoImport validates a social/video URL, creates an async import job,
+// and kicks off background processing. It returns the queued job immediately;
+// callers poll GetVideoImport for completion. The heavy work (fetch, frame
+// sampling, multimodal extraction) and all cost controls run in the goroutine.
+func (s *ImportService) StartVideoImport(ctx context.Context, rawURL string, user *models.User) (*models.VideoImport, error) {
+	if !s.videoImportConfigured() {
+		return nil, &ExtractionError{Code: "video_unavailable", Message: "video import is not available"}
+	}
+
+	platform, ok := video.DetectPlatform(rawURL)
+	if !ok {
+		return nil, &ExtractionError{Code: "unsupported_platform", Message: "unsupported video link; supported platforms are TikTok, Instagram, YouTube, Facebook, and Pinterest"}
+	}
+
+	job := &models.VideoImport{
+		UserID:    user.ID,
+		SourceURL: rawURL,
+		Platform:  string(platform),
+		Status:    models.VideoImportQueued,
+	}
+	if err := s.VideoRepo.CreateImport(job); err != nil {
+		return nil, fmt.Errorf("failed to create video import job: %w", err)
+	}
+
+	go s.processVideoImport(job.ID, rawURL, user)
+
+	return job, nil
+}
+
+// GetVideoImport returns the current state of an async video-import job.
+func (s *ImportService) GetVideoImport(id uint) (*models.VideoImport, error) {
+	if s.VideoRepo == nil {
+		return nil, fmt.Errorf("video import is not available")
+	}
+	return s.VideoRepo.GetImportByID(id)
+}
+
+// processVideoImport runs the full pipeline for one job. It never uses the
+// request context (which is cancelled once the HTTP handler returns); it owns
+// its own timeout. Failures are recorded on the job, not returned.
+func (s *ImportService) processVideoImport(jobID uint, rawURL string, user *models.User) {
+	ctx, cancel := context.WithTimeout(context.Background(), videoProcessTimeout)
+	defer cancel()
+
+	log := logger.Get().With(zap.Uint("video_import_id", jobID), zap.Uint("user_id", user.ID))
+
+	job, err := s.VideoRepo.GetImportByID(jobID)
+	if err != nil {
+		log.Error("video import job vanished before processing", zap.Error(err))
+		return
+	}
+
+	fail := func(code, msg string, cause error) {
+		log.Warn("video import failed", zap.String("code", code), zap.Error(cause))
+		job.Status = models.VideoImportFailed
+		job.Error = msg
+		if uErr := s.VideoRepo.UpdateImport(job); uErr != nil {
+			log.Error("failed to persist video import failure", zap.Error(uErr))
+		}
+	}
+
+	job.Status = models.VideoImportProcessing
+	if err := s.VideoRepo.UpdateImport(job); err != nil {
+		log.Error("failed to mark video import processing", zap.Error(err))
+	}
+
+	// 1. Resolve caption, transcript, and a downloadable media URL.
+	meta, err := s.VideoFetcher.FetchVideo(ctx, rawURL)
+	if err != nil {
+		fail("fetch_failed", "could not retrieve the video", err)
+		return
+	}
+	videoKey := videoCacheKey(meta)
+	job.VideoKey = videoKey
+
+	// 2. Cache: a viral video is extracted once and served to everyone after,
+	//    at no metered cost — the primary cost control.
+	if entry, cacheErr := s.VideoRepo.GetCacheByVideoKey(videoKey); cacheErr == nil && entry != nil {
+		log.Info("video extraction cache hit", zap.String("video_key", videoKey))
+		go s.VideoRepo.IncrementCacheHit(entry.ID)
+		def := entry.RecipeData
+		if def.SourceURL == "" {
+			def.SourceURL = rawURL
+		}
+		_, recipeID, createErr := s.createImportedRecipe(ctx, &def, user, models.RecipeTypeImportVideo, rawURL, "", nil, nil, entry.PromptVersion)
+		if createErr != nil {
+			fail("save_failed", "could not save the recipe", createErr)
+			return
+		}
+		job.Status = models.VideoImportDone
+		job.RecipeID = &recipeID
+		job.CacheHit = true
+		job.CostUSD = 0
+		if err := s.VideoRepo.UpdateImport(job); err != nil {
+			log.Error("failed to persist completed cache-hit import", zap.Error(err))
+		}
+		return
+	}
+
+	// 3. Fresh extraction is expensive — enforce the global daily budget first.
+	if budget := s.Cfg.EnvVars.VideoImportDailyBudgetUSD; budget > 0 {
+		since := time.Now().UTC().Truncate(24 * time.Hour)
+		if spent, sErr := s.VideoRepo.SumImportCostSince(since); sErr == nil && spent >= budget {
+			fail("at_capacity", "video import is temporarily at capacity; please try again later", fmt.Errorf("daily budget $%.2f reached (spent $%.2f)", budget, spent))
+			return
+		}
+	}
+
+	if meta.MediaURL == "" {
+		fail("no_media", "the video could not be downloaded", fmt.Errorf("empty media url for %s", videoKey))
+		return
+	}
+	// The media URL comes from a third-party scraper; treat it as untrusted and
+	// block private/internal addresses before the sampler fetches it (SSRF).
+	if err := ValidateExternalURL(meta.MediaURL); err != nil {
+		fail("no_media", "the video could not be downloaded", err)
+		return
+	}
+
+	// 4. Sample representative frames (scene changes catch on-screen text and
+	//    flashy cuts; even sampling backs it up).
+	frames, err := s.VideoFrameSampler.Sample(ctx, meta.MediaURL, meta.DurationMS)
+	if err != nil {
+		fail("sampling_failed", "could not process the video", err)
+		return
+	}
+
+	media := make([]ai.MediaInput, 0, len(frames))
+	for _, f := range frames {
+		media = append(media, ai.MediaInput{Data: f, Kind: ai.MediaImage})
+	}
+
+	// 5. Multimodal extraction: frames + transcript/caption together.
+	contextText := buildVideoContext(meta)
+	unitSystem := user.Personalization.UnitSystemText()
+	requirements := user.Personalization.Requirements
+	results, err := s.VisionProvider.ExtractRecipesFromMedia(ctx, media, contextText, unitSystem, requirements)
+	if err != nil || len(results) == 0 {
+		fail("extraction_failed", "could not find a recipe in this video", err)
+		return
+	}
+
+	// A single video yields a single recipe; take the most prominent.
+	def := recipeResultToRecipeDef(results[0])
+	def.SourceURL = rawURL
+	ensureUnitSystem(&def)
+
+	_, recipeID, createErr := s.createImportedRecipe(ctx, &def, user, models.RecipeTypeImportVideo, rawURL, "", nil, results[0].Hashtags, results[0].PromptVersion)
+	if createErr != nil {
+		fail("save_failed", "could not save the recipe", createErr)
+		return
+	}
+
+	// 6. Cache the extraction so the next importer of this video pays nothing.
+	now := time.Now()
+	cacheEntry := &models.VideoExtractionCache{
+		VideoKey:       videoKey,
+		Platform:       string(meta.Platform),
+		OriginalURL:    rawURL,
+		RecipeData:     def,
+		FetchedAt:      now,
+		LastAccessedAt: now,
+		PromptVersion:  results[0].PromptVersion,
+	}
+	if err := s.VideoRepo.UpsertCache(cacheEntry); err != nil {
+		log.Warn("failed to cache video extraction", zap.Error(err))
+	}
+
+	job.Status = models.VideoImportDone
+	job.RecipeID = &recipeID
+	job.CostUSD = estimateVideoCost(len(frames))
+	job.CacheHit = false
+	if err := s.VideoRepo.UpdateImport(job); err != nil {
+		log.Error("failed to persist completed video import", zap.Error(err))
+	}
+	log.Info("video import complete", zap.Int("frames", len(frames)), zap.Float64("cost_usd", job.CostUSD))
+}
+
+// videoCacheKey is the per-video cache key: "<platform>:<video_id>".
+func videoCacheKey(meta *video.VideoMeta) string {
+	return string(meta.Platform) + ":" + meta.VideoID
+}
+
+// buildVideoContext combines the caption and transcript into a single labeled
+// text block for the extractor so the model can weigh each source.
+func buildVideoContext(meta *video.VideoMeta) string {
+	var b strings.Builder
+	if c := strings.TrimSpace(meta.Caption); c != "" {
+		b.WriteString("Caption: ")
+		b.WriteString(c)
+		b.WriteString("\n\n")
+	}
+	if t := strings.TrimSpace(meta.Transcript); t != "" {
+		b.WriteString("Transcript: ")
+		b.WriteString(t)
+	}
+	return strings.TrimSpace(b.String())
+}

--- a/internal/service/import_video_test.go
+++ b/internal/service/import_video_test.go
@@ -1,0 +1,267 @@
+package service
+
+import (
+	"context"
+	"errors"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/windoze95/saltybytes-api/internal/ai"
+	"github.com/windoze95/saltybytes-api/internal/config"
+	"github.com/windoze95/saltybytes-api/internal/models"
+	"github.com/windoze95/saltybytes-api/internal/testutil"
+	"github.com/windoze95/saltybytes-api/internal/video"
+)
+
+// --- fakes for the video fetcher and frame sampler ---
+
+type fakeVideoFetcher struct {
+	meta  *video.VideoMeta
+	err   error
+	calls int
+}
+
+func (f *fakeVideoFetcher) FetchVideo(ctx context.Context, rawURL string) (*video.VideoMeta, error) {
+	f.calls++
+	return f.meta, f.err
+}
+
+type fakeFrameSampler struct {
+	frames [][]byte
+	err    error
+	calls  int
+}
+
+func (f *fakeFrameSampler) Sample(ctx context.Context, mediaURL string, durationMS int) ([][]byte, error) {
+	f.calls++
+	return f.frames, f.err
+}
+
+func tiktokMeta() *video.VideoMeta {
+	return &video.VideoMeta{
+		Platform:   video.PlatformTikTok,
+		VideoID:    "7499229683859426602",
+		Caption:    "easy fluffy pancakes #recipe",
+		Transcript: "First mix the flour and eggs, then cook on a griddle.",
+		// A public TEST-NET-3 IP literal (RFC 5737): it passes the SSRF guard's
+		// private-address check, and LookupHost short-circuits IP literals so no
+		// DNS query is made — keeping the test offline.
+		MediaURL:   "https://203.0.113.10/nowm.mp4",
+		DurationMS: 45000,
+	}
+}
+
+func newVideoTestService(repo *testutil.MockRecipeRepo, vrepo *testutil.MockVideoImportRepo) *ImportService {
+	svc := newTestImportService(repo, nil, nil)
+	svc.VideoRepo = vrepo
+	return svc
+}
+
+// waitForVideoJob polls until the job reaches a terminal state or times out.
+func waitForVideoJob(t *testing.T, svc *ImportService, id uint) *models.VideoImport {
+	t.Helper()
+	deadline := time.Now().Add(3 * time.Second)
+	for time.Now().Before(deadline) {
+		job, err := svc.GetVideoImport(id)
+		if err == nil && (job.Status == models.VideoImportDone || job.Status == models.VideoImportFailed) {
+			return job
+		}
+		time.Sleep(5 * time.Millisecond)
+	}
+	t.Fatalf("video import job %d did not finish in time", id)
+	return nil
+}
+
+func TestStartVideoImport_NotConfigured(t *testing.T) {
+	svc := newTestImportService(testutil.NewMockRecipeRepo(), nil, nil)
+	_, err := svc.StartVideoImport(context.Background(), "https://www.tiktok.com/@x/video/1", testutil.TestUser())
+	var extractErr *ExtractionError
+	if err == nil || !errors.As(err, &extractErr) || extractErr.Code != "video_unavailable" {
+		t.Fatalf("expected video_unavailable ExtractionError, got %v", err)
+	}
+}
+
+func TestStartVideoImport_UnsupportedPlatform(t *testing.T) {
+	repo := testutil.NewMockRecipeRepo()
+	vrepo := testutil.NewMockVideoImportRepo()
+	svc := newVideoTestService(repo, vrepo)
+	svc.VideoFetcher = &fakeVideoFetcher{meta: tiktokMeta()}
+	svc.VideoFrameSampler = &fakeFrameSampler{}
+	svc.VisionProvider = &testutil.MockVisionProvider{}
+
+	_, err := svc.StartVideoImport(context.Background(), "https://example.com/not-a-video", testutil.TestUser())
+	var extractErr *ExtractionError
+	if err == nil || !errors.As(err, &extractErr) || extractErr.Code != "unsupported_platform" {
+		t.Fatalf("expected unsupported_platform ExtractionError, got %v", err)
+	}
+}
+
+func TestVideoImport_FreshExtraction(t *testing.T) {
+	repo := testutil.NewMockRecipeRepo()
+	vrepo := testutil.NewMockVideoImportRepo()
+	svc := newVideoTestService(repo, vrepo)
+
+	fetcher := &fakeVideoFetcher{meta: tiktokMeta()}
+	sampler := &fakeFrameSampler{frames: [][]byte{{0xFF, 0xD8, 0x01}, {0xFF, 0xD8, 0x02}, {0xFF, 0xD8, 0x03}}}
+	svc.VideoFetcher = fetcher
+	svc.VideoFrameSampler = sampler
+
+	var gotMedia []ai.MediaInput
+	var gotContext string
+	svc.VisionProvider = &testutil.MockVisionProvider{
+		ExtractRecipesFromMediaFunc: func(ctx context.Context, media []ai.MediaInput, contextText, unitSystem, requirements string) ([]*ai.RecipeResult, error) {
+			gotMedia = media
+			gotContext = contextText
+			return []*ai.RecipeResult{testutil.TestRecipeResult()}, nil
+		},
+	}
+
+	job, err := svc.StartVideoImport(context.Background(), "https://www.tiktok.com/@chef/video/7499229683859426602", testutil.TestUser())
+	if err != nil {
+		t.Fatalf("StartVideoImport error: %v", err)
+	}
+	if job.Status != models.VideoImportQueued {
+		t.Errorf("initial status = %q, want queued", job.Status)
+	}
+
+	done := waitForVideoJob(t, svc, job.ID)
+	if done.Status != models.VideoImportDone {
+		t.Fatalf("final status = %q (error %q), want done", done.Status, done.Error)
+	}
+	if done.RecipeID == nil {
+		t.Error("expected a RecipeID on the completed job")
+	}
+	if done.CacheHit {
+		t.Error("fresh extraction should not be a cache hit")
+	}
+	if done.CostUSD <= 0 {
+		t.Errorf("expected a positive metered cost, got %v", done.CostUSD)
+	}
+	if len(repo.Recipes) != 1 {
+		t.Errorf("expected 1 recipe saved, got %d", len(repo.Recipes))
+	}
+	if len(gotMedia) != 3 {
+		t.Errorf("vision got %d frames, want 3", len(gotMedia))
+	}
+	for i, m := range gotMedia {
+		if m.Kind != ai.MediaImage {
+			t.Errorf("frame %d kind = %q, want image", i, m.Kind)
+		}
+	}
+	if !strings.Contains(gotContext, "Transcript") || !strings.Contains(gotContext, "flour and eggs") {
+		t.Errorf("context text missing transcript: %q", gotContext)
+	}
+	// The extraction should be cached for the next importer.
+	if _, err := vrepo.GetCacheByVideoKey("tiktok:7499229683859426602"); err != nil {
+		t.Errorf("expected cache entry for the video, got %v", err)
+	}
+}
+
+func TestVideoImport_CacheHit(t *testing.T) {
+	repo := testutil.NewMockRecipeRepo()
+	vrepo := testutil.NewMockVideoImportRepo()
+	svc := newVideoTestService(repo, vrepo)
+
+	// Seed the cache so the video is served without sampling or extraction.
+	cached := recipeResultToRecipeDef(testutil.TestRecipeResult())
+	if err := vrepo.UpsertCache(&models.VideoExtractionCache{
+		VideoKey:    "tiktok:7499229683859426602",
+		Platform:    "tiktok",
+		OriginalURL: "https://www.tiktok.com/@chef/video/7499229683859426602",
+		RecipeData:  cached,
+	}); err != nil {
+		t.Fatalf("seed cache: %v", err)
+	}
+
+	fetcher := &fakeVideoFetcher{meta: tiktokMeta()}
+	sampler := &fakeFrameSampler{frames: [][]byte{{0xFF}}}
+	svc.VideoFetcher = fetcher
+	svc.VideoFrameSampler = sampler
+	visionCalls := 0
+	svc.VisionProvider = &testutil.MockVisionProvider{
+		ExtractRecipesFromMediaFunc: func(ctx context.Context, media []ai.MediaInput, contextText, unitSystem, requirements string) ([]*ai.RecipeResult, error) {
+			visionCalls++
+			return []*ai.RecipeResult{testutil.TestRecipeResult()}, nil
+		},
+	}
+
+	job, err := svc.StartVideoImport(context.Background(), "https://www.tiktok.com/@chef/video/7499229683859426602", testutil.TestUser())
+	if err != nil {
+		t.Fatalf("StartVideoImport error: %v", err)
+	}
+
+	done := waitForVideoJob(t, svc, job.ID)
+	if done.Status != models.VideoImportDone {
+		t.Fatalf("final status = %q (error %q), want done", done.Status, done.Error)
+	}
+	if !done.CacheHit {
+		t.Error("expected CacheHit=true")
+	}
+	if done.CostUSD != 0 {
+		t.Errorf("cache hit cost = %v, want 0", done.CostUSD)
+	}
+	if done.RecipeID == nil {
+		t.Error("expected a RecipeID on the cache-hit job")
+	}
+	if sampler.calls != 0 {
+		t.Errorf("sampler called %d times on cache hit, want 0", sampler.calls)
+	}
+	if visionCalls != 0 {
+		t.Errorf("vision called %d times on cache hit, want 0", visionCalls)
+	}
+}
+
+func TestVideoImport_BudgetExceeded(t *testing.T) {
+	repo := testutil.NewMockRecipeRepo()
+	vrepo := testutil.NewMockVideoImportRepo()
+	vrepo.SumImportCostSinceFunc = func(t time.Time) (float64, error) { return 50.0, nil }
+
+	svc := newVideoTestService(repo, vrepo)
+	svc.Cfg = &config.Config{EnvVars: config.EnvVars{VideoImportDailyBudgetUSD: 25.0}}
+
+	fetcher := &fakeVideoFetcher{meta: tiktokMeta()}
+	sampler := &fakeFrameSampler{frames: [][]byte{{0xFF}}}
+	svc.VideoFetcher = fetcher
+	svc.VideoFrameSampler = sampler
+	svc.VisionProvider = &testutil.MockVisionProvider{}
+
+	job, err := svc.StartVideoImport(context.Background(), "https://www.tiktok.com/@chef/video/7499229683859426602", testutil.TestUser())
+	if err != nil {
+		t.Fatalf("StartVideoImport error: %v", err)
+	}
+
+	done := waitForVideoJob(t, svc, job.ID)
+	if done.Status != models.VideoImportFailed {
+		t.Fatalf("final status = %q, want failed", done.Status)
+	}
+	if !strings.Contains(strings.ToLower(done.Error), "capacity") {
+		t.Errorf("error = %q, want an at-capacity message", done.Error)
+	}
+	if sampler.calls != 0 {
+		t.Errorf("sampler called %d times when over budget, want 0 (fail before sampling)", sampler.calls)
+	}
+}
+
+func TestVideoImport_FetchFailed(t *testing.T) {
+	repo := testutil.NewMockRecipeRepo()
+	vrepo := testutil.NewMockVideoImportRepo()
+	svc := newVideoTestService(repo, vrepo)
+
+	svc.VideoFetcher = &fakeVideoFetcher{err: context.DeadlineExceeded}
+	svc.VideoFrameSampler = &fakeFrameSampler{}
+	svc.VisionProvider = &testutil.MockVisionProvider{}
+
+	job, err := svc.StartVideoImport(context.Background(), "https://www.tiktok.com/@chef/video/1", testutil.TestUser())
+	if err != nil {
+		t.Fatalf("StartVideoImport error: %v", err)
+	}
+
+	done := waitForVideoJob(t, svc, job.ID)
+	if done.Status != models.VideoImportFailed {
+		t.Fatalf("final status = %q, want failed", done.Status)
+	}
+	if done.Error == "" {
+		t.Error("expected an error message on the failed job")
+	}
+}

--- a/internal/service/subscription.go
+++ b/internal/service/subscription.go
@@ -58,6 +58,7 @@ func (s *SubscriptionService) GetSubscription(userID uint) (*models.Subscription
 		user.Subscription.AllergenAnalysesUsed = 0
 		user.Subscription.WebSearchesUsed = 0
 		user.Subscription.AIGenerationsUsed = 0
+		user.Subscription.VideoImportsUsed = 0
 		user.Subscription.MonthlyResetAt = nextReset
 	}
 

--- a/internal/testutil/mocks.go
+++ b/internal/testutil/mocks.go
@@ -95,7 +95,7 @@ func (m *MockTextProvider) DietaryInterview(ctx context.Context, messages []ai.M
 // MockVisionProvider is a mock implementation of ai.VisionProvider.
 type MockVisionProvider struct {
 	ExtractRecipeFromImageFunc  func(ctx context.Context, imageData []byte, unitSystem string, requirements string) (*ai.RecipeResult, error)
-	ExtractRecipesFromMediaFunc func(ctx context.Context, media []ai.MediaInput, unitSystem string, requirements string) ([]*ai.RecipeResult, error)
+	ExtractRecipesFromMediaFunc func(ctx context.Context, media []ai.MediaInput, contextText string, unitSystem string, requirements string) ([]*ai.RecipeResult, error)
 }
 
 func (m *MockVisionProvider) ExtractRecipeFromImage(ctx context.Context, imageData []byte, unitSystem string, requirements string) (*ai.RecipeResult, error) {
@@ -105,9 +105,9 @@ func (m *MockVisionProvider) ExtractRecipeFromImage(ctx context.Context, imageDa
 	return nil, fmt.Errorf("ExtractRecipeFromImage not configured")
 }
 
-func (m *MockVisionProvider) ExtractRecipesFromMedia(ctx context.Context, media []ai.MediaInput, unitSystem string, requirements string) ([]*ai.RecipeResult, error) {
+func (m *MockVisionProvider) ExtractRecipesFromMedia(ctx context.Context, media []ai.MediaInput, contextText string, unitSystem string, requirements string) ([]*ai.RecipeResult, error) {
 	if m.ExtractRecipesFromMediaFunc != nil {
-		return m.ExtractRecipesFromMediaFunc(ctx, media, unitSystem, requirements)
+		return m.ExtractRecipesFromMediaFunc(ctx, media, contextText, unitSystem, requirements)
 	}
 	return nil, fmt.Errorf("ExtractRecipesFromMedia not configured")
 }
@@ -756,6 +756,8 @@ func (m *MockUserRepo) IncrementSubscriptionUsage(userID uint, column string) er
 		u.Subscription.WebSearchesUsed++
 	case "ai_generations_used":
 		u.Subscription.AIGenerationsUsed++
+	case "video_imports_used":
+		u.Subscription.VideoImportsUsed++
 	default:
 		return fmt.Errorf("unknown usage column: %s", column)
 	}
@@ -773,6 +775,7 @@ func (m *MockUserRepo) ResetSubscriptionUsage(userID uint, nextReset time.Time) 
 	u.Subscription.AllergenAnalysesUsed = 0
 	u.Subscription.WebSearchesUsed = 0
 	u.Subscription.AIGenerationsUsed = 0
+	u.Subscription.VideoImportsUsed = 0
 	u.Subscription.MonthlyResetAt = nextReset
 	return nil
 }
@@ -968,6 +971,110 @@ func (m *MockCanonicalRecipeRepo) IncrementHitCount(id uint) error {
 	return nil
 }
 
+// --- MockVideoImportRepo ---
+
+// MockVideoImportRepo is an in-memory mock of repository.VideoImportRepo.
+// Jobs and cache entries are stored in maps so async orchestration
+// (create → update → poll) can be observed by tests. The *Func fields
+// override individual methods when set. Returned values are copies so the
+// stored structs are never mutated through an aliased pointer.
+type MockVideoImportRepo struct {
+	mu      sync.Mutex
+	imports map[uint]*models.VideoImport
+	cache   map[string]*models.VideoExtractionCache
+	nextID  uint
+
+	GetCacheByVideoKeyFunc func(videoKey string) (*models.VideoExtractionCache, error)
+	SumImportCostSinceFunc func(t time.Time) (float64, error)
+}
+
+// NewMockVideoImportRepo creates an empty in-memory video-import repo.
+func NewMockVideoImportRepo() *MockVideoImportRepo {
+	return &MockVideoImportRepo{
+		imports: make(map[uint]*models.VideoImport),
+		cache:   make(map[string]*models.VideoExtractionCache),
+	}
+}
+
+func (m *MockVideoImportRepo) GetCacheByVideoKey(videoKey string) (*models.VideoExtractionCache, error) {
+	if m.GetCacheByVideoKeyFunc != nil {
+		return m.GetCacheByVideoKeyFunc(videoKey)
+	}
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	entry, ok := m.cache[videoKey]
+	if !ok {
+		return nil, gorm.ErrRecordNotFound
+	}
+	cp := *entry
+	return &cp, nil
+}
+
+func (m *MockVideoImportRepo) UpsertCache(entry *models.VideoExtractionCache) error {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	if entry.ID == 0 {
+		m.nextID++
+		entry.ID = m.nextID
+	}
+	cp := *entry
+	m.cache[entry.VideoKey] = &cp
+	return nil
+}
+
+func (m *MockVideoImportRepo) IncrementCacheHit(id uint) error {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	for _, e := range m.cache {
+		if e.ID == id {
+			e.HitCount++
+		}
+	}
+	return nil
+}
+
+func (m *MockVideoImportRepo) CreateImport(job *models.VideoImport) error {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	m.nextID++
+	job.ID = m.nextID
+	cp := *job
+	m.imports[job.ID] = &cp
+	return nil
+}
+
+func (m *MockVideoImportRepo) GetImportByID(id uint) (*models.VideoImport, error) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	job, ok := m.imports[id]
+	if !ok {
+		return nil, gorm.ErrRecordNotFound
+	}
+	cp := *job
+	return &cp, nil
+}
+
+func (m *MockVideoImportRepo) UpdateImport(job *models.VideoImport) error {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	cp := *job
+	m.imports[job.ID] = &cp
+	return nil
+}
+
+func (m *MockVideoImportRepo) SumImportCostSince(t time.Time) (float64, error) {
+	if m.SumImportCostSinceFunc != nil {
+		return m.SumImportCostSinceFunc(t)
+	}
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	var total float64
+	for _, j := range m.imports {
+		total += j.CostUSD
+	}
+	return total, nil
+}
+
 // Compile-time interface checks.
 var _ ai.TextProvider = (*MockTextProvider)(nil)
 var _ ai.VisionProvider = (*MockVisionProvider)(nil)
@@ -980,3 +1087,4 @@ var _ repository.UserRepo = (*MockUserRepo)(nil)
 var _ repository.SearchCacheRepo = (*MockSearchCacheRepo)(nil)
 var _ repository.CanonicalRecipeRepo = (*MockCanonicalRecipeRepo)(nil)
 var _ repository.FamilyRepo = (*MockFamilyRepo)(nil)
+var _ repository.VideoImportRepo = (*MockVideoImportRepo)(nil)


### PR DESCRIPTION
## What this is

PR2c — the final assembly of the **video-link import** feature (Phase 2.5). It wires the three merged foundation PRs into a working end-to-end pipeline behind a paywall:

- **#86** cache/quota/config + async-job model
- **#87** ScrapeCreators client (platform detect + TikTok)
- **#88** ffmpeg frame sampler (+ ffmpeg in the Docker image)

A user pastes a TikTok/Instagram/YouTube/Facebook/Pinterest link; we pull the caption + transcript + a downloadable copy of the video, sample representative frames, and run a single multimodal Claude extraction over **frames + transcript/caption together** to reconstruct the recipe.

## Pipeline (async)

`POST /v1/recipes/import/video` → premium gate → create job → return `202 {job}`.
Goroutine: `FetchVideo` → **per-video cache check** → **daily-budget kill switch** → SSRF-guard the scraper media URL → `Sample` frames → `ExtractRecipesFromMedia(frames, transcript+caption)` → save recipe → **cache the extraction**.
`GET /v1/recipes/import/video/:id` → owner-only status poll (returns `recipe_id` when done).

## Cost controls ("don't let users bleed me")

- **Process-once cache** (`VideoExtractionCache`, keyed `platform:video_id`): a viral video is extracted once; every later importer is served from cache at **$0**.
- **Per-user monthly quota**: free **2** / premium **20** (`CanUseVideoImport`).
- **Global daily-budget kill switch**: fresh extractions stop once `SUM(cost_usd)` since UTC-midnight reaches `VIDEO_IMPORT_DAILY_BUDGET_USD` (default $25).
- **Feature flag**: the endpoint returns `503` until `SCRAPECREATORS_API_KEY` is configured — ships dark.
- Frame count is the master cost dial (~$0.0048/frame on Sonnet); cost is over-estimated so the kill switch trips early.

## Notable decisions

- **Interface ripple**: `VisionProvider.ExtractRecipesFromMedia` gained a `contextText` arg (transcript/caption); `ImportFromFiles` passes `""`.
- **SSRF**: the scraper-supplied media URL is validated with the existing `ValidateExternalURL` before the sampler fetches it. *Follow-up:* harden the sampler's HTTP client against redirect-hop rebinding (the validator is TOCTOU-imperfect on its own).
- **Quota on accept**: usage is incremented when a job is accepted (not on completion) and cache hits still count — a deliberate product/cost choice; documented for review.
- **Bug fix**: monthly usage reset now also zeroes `VideoImportsUsed` in-memory.

## Tests

All offline and race-clean (`go test ./... -race`):
- Service: fresh extraction, cache hit (no sample/extract), budget-exceeded (fails before sampling), fetch-failure, not-configured, unsupported platform.
- Handler: gate `403`, unconfigured `503`, bad platform `400`, accept `202` + poll → `done`, non-owner `404`.

## Deploy note (not in this PR)

At deploy, add `SCRAPECREATORS_API_KEY` to the prod ECS task definition to switch the feature on, then run a real TikTok end-to-end check. Only TikTok is implemented in the client so far; IG/YouTube/Facebook/Pinterest detect but return "not yet supported".

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BU4UWZutHd1AnK3XAf7H19