### PR TITLE
Add Facebook (reels) support to video-link import

### DIFF
--- a/internal/video/scrapecreators.go
+++ b/internal/video/scrapecreators.go
@@ -114,6 +114,8 @@ func (c *ScrapeCreatorsClient) FetchVideo(ctx context.Context, rawURL string) (*
 		return c.fetchTikTok(ctx, rawURL)
 	case PlatformInstagram:
 		return c.fetchInstagram(ctx, rawURL)
+	case PlatformFacebook:
+		return c.fetchFacebook(ctx, rawURL)
 	default:
 		return nil, fmt.Errorf("platform %q not yet supported", platform)
 	}
@@ -260,6 +262,76 @@ func (c *ScrapeCreatorsClient) instagramTranscript(ctx context.Context, rawURL s
 		if t != nil && *t != "" {
 			return *t
 		}
+	}
+	return ""
+}
+
+// facebookPostResponse is the subset of the /v1/facebook/post response we use.
+type facebookPostResponse struct {
+	PostID      string `json:"post_id"`
+	Description string `json:"description"`
+	Video       struct {
+		SDURL          string  `json:"sd_url"`
+		HDURL          string  `json:"hd_url"`
+		LengthInSecond float64 `json:"length_in_second"`
+	} `json:"video"`
+}
+
+// facebookTranscriptResponse is the /v1/facebook/post/transcript response.
+type facebookTranscriptResponse struct {
+	Transcript *string `json:"transcript"`
+}
+
+func (c *ScrapeCreatorsClient) fetchFacebook(ctx context.Context, rawURL string) (*VideoMeta, error) {
+	q := url.Values{}
+	q.Set("url", rawURL)
+
+	body, err := c.get(ctx, "/v1/facebook/post", q)
+	if err != nil {
+		return nil, err
+	}
+	var r facebookPostResponse
+	if err := json.Unmarshal(body, &r); err != nil {
+		return nil, fmt.Errorf("parse facebook response: %w", err)
+	}
+	if r.PostID == "" {
+		return nil, fmt.Errorf("facebook response missing post detail")
+	}
+
+	// Prefer the smaller SD stream — it downloads faster and stays under the
+	// sampler's size cap, and frames are scaled down regardless.
+	media := r.Video.SDURL
+	if media == "" {
+		media = r.Video.HDURL
+	}
+	if media == "" {
+		return nil, fmt.Errorf("facebook post is not a downloadable video")
+	}
+
+	return &VideoMeta{
+		Platform:   PlatformFacebook,
+		VideoID:    r.PostID,
+		Caption:    r.Description,
+		Transcript: c.facebookTranscript(ctx, rawURL), // best-effort; often empty
+		MediaURL:   media,
+		DurationMS: int(math.Round(r.Video.LengthInSecond * 1000)),
+	}, nil
+}
+
+// facebookTranscript fetches a reel's spoken transcript, best-effort.
+func (c *ScrapeCreatorsClient) facebookTranscript(ctx context.Context, rawURL string) string {
+	q := url.Values{}
+	q.Set("url", rawURL)
+	body, err := c.get(ctx, "/v1/facebook/post/transcript", q)
+	if err != nil {
+		return ""
+	}
+	var r facebookTranscriptResponse
+	if err := json.Unmarshal(body, &r); err != nil {
+		return ""
+	}
+	if r.Transcript != nil {
+		return *r.Transcript
 	}
 	return ""
 }

--- a/internal/video/scrapecreators_test.go
+++ b/internal/video/scrapecreators_test.go
@@ -177,6 +177,69 @@ func TestFetchVideo_Instagram_NotAVideo(t *testing.T) {
 	}
 }
 
