### PR TITLE
Polish video import: thumbnails, quota refunds, SSRF-hardened download

### DIFF
--- a/internal/models/video_import.go
+++ b/internal/models/video_import.go
@@ -15,6 +15,7 @@ type VideoExtractionCache struct {
 	Platform       string    `gorm:"size:32;not null"`
 	OriginalURL    string    `gorm:"size:2048;not null"`
 	RecipeData     RecipeDef `gorm:"type:jsonb;not null"`
+	ThumbnailURL   string    `gorm:"size:1024"` // S3 URL of a representative frame, shared across importers
 	HitCount       int       `gorm:"default:0"`
 	LastAccessedAt time.Time `gorm:"index;not null"`
 	FetchedAt      time.Time `gorm:"index;not null"`

--- a/internal/repository/interfaces.go
+++ b/internal/repository/interfaces.go
@@ -106,6 +106,7 @@ type UserRepo interface {
 	IncrementTokenVersion(userID uint) error
 	CreateSubscription(sub *models.Subscription) error
 	IncrementSubscriptionUsage(userID uint, column string) error
+	DecrementSubscriptionUsage(userID uint, column string) error
 	ResetSubscriptionUsage(userID uint, nextReset time.Time) error
 }
 

--- a/internal/repository/user.go
+++ b/internal/repository/user.go
@@ -199,6 +199,23 @@ func (r *UserRepository) IncrementSubscriptionUsage(userID uint, column string) 
 	return nil
 }
 
