### PR TITLE
Add Instagram support to video-link import

### DIFF
--- a/internal/video/scrapecreators.go
+++ b/internal/video/scrapecreators.go
@@ -8,6 +8,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
+	"math"
 	"net/http"
 	"net/url"
 	"strings"
@@ -96,7 +97,9 @@ func (c *ScrapeCreatorsClient) get(ctx context.Context, path string, q url.Value
 	if resp.StatusCode != http.StatusOK {
 		return nil, fmt.Errorf("scrapecreators %s returned status %d", path, resp.StatusCode)
 	}
-	return body, nil
+	// Some providers (e.g. Instagram captions) emit raw control characters inside
+	// JSON string values, which encoding/json rejects. Escape them defensively.
+	return sanitizeJSONControlChars(body), nil
 }
 
 // FetchVideo resolves a supported video URL to normalized metadata (caption,
@@ -109,6 +112,8 @@ func (c *ScrapeCreatorsClient) FetchVideo(ctx context.Context, rawURL string) (*
 	switch platform {
 	case PlatformTikTok:
 		return c.fetchTikTok(ctx, rawURL)
+	case PlatformInstagram:
+		return c.fetchInstagram(ctx, rawURL)
 	default:
 		return nil, fmt.Errorf("platform %q not yet supported", platform)
 	}
@@ -173,4 +178,137 @@ func firstNonEmpty(list []string) string {
 		}
 	}
 	return ""
+}
+
+// instagramPostResponse is the subset of the /v1/instagram/post response we use.
+type instagramPostResponse struct {
+	Data struct {
+		Media struct {
+			Typename      string  `json:"__typename"`
+			ID            string  `json:"id"`
+			Shortcode     string  `json:"shortcode"`
+			IsVideo       bool    `json:"is_video"`
+			VideoURL      string  `json:"video_url"`
+			VideoDuration float64 `json:"video_duration"` // seconds (float)
+			Caption       struct {
+				Edges []struct {
+					Node struct {
+						Text string `json:"text"`
+					} `json:"node"`
+				} `json:"edges"`
+			} `json:"edge_media_to_caption"`
+		} `json:"xdt_shortcode_media"`
+	} `json:"data"`
+}
+
+// instagramTranscriptResponse is the /v2/instagram/media/transcript response.
+// transcripts entries may be null when no transcript is available.
+type instagramTranscriptResponse struct {
+	Transcripts []*string `json:"transcripts"`
+}
+
+func (c *ScrapeCreatorsClient) fetchInstagram(ctx context.Context, rawURL string) (*VideoMeta, error) {
+	q := url.Values{}
+	q.Set("url", rawURL)
+
+	body, err := c.get(ctx, "/v1/instagram/post", q)
+	if err != nil {
+		return nil, err
+	}
+	var r instagramPostResponse
+	if err := json.Unmarshal(body, &r); err != nil {
+		return nil, fmt.Errorf("parse instagram response: %w", err)
+	}
+	m := r.Data.Media
+	if m.Shortcode == "" {
+		return nil, fmt.Errorf("instagram response missing media detail")
+	}
+	if m.VideoURL == "" {
+		return nil, fmt.Errorf("instagram post is not a downloadable video")
+	}
+
+	caption := ""
+	if len(m.Caption.Edges) > 0 {
+		caption = m.Caption.Edges[0].Node.Text
+	}
+
+	return &VideoMeta{
+		Platform:   PlatformInstagram,
+		VideoID:    m.Shortcode,
+		Caption:    caption,
+		Transcript: c.instagramTranscript(ctx, rawURL), // best-effort; often empty
+		MediaURL:   m.VideoURL,
+		DurationMS: int(math.Round(m.VideoDuration * 1000)),
+	}, nil
+}
+
+// instagramTranscript fetches the spoken transcript for a reel. It is
+// best-effort: any error or absent transcript yields an empty string, and the
+// caller falls back to the caption plus sampled frames.
+func (c *ScrapeCreatorsClient) instagramTranscript(ctx context.Context, rawURL string) string {
+	q := url.Values{}
+	q.Set("url", rawURL)
+	body, err := c.get(ctx, "/v2/instagram/media/transcript", q)
+	if err != nil {
+		return ""
+	}
+	var r instagramTranscriptResponse
+	if err := json.Unmarshal(body, &r); err != nil {
+		return ""
+	}
+	for _, t := range r.Transcripts {
+		if t != nil && *t != "" {
+			return *t
+		}
+	}
+	return ""
+}
+
+// sanitizeJSONControlChars escapes raw control characters (U+0000–U+001F) that
+// appear inside JSON string literals, which some providers emit (e.g. literal
+// newlines in Instagram captions) and which encoding/json rejects per RFC 8259.
+// Control characters outside of strings (structural whitespace) are left as-is,
+// so well-formed JSON passes through unchanged.
+func sanitizeJSONControlChars(b []byte) []byte {
+	const hex = "0123456789abcdef"
+	out := make([]byte, 0, len(b))
+	inStr := false
+	escaped := false
+	for i := 0; i < len(b); i++ {
+		ch := b[i]
+		if !inStr {
+			out = append(out, ch)
+			if ch == '"' {
+				inStr = true
+			}
+			continue
+		}
+		if escaped {
+			out = append(out, ch)
+			escaped = false
+			continue
+		}
+		switch {
+		case ch == '\\':
+			out = append(out, ch)
+			escaped = true
+		case ch == '"':
+			out = append(out, ch)
+			inStr = false
+		case ch < 0x20:
+			switch ch {
+			case '\n':
+				out = append(out, '\\', 'n')
+			case '\r':
+				out = append(out, '\\', 'r')
+			case '\t':
+				out = append(out, '\\', 't')
+			default:
+				out = append(out, '\\', 'u', '0', '0', hex[ch>>4], hex[ch&0xf])
+			}
+		default:
+			out = append(out, ch)
+		}
+	}
+	return out
 }