+func TestFetchVideo_Facebook(t *testing.T) {
+	const postFixture = `{"success":true,"post_id":"1417081470454978","description":"Civico - Focaccia & Pesto","video":{"id":"1680614736552635","sd_url":"https://video.fbcdn.net/sd.mp4","hd_url":"https://video.fbcdn.net/hd.mp4","length_in_second":109.859,"captions_url":null}}`
+	const transcriptFixture = `{"success":true,"transcript":"Mix the flour, water, and yeast, then let it rise."}`
+
+	c := NewScrapeCreatorsClient("k")
+	c.httpDo = func(req *http.Request) (*http.Response, error) {
+		body := postFixture
+		if strings.Contains(req.URL.Path, "/v1/facebook/post/transcript") {
+			body = transcriptFixture
+		}
+		return &http.Response{StatusCode: 200, Body: io.NopCloser(strings.NewReader(body))}, nil
+	}
+
+	m, err := c.FetchVideo(context.Background(), "https://www.facebook.com/reel/1680614736552635")
+	if err != nil {
+		t.Fatalf("FetchVideo error: %v", err)
+	}
+	if m.Platform != PlatformFacebook {
+		t.Errorf("platform = %q, want facebook", m.Platform)
+	}
+	if m.VideoID != "1417081470454978" {
+		t.Errorf("video id = %q, want the post_id", m.VideoID)
+	}
+	if m.Caption != "Civico - Focaccia & Pesto" {
+		t.Errorf("caption = %q", m.Caption)
+	}
+	if m.MediaURL != "https://video.fbcdn.net/sd.mp4" {
+		t.Errorf("media url = %q, want the sd_url", m.MediaURL)
+	}
+	if m.DurationMS != 109859 { // 109.859s → ms
+		t.Errorf("duration = %d ms, want 109859", m.DurationMS)
+	}
+	if m.Transcript == "" {
+		t.Error("expected the best-effort transcript to be populated")
+	}
+}
+
+func TestFetchVideo_Facebook_FallsBackToHD(t *testing.T) {
+	const fixture = `{"success":true,"post_id":"1","description":"x","video":{"hd_url":"https://video.fbcdn.net/hd.mp4","length_in_second":12.0}}`
+	c := NewScrapeCreatorsClient("k")
+	c.httpDo = func(req *http.Request) (*http.Response, error) {
+		return &http.Response{StatusCode: 200, Body: io.NopCloser(strings.NewReader(fixture))}, nil
+	}
+	m, err := c.FetchVideo(context.Background(), "https://www.facebook.com/reel/1")
+	if err != nil {
+		t.Fatalf("error: %v", err)
+	}
+	if m.MediaURL != "https://video.fbcdn.net/hd.mp4" {
+		t.Errorf("media url = %q, want hd_url fallback", m.MediaURL)
+	}
+}
+
+func TestFetchVideo_Facebook_NotAVideo(t *testing.T) {
+	const fixture = `{"success":true,"post_id":"1","description":"a photo post","video":{}}`
+	c := NewScrapeCreatorsClient("k")
+	c.httpDo = func(req *http.Request) (*http.Response, error) {
+		return &http.Response{StatusCode: 200, Body: io.NopCloser(strings.NewReader(fixture))}, nil
+	}
+	if _, err := c.FetchVideo(context.Background(), "https://www.facebook.com/reel/1"); err == nil {
+		t.Fatal("expected an error for a post with no downloadable video")
+	}
+}
+
 func TestSanitizeJSONControlChars(t *testing.T) {
 	// Raw newline + tab inside a string value → must become valid, parseable JSON.
 	raw := []byte("{\"text\":\"a\nb\tc\",\"keep\":\"x\\ny\",\"n\":7}")


### PR DESCRIPTION
## What

Third platform after TikTok (#89) and Instagram (#90): **Facebook reels**.

- **`fetchFacebook`** — `GET /v1/facebook/post` → `post_id` (VideoID), `description` (caption), `video.{sd_url, hd_url, length_in_second}`. Prefers the **SD** stream (smaller → faster download, stays under the sampler's 120 MB cap; frames are downscaled to 640px regardless), falling back to HD. Seconds → rounded ms.
- Best-effort transcript via `/v1/facebook/post/transcript` (often null, like Instagram → falls back to caption + sampled frames).

## Verified live

A `buzzfeedtasty` reel's `fbcdn` `sd_url` **downloads server-side (HTTP 206, video/mp4)** — so Facebook fits the existing frames pipeline with no special handling.

## Tests (offline)

`TestFetchVideo_Facebook` (SD preferred, seconds→ms, transcript populated), `_FallsBackToHD`, `_NotAVideo`.

## Scope note — YouTube & Pinterest are NOT in this PR

They don't fit the video-frames pipeline:
- **YouTube**: ScrapeCreators' `/v1/youtube/video` returns **no downloadable media URL** (only metadata + caption tracks).
- **Pinterest**: image-dominant — most recipe pins are images with a rich `description`, not video.

Both need a separate **transcript/description text-extraction path** (extract from text when there's no video to sample). That's a focused follow-up so this PR stays clean and verifiable.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BU4UWZutHd1AnK3XAf7H19