+// DecrementSubscriptionUsage atomically decrements a usage counter on the
+// subscription row, flooring at zero. Used to refund a counted action that
+// later failed on our side (e.g. a video import that errored after acceptance).
+func (r *UserRepository) DecrementSubscriptionUsage(userID uint, column string) error {
+	result := r.DB.Model(&models.Subscription{}).
+		Where("user_id = ?", userID).
+		UpdateColumn(column, gorm.Expr("GREATEST("+column+" - 1, 0)"))
+	if result.Error != nil {
+		logger.Get().Error("failed to decrement subscription usage", zap.Uint("user_id", userID), zap.String("column", column), zap.Error(result.Error))
+		return result.Error
+	}
+	if result.RowsAffected == 0 {
+		return errors.New("no subscription found for user")
+	}
+	return nil
+}
+
 // ResetSubscriptionUsage zeroes all usage counters and advances the monthly
 // reset timestamp for the given user's subscription.
 func (r *UserRepository) ResetSubscriptionUsage(userID uint, nextReset time.Time) error {

--- a/internal/repository/video_import.go
+++ b/internal/repository/video_import.go
@@ -31,7 +31,7 @@ func (r *VideoImportRepository) GetCacheByVideoKey(videoKey string) (*models.Vid
 func (r *VideoImportRepository) UpsertCache(entry *models.VideoExtractionCache) error {
 	return r.DB.Clauses(clause.OnConflict{
 		Columns:   []clause.Column{{Name: "video_key"}},
-		DoUpdates: clause.AssignmentColumns([]string{"recipe_data", "original_url", "platform", "fetched_at", "last_accessed_at", "prompt_version"}),
+		DoUpdates: clause.AssignmentColumns([]string{"recipe_data", "original_url", "platform", "thumbnail_url", "fetched_at", "last_accessed_at", "prompt_version"}),
 	}).Create(entry).Error
 }
 

--- a/internal/router/router.go
+++ b/internal/router/router.go
@@ -90,6 +90,7 @@ func SetupRouter(cfg *config.Config, database *gorm.DB) *gin.Engine {
 	importService.Normalize = service.NewNormalizeService(cfg, previewProvider)
 	importHandler := handlers.NewImportHandler(importService)
 	importHandler.SubService = subService
+	importService.SubService = subService
 	// MultiResolver is wired later after search setup; set via field
 
 	// Video-link import (premium). Stays dark until a ScrapeCreators API key is

--- a/internal/service/import.go
+++ b/internal/service/import.go
@@ -53,6 +53,12 @@ type ImportService struct {
 	VideoRepo         repository.VideoImportRepo
 	VideoFetcher      VideoFetcher
 	VideoFrameSampler VideoFrameSampler
+	// SubService refunds the per-user video quota when an accepted import later
+	// fails on our side. Optional; nil disables refunds (e.g. in tests).
+	SubService *SubscriptionService
+	// ThumbnailUploader stores a representative video frame and returns its URL.
+	// Optional test seam; nil uses the default S3 uploader.
+	ThumbnailUploader func(ctx context.Context, frameJPEG []byte, videoKey string) (string, error)
 
 	// Test seams — nil in production, set in tests to bypass real HTTP/Firecrawl calls
 	HTTPFetchOverride      func(ctx context.Context, url string) (body []byte, statusCode int, err error)

--- a/internal/service/import_video.go
+++ b/internal/service/import_video.go
@@ -9,6 +9,7 @@ import (
 	"github.com/windoze95/saltybytes-api/internal/ai"
 	"github.com/windoze95/saltybytes-api/internal/logger"
 	"github.com/windoze95/saltybytes-api/internal/models"
+	"github.com/windoze95/saltybytes-api/internal/s3"
 	"github.com/windoze95/saltybytes-api/internal/video"
 	"go.uber.org/zap"
 )
@@ -109,6 +110,13 @@ func (s *ImportService) processVideoImport(jobID uint, rawURL string, user *mode
 		if uErr := s.VideoRepo.UpdateImport(job); uErr != nil {
 			log.Error("failed to persist video import failure", zap.Error(uErr))
 		}
+		// The quota was consumed on acceptance; refund it since the user got no
+		// recipe and the failure is on our side.
+		if s.SubService != nil {
+			if rErr := s.SubService.DecrementUsage(user.ID, "video_import"); rErr != nil {
+				log.Warn("failed to refund video import quota", zap.Error(rErr))
+			}
+		}
 	}
 
 	job.Status = models.VideoImportProcessing
@@ -134,7 +142,7 @@ func (s *ImportService) processVideoImport(jobID uint, rawURL string, user *mode
 		if def.SourceURL == "" {
 			def.SourceURL = rawURL
 		}
-		_, recipeID, createErr := s.createImportedRecipe(ctx, &def, user, models.RecipeTypeImportVideo, rawURL, "", nil, nil, entry.PromptVersion)
+		_, recipeID, createErr := s.createImportedRecipe(ctx, &def, user, models.RecipeTypeImportVideo, rawURL, entry.ThumbnailURL, nil, nil, entry.PromptVersion)
 		if createErr != nil {
 			fail("save_failed", "could not save the recipe", createErr)
 			return
@@ -197,19 +205,24 @@ func (s *ImportService) processVideoImport(jobID uint, rawURL string, user *mode
 	def.SourceURL = rawURL
 	ensureUnitSystem(&def)
 
-	_, recipeID, createErr := s.createImportedRecipe(ctx, &def, user, models.RecipeTypeImportVideo, rawURL, "", nil, results[0].Hashtags, results[0].PromptVersion)
+	// Use a representative frame as the recipe thumbnail (best-effort).
+	thumbnailURL := s.uploadVideoThumbnail(ctx, frames, videoKey)
+
+	_, recipeID, createErr := s.createImportedRecipe(ctx, &def, user, models.RecipeTypeImportVideo, rawURL, thumbnailURL, nil, results[0].Hashtags, results[0].PromptVersion)
 	if createErr != nil {
 		fail("save_failed", "could not save the recipe", createErr)
 		return
 	}
 
-	// 6. Cache the extraction so the next importer of this video pays nothing.
+	// 6. Cache the extraction (and its thumbnail) so the next importer of this
+	//    video pays nothing and reuses the same hero image.
 	now := time.Now()
 	cacheEntry := &models.VideoExtractionCache{
 		VideoKey:       videoKey,
 		Platform:       string(meta.Platform),
 		OriginalURL:    rawURL,
 		RecipeData:     def,
+		ThumbnailURL:   thumbnailURL,
 		FetchedAt:      now,
 		LastAccessedAt: now,
 		PromptVersion:  results[0].PromptVersion,
@@ -226,6 +239,30 @@ func (s *ImportService) processVideoImport(jobID uint, rawURL string, user *mode
 		log.Error("failed to persist completed video import", zap.Error(err))
 	}
 	log.Info("video import complete", zap.Int("frames", len(frames)), zap.Float64("cost_usd", job.CostUSD))
+}
+
+// uploadVideoThumbnail stores a representative frame (the middle one — past any
+// intro, before any outro) as the recipe's hero image and returns its URL.
+// Best-effort: returns "" on any failure so the import still succeeds.
+func (s *ImportService) uploadVideoThumbnail(ctx context.Context, frames [][]byte, videoKey string) string {
+	if len(frames) == 0 {
+		return ""
+	}
+	frame := frames[len(frames)/2]
+	if s.ThumbnailUploader != nil {
+		url, err := s.ThumbnailUploader(ctx, frame, videoKey)
+		if err != nil {
+			return ""
+		}
+		return url
+	}
+	key := "recipes/video_thumbnails/" + strings.ReplaceAll(videoKey, ":", "_") + ".jpg"
+	url, err := s3.UploadRecipeImageToS3(ctx, s.Cfg, frame, key, "image/jpeg")
+	if err != nil {
+		logger.Get().Warn("failed to upload video thumbnail", zap.String("video_key", videoKey), zap.Error(err))
+		return ""
+	}
+	return url
 }
 
 // videoCacheKey is the per-video cache key: "<platform>:<video_id>".

--- a/internal/service/import_video_test.go
+++ b/internal/service/import_video_test.go
@@ -243,6 +243,119 @@ func TestVideoImport_BudgetExceeded(t *testing.T) {
 	}
 }
 
+func TestVideoImport_SetsThumbnail(t *testing.T) {
+	repo := testutil.NewMockRecipeRepo()
+	vrepo := testutil.NewMockVideoImportRepo()
+	svc := newVideoTestService(repo, vrepo)
+	svc.VideoFetcher = &fakeVideoFetcher{meta: tiktokMeta()}
+	svc.VideoFrameSampler = &fakeFrameSampler{frames: [][]byte{{0xFF, 1}, {0xFF, 2}, {0xFF, 3}}}
+	svc.VisionProvider = &testutil.MockVisionProvider{
+		ExtractRecipesFromMediaFunc: func(ctx context.Context, media []ai.MediaInput, contextText, unitSystem, requirements string) ([]*ai.RecipeResult, error) {
+			return []*ai.RecipeResult{testutil.TestRecipeResult()}, nil
+		},
+	}
+	var gotKey string
+	var gotFrame []byte
+	svc.ThumbnailUploader = func(ctx context.Context, frame []byte, videoKey string) (string, error) {
+		gotKey, gotFrame = videoKey, frame
+		return "https://s3.example/thumb.jpg", nil
+	}
+
+	job, err := svc.StartVideoImport(context.Background(), "https://www.tiktok.com/@chef/video/7499229683859426602", testutil.TestUser())
+	if err != nil {
+		t.Fatalf("StartVideoImport: %v", err)
+	}
+	done := waitForVideoJob(t, svc, job.ID)
+	if done.Status != models.VideoImportDone || done.RecipeID == nil {
+		t.Fatalf("status=%q recipe=%v, want done with a recipe", done.Status, done.RecipeID)
+	}
+	if gotKey != "tiktok:7499229683859426602" {
+		t.Errorf("thumbnail keyed by %q", gotKey)
+	}
+	if len(gotFrame) < 2 || gotFrame[1] != 2 {
+		t.Errorf("uploaded frame = %v, want the middle frame (marker 2)", gotFrame)
+	}
+	if got := repo.Recipes[*done.RecipeID].ImageURL; got != "https://s3.example/thumb.jpg" {
+		t.Errorf("recipe ImageURL = %q, want the thumbnail", got)
+	}
+	entry, err := vrepo.GetCacheByVideoKey("tiktok:7499229683859426602")
+	if err != nil {
+		t.Fatalf("cache lookup: %v", err)
+	}
+	if entry.ThumbnailURL != "https://s3.example/thumb.jpg" {
+		t.Errorf("cache ThumbnailURL = %q, want the thumbnail", entry.ThumbnailURL)
+	}
+}
+
+func TestVideoImport_CacheHitReusesThumbnail(t *testing.T) {
+	repo := testutil.NewMockRecipeRepo()
+	vrepo := testutil.NewMockVideoImportRepo()
+	svc := newVideoTestService(repo, vrepo)
+
+	cached := recipeResultToRecipeDef(testutil.TestRecipeResult())
+	if err := vrepo.UpsertCache(&models.VideoExtractionCache{
+		VideoKey: "tiktok:7499229683859426602", Platform: "tiktok",
+		OriginalURL: "https://x", RecipeData: cached,
+		ThumbnailURL: "https://s3.example/cached-thumb.jpg",
+	}); err != nil {
+		t.Fatalf("seed cache: %v", err)
+	}
+	svc.VideoFetcher = &fakeVideoFetcher{meta: tiktokMeta()}
+	svc.VideoFrameSampler = &fakeFrameSampler{}
+	svc.VisionProvider = &testutil.MockVisionProvider{}
+
+	job, err := svc.StartVideoImport(context.Background(), "https://www.tiktok.com/@chef/video/7499229683859426602", testutil.TestUser())
+	if err != nil {
+		t.Fatalf("StartVideoImport: %v", err)
+	}
+	done := waitForVideoJob(t, svc, job.ID)
+	if !done.CacheHit || done.RecipeID == nil {
+		t.Fatalf("want cache hit with a recipe, got hit=%v recipe=%v", done.CacheHit, done.RecipeID)
+	}
+	if got := repo.Recipes[*done.RecipeID].ImageURL; got != "https://s3.example/cached-thumb.jpg" {
+		t.Errorf("recipe ImageURL = %q, want the cached thumbnail", got)
+	}
+}
+
+func TestVideoImport_RefundsQuotaOnFailure(t *testing.T) {
+	repo := testutil.NewMockRecipeRepo()
+	vrepo := testutil.NewMockVideoImportRepo()
+	svc := newVideoTestService(repo, vrepo)
+
+	// The handler increments quota on acceptance; model that as Used=1.
+	user := testutil.TestUser()
+	user.Subscription = &models.Subscription{
+		UserID: user.ID, Tier: models.TierFree,
+		VideoImportsUsed: 1, MonthlyResetAt: time.Now().Add(time.Hour),
+	}
+	userRepo := testutil.NewMockUserRepo()
+	userRepo.Users[user.ID] = user
+	svc.SubService = NewSubscriptionService(&config.Config{}, userRepo)
+
+	// Fail on our side (fetch error) → quota should be refunded.
+	svc.VideoFetcher = &fakeVideoFetcher{err: context.DeadlineExceeded}
+	svc.VideoFrameSampler = &fakeFrameSampler{}
+	svc.VisionProvider = &testutil.MockVisionProvider{}
+
+	job, err := svc.StartVideoImport(context.Background(), "https://www.tiktok.com/@x/video/1", user)
+	if err != nil {
+		t.Fatalf("StartVideoImport: %v", err)
+	}
+	done := waitForVideoJob(t, svc, job.ID)
+	if done.Status != models.VideoImportFailed {
+		t.Fatalf("want failed, got %s", done.Status)
+	}
+	// The refund runs in the goroutine after the job is marked failed; poll the
+	// lock-synchronized counter until it lands.
+	deadline := time.Now().Add(2 * time.Second)
+	for time.Now().Before(deadline) && userRepo.SubscriptionUsage(user.ID, "video_imports_used") != 0 {
+		time.Sleep(5 * time.Millisecond)
+	}
+	if got := userRepo.SubscriptionUsage(user.ID, "video_imports_used"); got != 0 {
+		t.Errorf("VideoImportsUsed = %d, want 0 after refund", got)
+	}
+}
+
 func TestVideoImport_FetchFailed(t *testing.T) {
 	repo := testutil.NewMockRecipeRepo()
 	vrepo := testutil.NewMockVideoImportRepo()

--- a/internal/service/subscription.go
+++ b/internal/service/subscription.go
@@ -73,24 +73,40 @@ func (s *SubscriptionService) UpgradeSubscription(userID uint) (*models.Subscrip
 	return nil, fmt.Errorf("paid plans are not yet available")
 }
 
-// IncrementUsage atomically increments a usage counter in the database.
-// Valid usageType values: "allergen", "search", "ai_generation".
-func (s *SubscriptionService) IncrementUsage(userID uint, usageType string) error {
-	var column string
+// usageColumn maps a usage type to its subscription counter column.
+func usageColumn(usageType string) (string, error) {
 	switch usageType {
 	case "allergen":
-		column = "allergen_analyses_used"
+		return "allergen_analyses_used", nil
 	case "search":
-		column = "web_searches_used"
+		return "web_searches_used", nil
 	case "ai_generation":
-		column = "ai_generations_used"
+		return "ai_generations_used", nil
 	case "video_import":
-		column = "video_imports_used"
+		return "video_imports_used", nil
 	default:
-		return fmt.Errorf("unknown usage type: %s", usageType)
+		return "", fmt.Errorf("unknown usage type: %s", usageType)
 	}
+}
 
+// IncrementUsage atomically increments a usage counter in the database.
+// Valid usageType values: "allergen", "search", "ai_generation", "video_import".
+func (s *SubscriptionService) IncrementUsage(userID uint, usageType string) error {
+	column, err := usageColumn(usageType)
+	if err != nil {
+		return err
+	}
 	return s.Repo.IncrementSubscriptionUsage(userID, column)
+}
+
+// DecrementUsage refunds one unit of a usage counter (floored at zero) — used
+// when an action that was counted on acceptance later fails on our side.
+func (s *SubscriptionService) DecrementUsage(userID uint, usageType string) error {
+	column, err := usageColumn(usageType)
+	if err != nil {
+		return err
+	}
+	return s.Repo.DecrementSubscriptionUsage(userID, column)
 }
 
 // CheckLimit returns true if the user is within their usage limits for the given type.

--- a/internal/testutil/mocks.go
+++ b/internal/testutil/mocks.go
@@ -764,6 +764,56 @@ func (m *MockUserRepo) IncrementSubscriptionUsage(userID uint, column string) er
 	return nil
 }
 
+// SubscriptionUsage reads a usage counter under lock, so tests can observe
+// asynchronous increments/refunds without racing the writer.
+func (m *MockUserRepo) SubscriptionUsage(userID uint, column string) int {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	u, ok := m.Users[userID]
+	if !ok || u.Subscription == nil {
+		return -1
+	}
+	switch column {
+	case "allergen_analyses_used":
+		return u.Subscription.AllergenAnalysesUsed
+	case "web_searches_used":
+		return u.Subscription.WebSearchesUsed
+	case "ai_generations_used":
+		return u.Subscription.AIGenerationsUsed
+	case "video_imports_used":
+		return u.Subscription.VideoImportsUsed
+	}
+	return -1
+}
+
+func (m *MockUserRepo) DecrementSubscriptionUsage(userID uint, column string) error {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	u, ok := m.Users[userID]
+	if !ok || u.Subscription == nil {
+		return fmt.Errorf("no subscription found for user")
+	}
+	dec := func(p *int) {
+		if *p > 0 {
+			*p--
+		}
+	}
+	switch column {
+	case "allergen_analyses_used":
+		dec(&u.Subscription.AllergenAnalysesUsed)
+	case "web_searches_used":
+		dec(&u.Subscription.WebSearchesUsed)
+	case "ai_generations_used":
+		dec(&u.Subscription.AIGenerationsUsed)
+	case "video_imports_used":
+		dec(&u.Subscription.VideoImportsUsed)
+	default:
+		return fmt.Errorf("unknown usage column: %s", column)
+	}
+	return nil
+}
+
 func (m *MockUserRepo) ResetSubscriptionUsage(userID uint, nextReset time.Time) error {
 	m.mu.Lock()
 	defer m.mu.Unlock()

--- a/internal/video/frames.go
+++ b/internal/video/frames.go
@@ -5,12 +5,14 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"net"
 	"net/http"
 	"os"
 	"os/exec"
 	"path/filepath"
 	"sort"
 	"strconv"
+	"syscall"
 	"time"
 )
 
@@ -41,9 +43,44 @@ type FrameSampler struct {
 	download func(ctx context.Context, mediaURL, dest string) error
 }
 
-// NewFrameSampler returns a sampler with sensible defaults.
+// NewFrameSampler returns a sampler with sensible defaults, including an
+// SSRF-hardened HTTP client (see newSafeHTTPClient).
 func NewFrameSampler() *FrameSampler {
-	return &FrameSampler{MaxFrames: DefaultMaxFrames, HTTP: &http.Client{Timeout: 90 * time.Second}}
+	return &FrameSampler{MaxFrames: DefaultMaxFrames, HTTP: newSafeHTTPClient()}
+}
+
+// safeDialControl rejects connections to non-public IP addresses. Used as
+// net.Dialer.Control it runs after DNS resolution with the resolved ip:port, so
+// it blocks SSRF through the initial host, any redirect hop, and DNS rebinding
+// alike — the scraper-supplied media URL is untrusted.
+func safeDialControl(_ /*network*/, address string, _ syscall.RawConn) error {
+	host, _, err := net.SplitHostPort(address)
+	if err != nil {
+		return err
+	}
+	ip := net.ParseIP(host)
+	if ip == nil {
+		return fmt.Errorf("refusing to dial unparseable address %q", address)
+	}
+	if ip.IsLoopback() || ip.IsPrivate() || ip.IsLinkLocalUnicast() || ip.IsLinkLocalMulticast() || ip.IsUnspecified() {
+		return fmt.Errorf("refusing to dial non-public address %s", ip)
+	}
+	return nil
+}
+
+// newSafeHTTPClient builds an HTTP client whose dialer blocks private/internal
+// addresses on every connection, including redirect targets.
+func newSafeHTTPClient() *http.Client {
+	dialer := &net.Dialer{Timeout: 30 * time.Second, Control: safeDialControl}
+	return &http.Client{
+		Timeout: 90 * time.Second,
+		Transport: &http.Transport{
+			DialContext:           dialer.DialContext,
+			TLSHandshakeTimeout:   15 * time.Second,
+			ResponseHeaderTimeout: 30 * time.Second,
+			MaxIdleConns:          10,
+		},
+	}
 }
 
 func (s *FrameSampler) maxFrames() int {

--- a/internal/video/frames_test.go
+++ b/internal/video/frames_test.go
@@ -108,6 +108,28 @@ func TestFrameSampler_DownloadError(t *testing.T) {
 	}
 }
 
+func TestSafeDialControl(t *testing.T) {
+	cases := []struct {
+		addr    string
+		blocked bool
+	}{
+		{"127.0.0.1:443", true},      // loopback
+		{"10.0.0.5:80", true},        // private
+		{"192.168.1.1:443", true},    // private
+		{"172.16.5.4:80", true},      // private
+		{"169.254.169.254:80", true}, // link-local (cloud metadata)
+		{"0.0.0.0:80", true},         // unspecified
+		{"8.8.8.8:443", false},       // public
+		{"203.0.113.10:443", false},  // public (TEST-NET-3)
+	}
+	for _, tc := range cases {
+		err := safeDialControl("tcp", tc.addr, nil)
+		if (err != nil) != tc.blocked {
+			t.Errorf("safeDialControl(%q): err=%v, want blocked=%v", tc.addr, err, tc.blocked)
+		}
+	}
+}
+
 func TestFrameSampler_NoFrames(t *testing.T) {
 	s := NewFrameSampler()
 	s.download = writeFakeVideo


### PR DESCRIPTION
## What

Production hardening for the two live video-import platforms (TikTok #89, Instagram #90), per the "polish what's live" direction. Three independent improvements, all backend-only:

### 1. Recipe thumbnails
Video imports had an empty `imageUrl`. Now a representative sampled frame (the **middle** one — past any intro, before any outro) is uploaded to S3 and set as the recipe's hero image. The URL is stored on `VideoExtractionCache` (**additive column**, dashboard-safe) so **cache hits reuse the same image** at no extra cost. Best-effort: an upload failure never fails the import.

### 2. Quota refunds on our-side failures
Video quota is consumed **on acceptance** (bounds concurrent-spam), but a job that later **fails on our side** (fetch error, frame sampling, extraction, at-capacity) now **refunds** the quota unit (`DecrementUsage`, floored at zero). A user never loses one of their monthly imports to an infra error — which the earlier Anthropic-credits outage showed is a real scenario.

### 3. SSRF-hardened media download
The frame sampler downloads a scraper-supplied (untrusted) media URL. Its HTTP client now blocks connections to private/internal IPs at **dial time** via `net.Dialer.Control`, which runs post-DNS-resolution — so it covers the initial host, **every redirect hop, and DNS rebinding** alike (the prior upfront `ValidateExternalURL` check was TOCTOU/redirect-blind).

## Tests (offline, race-clean)

- `TestSafeDialControl` — loopback/private/link-local/unspecified blocked; public allowed.
- `TestVideoImport_SetsThumbnail` — middle frame uploaded, set on recipe + cached.
- `TestVideoImport_CacheHitReusesThumbnail` — cache hit reuses the stored thumbnail.
- `TestVideoImport_RefundsQuotaOnFailure` — failed import refunds quota (asserted via a lock-synchronized mock getter to avoid racing the async refund).

## Schema

Adds `thumbnail_url` to `video_extraction_caches` (additive; AutoMigrate handles it). No changes to existing columns.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BU4UWZutHd1AnK3XAf7H19