--- a/internal/video/scrapecreators_test.go
+++ b/internal/video/scrapecreators_test.go
@@ -2,6 +2,7 @@ package video
 
 import (
 	"context"
+	"encoding/json"
 	"io"
 	"net/http"
 	"strings"
@@ -111,6 +112,96 @@ func TestFetchVideo_TikTok_FallsBackToPlayAddr(t *testing.T) {
 	}
 	if m.MediaURL != "https://cdn.example/play.mp4" {
 		t.Errorf("media url = %q, want play_addr fallback", m.MediaURL)
+	}
+}
+
+func TestFetchVideo_Instagram(t *testing.T) {
+	// The caption deliberately contains a RAW newline byte (between "rice" and
+	// "with") — invalid per JSON spec and rejected by encoding/json — to prove
+	// the client's control-char sanitizer makes real Instagram responses parse.
+	const postFixture = `{"success":true,"data":{"xdt_shortcode_media":{"__typename":"XDTGraphVideo","id":"3890383696589050992","shortcode":"DX9a1wjKVRw","is_video":true,"video_url":"https://scontent.cdninstagram.com/v.mp4","video_duration":22.547,"edge_media_to_caption":{"edges":[{"node":{"text":"Thai mango sticky rice
+with creamy coconut sauce #recipe"}}]}}}}`
+	const transcriptFixture = `{"success":true,"transcripts":["Soak the rice then steam it with coconut milk."]}`
+
+	c := NewScrapeCreatorsClient("k")
+	var gotPostURL, gotTranscriptURL string
+	c.httpDo = func(req *http.Request) (*http.Response, error) {
+		body := postFixture
+		if strings.Contains(req.URL.Path, "/v2/instagram/media/transcript") {
+			gotTranscriptURL = req.URL.String()
+			body = transcriptFixture
+		} else {
+			gotPostURL = req.URL.String()
+		}
+		return &http.Response{StatusCode: 200, Body: io.NopCloser(strings.NewReader(body))}, nil
+	}
+
+	m, err := c.FetchVideo(context.Background(), "https://www.instagram.com/reel/DX9a1wjKVRw/")
+	if err != nil {
+		t.Fatalf("FetchVideo error: %v", err)
+	}
+	if !strings.Contains(gotPostURL, "/v1/instagram/post") {
+		t.Errorf("post URL = %q, want /v1/instagram/post", gotPostURL)
+	}
+	if !strings.Contains(gotTranscriptURL, "/v2/instagram/media/transcript") {
+		t.Errorf("transcript URL = %q, want the transcript endpoint", gotTranscriptURL)
+	}
+	if m.Platform != PlatformInstagram {
+		t.Errorf("platform = %q, want instagram", m.Platform)
+	}
+	if m.VideoID != "DX9a1wjKVRw" {
+		t.Errorf("video id = %q, want the shortcode", m.VideoID)
+	}
+	if !strings.Contains(m.Caption, "Thai mango sticky rice") || !strings.Contains(m.Caption, "creamy coconut sauce") {
+		t.Errorf("caption did not survive sanitization: %q", m.Caption)
+	}
+	if m.MediaURL != "https://scontent.cdninstagram.com/v.mp4" {
+		t.Errorf("media url = %q", m.MediaURL)
+	}
+	if m.DurationMS != 22547 { // 22.547s rounded to ms
+		t.Errorf("duration = %d ms, want 22547", m.DurationMS)
+	}
+	if m.Transcript == "" {
+		t.Error("expected the best-effort transcript to be populated")
+	}
+}
+
+func TestFetchVideo_Instagram_NotAVideo(t *testing.T) {
+	const fixture = `{"success":true,"data":{"xdt_shortcode_media":{"__typename":"XDTGraphImage","shortcode":"ABC123","is_video":false}}}`
+	c := NewScrapeCreatorsClient("k")
+	c.httpDo = func(req *http.Request) (*http.Response, error) {
+		return &http.Response{StatusCode: 200, Body: io.NopCloser(strings.NewReader(fixture))}, nil
+	}
+	if _, err := c.FetchVideo(context.Background(), "https://www.instagram.com/p/ABC123/"); err == nil {
+		t.Fatal("expected an error for a non-video (image) post")
+	}
+}
+
+func TestSanitizeJSONControlChars(t *testing.T) {
+	// Raw newline + tab inside a string value → must become valid, parseable JSON.
+	raw := []byte("{\"text\":\"a\nb\tc\",\"keep\":\"x\\ny\",\"n\":7}")
+	var v struct {
+		Text string `json:"text"`
+		Keep string `json:"keep"`
+		N    int    `json:"n"`
+	}
+	if err := json.Unmarshal(sanitizeJSONControlChars(raw), &v); err != nil {
+		t.Fatalf("sanitized JSON should parse, got: %v", err)
+	}
+	if v.Text != "a\nb\tc" {
+		t.Errorf("text = %q, want the control chars decoded back", v.Text)
+	}
+	if v.Keep != "x\ny" { // already-escaped \n must be left intact
+		t.Errorf("keep = %q, want already-escaped sequence preserved", v.Keep)
+	}
+	if v.N != 7 {
+		t.Errorf("n = %d, want 7", v.N)
+	}
+
+	// Clean JSON (control chars only as structural whitespace) is unchanged.
+	clean := []byte("{\n  \"a\": 1\n}")
+	if got := sanitizeJSONControlChars(clean); string(got) != string(clean) {
+		t.Errorf("clean JSON was modified:\n got %q\nwant %q", got, clean)
 	}
 }
 


### PR DESCRIPTION
## What

Extends the now-live video-link import (PR #89) to **Instagram reels** — the platform you asked about. TikTok was the only wired platform; this adds Instagram and the JSON robustness needed for it.

## Changes

- **`fetchInstagram`** — `GET /v1/instagram/post` → `shortcode` (cache key), `video_url`, caption, and `video_duration` (seconds → rounded to ms). Transcript is a best-effort `GET /v2/instagram/media/transcript` (frequently null for reels; we fall back to caption + sampled frames, which already carry the recipe).
- **Control-char sanitizer** in the shared `get()` — Instagram captions contain **raw newlines inside JSON string values**, which `encoding/json` rejects (verified: `invalid character '\n' in string literal`). The sanitizer escapes control chars *inside string literals only*, so it's a no-op on well-formed JSON and leaves the TikTok path unchanged (just hardened).

## Verified live (against real ScrapeCreators)

- `@thecookingfoodie` reel `DX9a1wjKVRw` ("Thai mango sticky rice") parsed correctly: shortcode, caption, 22.547s duration, media URL.
- **The `cdninstagram.com` media URL downloaded fine from a server** (HTTP 206, `video/mp4`) — the feared IP-bound-CDN caveat did not materialize, so no `download_media` proxy is needed.

## Tests (all offline)

- `TestFetchVideo_Instagram` — fixture deliberately embeds a **raw-newline caption** to prove the sanitizer makes real responses parse end-to-end; asserts shortcode→VideoID, seconds→ms rounding, media URL, transcript.
- `TestFetchVideo_Instagram_NotAVideo` — image posts are rejected.
- `TestSanitizeJSONControlChars` — raw `\n`/`\t` escaped + decode round-trip; already-escaped sequences preserved; clean JSON untouched.

## Not in this PR

YouTube / Facebook / Pinterest still detect but return "not yet supported" — each needs its own live shape check (YouTube also needs the finished MP4, not the raw googlevideo URL). Follow-ups.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BU4UWZutHd1AnK3XAf7H19