### PR TITLE
Add YouTube + Pinterest via a text-extraction path

### DIFF
--- a/internal/service/import_video.go
+++ b/internal/service/import_video.go
@@ -166,49 +166,68 @@ func (s *ImportService) processVideoImport(jobID uint, rawURL string, user *mode
 		}
 	}
 
-	if meta.MediaURL == "" {
-		fail("no_media", "the video could not be downloaded", fmt.Errorf("empty media url for %s", videoKey))
-		return
-	}
-	// The media URL comes from a third-party scraper; treat it as untrusted and
-	// block private/internal addresses before the sampler fetches it (SSRF).
-	if err := ValidateExternalURL(meta.MediaURL); err != nil {
-		fail("no_media", "the video could not be downloaded", err)
-		return
-	}
-
-	// 4. Sample representative frames (scene changes catch on-screen text and
-	//    flashy cuts; even sampling backs it up).
-	frames, err := s.VideoFrameSampler.Sample(ctx, meta.MediaURL, meta.DurationMS)
-	if err != nil {
-		fail("sampling_failed", "could not process the video", err)
-		return
-	}
-
-	media := make([]ai.MediaInput, 0, len(frames))
-	for _, f := range frames {
-		media = append(media, ai.MediaInput{Data: f, Kind: ai.MediaImage})
-	}
-
-	// 5. Multimodal extraction: frames + transcript/caption together.
+	// 4. Extract the recipe. Video platforms give a downloadable media URL and
+	//    go through frame sampling + multimodal extraction; text platforms
+	//    (YouTube, Pinterest) have no video to sample, so they extract from the
+	//    title/description/transcript instead.
 	contextText := buildVideoContext(meta)
 	unitSystem := user.Personalization.UnitSystemText()
-	requirements := user.Personalization.Requirements
-	results, err := s.VisionProvider.ExtractRecipesFromMedia(ctx, media, contextText, unitSystem, requirements)
-	if err != nil || len(results) == 0 {
-		fail("extraction_failed", "could not find a recipe in this video", err)
-		return
+
+	var chosen *ai.RecipeResult
+	var frames [][]byte
+
+	if meta.MediaURL != "" {
+		// The media URL comes from a third-party scraper; treat it as untrusted
+		// and block private/internal addresses before the sampler fetches it.
+		if err := ValidateExternalURL(meta.MediaURL); err != nil {
+			fail("no_media", "the video could not be downloaded", err)
+			return
+		}
+		// Scene-change frames catch on-screen text and flashy cuts; even
+		// sampling backs it up.
+		sampled, sErr := s.VideoFrameSampler.Sample(ctx, meta.MediaURL, meta.DurationMS)
+		if sErr != nil {
+			fail("sampling_failed", "could not process the video", sErr)
+			return
+		}
+		frames = sampled
+
+		media := make([]ai.MediaInput, 0, len(frames))
+		for _, f := range frames {
+			media = append(media, ai.MediaInput{Data: f, Kind: ai.MediaImage})
+		}
+		results, eErr := s.VisionProvider.ExtractRecipesFromMedia(ctx, media, contextText, unitSystem, user.Personalization.Requirements)
+		if eErr != nil || len(results) == 0 {
+			fail("extraction_failed", "could not find a recipe in this video", eErr)
+			return
+		}
+		chosen = results[0] // a single video yields a single recipe
+	} else {
+		if strings.TrimSpace(contextText) == "" {
+			fail("no_content", "this link did not contain a recipe", fmt.Errorf("no media or text for %s", videoKey))
+			return
+		}
+		if s.TextProvider == nil {
+			fail("extraction_failed", "could not find a recipe in this video", fmt.Errorf("no text provider configured"))
+			return
+		}
+		r, eErr := s.TextProvider.ExtractRecipeFromText(ctx, contextText, unitSystem)
+		if eErr != nil || r == nil {
+			fail("extraction_failed", "could not find a recipe in this video", eErr)
+			return
+		}
+		chosen = r
 	}
 
-	// A single video yields a single recipe; take the most prominent.
-	def := recipeResultToRecipeDef(results[0])
+	def := recipeResultToRecipeDef(chosen)
 	def.SourceURL = rawURL
 	ensureUnitSystem(&def)
 
-	// Use a representative frame as the recipe thumbnail (best-effort).
+	// Use a representative frame as the recipe thumbnail (best-effort; the text
+	// path has no frames, so this is a no-op there).
 	thumbnailURL := s.uploadVideoThumbnail(ctx, frames, videoKey)
 
-	_, recipeID, createErr := s.createImportedRecipe(ctx, &def, user, models.RecipeTypeImportVideo, rawURL, thumbnailURL, nil, results[0].Hashtags, results[0].PromptVersion)
+	_, recipeID, createErr := s.createImportedRecipe(ctx, &def, user, models.RecipeTypeImportVideo, rawURL, thumbnailURL, nil, chosen.Hashtags, chosen.PromptVersion)
 	if createErr != nil {
 		fail("save_failed", "could not save the recipe", createErr)
 		return
@@ -225,7 +244,7 @@ func (s *ImportService) processVideoImport(jobID uint, rawURL string, user *mode
 		ThumbnailURL:   thumbnailURL,
 		FetchedAt:      now,
 		LastAccessedAt: now,
-		PromptVersion:  results[0].PromptVersion,
+		PromptVersion:  chosen.PromptVersion,
 	}
 	if err := s.VideoRepo.UpsertCache(cacheEntry); err != nil {
 		log.Warn("failed to cache video extraction", zap.Error(err))

--- a/internal/service/import_video_test.go
+++ b/internal/service/import_video_test.go
@@ -356,6 +356,61 @@ func TestVideoImport_RefundsQuotaOnFailure(t *testing.T) {
 	}
 }
 
+func TestVideoImport_TextPath(t *testing.T) {
+	repo := testutil.NewMockRecipeRepo()
+	vrepo := testutil.NewMockVideoImportRepo()
+	svc := newVideoTestService(repo, vrepo)
+
+	// A YouTube-style result: no downloadable media, recipe in the text.
+	svc.VideoFetcher = &fakeVideoFetcher{meta: &video.VideoMeta{
+		Platform: video.PlatformYouTube,
+		VideoID:  "yt123",
+		Caption:  "Honey Garlic Chicken\n\n5 ingredients: chicken, honey, garlic, soy, butter.",
+		MediaURL: "", // text path
+	}}
+	sampler := &fakeFrameSampler{}
+	svc.VideoFrameSampler = sampler
+
+	visionCalls := 0
+	svc.VisionProvider = &testutil.MockVisionProvider{
+		ExtractRecipesFromMediaFunc: func(ctx context.Context, media []ai.MediaInput, contextText, unitSystem, requirements string) ([]*ai.RecipeResult, error) {
+			visionCalls++
+			return nil, nil
+		},
+	}
+	var gotText string
+	svc.TextProvider = &testutil.MockTextProvider{
+		ExtractRecipeFromTextFunc: func(ctx context.Context, text, unitSystem string) (*ai.RecipeResult, error) {
+			gotText = text
+			return testutil.TestRecipeResult(), nil
+		},
+	}
+
+	job, err := svc.StartVideoImport(context.Background(), "https://www.youtube.com/watch?v=yt123", testutil.TestUser())
+	if err != nil {
+		t.Fatalf("StartVideoImport: %v", err)
+	}
+	done := waitForVideoJob(t, svc, job.ID)
+	if done.Status != models.VideoImportDone || done.RecipeID == nil {
+		t.Fatalf("status=%q recipe=%v, want done with a recipe", done.Status, done.RecipeID)
+	}
+	if sampler.calls != 0 {
+		t.Errorf("frame sampler called %d times on text path, want 0", sampler.calls)
+	}
+	if visionCalls != 0 {
+		t.Errorf("vision called %d times on text path, want 0", visionCalls)
+	}
+	if !strings.Contains(gotText, "Honey Garlic Chicken") {
+		t.Errorf("text extraction input = %q, want the caption", gotText)
+	}
+	if got := repo.Recipes[*done.RecipeID].ImageURL; got != "" {
+		t.Errorf("text-path recipe should have no thumbnail, got %q", got)
+	}
+	if done.CostUSD <= 0 || done.CostUSD > 0.05 {
+		t.Errorf("text-path cost = %v, want ~the flat text overhead", done.CostUSD)
+	}
+}
+
 func TestVideoImport_FetchFailed(t *testing.T) {
 	repo := testutil.NewMockRecipeRepo()
 	vrepo := testutil.NewMockVideoImportRepo()

--- a/internal/video/scrapecreators.go
+++ b/internal/video/scrapecreators.go
@@ -116,6 +116,10 @@ func (c *ScrapeCreatorsClient) FetchVideo(ctx context.Context, rawURL string) (*
 		return c.fetchInstagram(ctx, rawURL)
 	case PlatformFacebook:
 		return c.fetchFacebook(ctx, rawURL)
+	case PlatformYouTube:
+		return c.fetchYouTube(ctx, rawURL)
+	case PlatformPinterest:
+		return c.fetchPinterest(ctx, rawURL)
 	default:
 		return nil, fmt.Errorf("platform %q not yet supported", platform)
 	}
@@ -334,6 +338,96 @@ func (c *ScrapeCreatorsClient) facebookTranscript(ctx context.Context, rawURL st
 		return *r.Transcript
 	}
 	return ""
+}
+
+// youtubeVideoResponse is the subset of the /v1/youtube/video response we use.
+// YouTube exposes no downloadable media here, so the recipe is extracted from
+// the title + description (which recipe channels routinely fill out).
+type youtubeVideoResponse struct {
+	ID          string `json:"id"`
+	Title       string `json:"title"`
+	Description string `json:"description"`
+	DurationMs  int    `json:"durationMs"`
+}
+
+func (c *ScrapeCreatorsClient) fetchYouTube(ctx context.Context, rawURL string) (*VideoMeta, error) {
+	q := url.Values{}
+	q.Set("url", rawURL)
+
+	body, err := c.get(ctx, "/v1/youtube/video", q)
+	if err != nil {
+		return nil, err
+	}
+	var r youtubeVideoResponse
+	if err := json.Unmarshal(body, &r); err != nil {
+		return nil, fmt.Errorf("parse youtube response: %w", err)
+	}
+	if r.ID == "" {
+		return nil, fmt.Errorf("youtube response missing video detail")
+	}
+
+	return &VideoMeta{
+		Platform:   PlatformYouTube,
+		VideoID:    r.ID,
+		Caption:    joinTitleDescription(r.Title, r.Description),
+		MediaURL:   "", // no downloadable media → text-extraction path
+		DurationMS: r.DurationMs,
+	}, nil
+}
+
+// pinterestPinResponse is the subset of the /v1/pinterest/pin response we use.
+// Recipe pins are description-driven (most are images, not video), so we
+// extract from the title + description text.
+type pinterestPinResponse struct {
+	EntityID           string `json:"entityId"`
+	Title              string `json:"title"`
+	Description        string `json:"description"`
+	CloseupDescription string `json:"closeupDescription"`
+}
+
+func (c *ScrapeCreatorsClient) fetchPinterest(ctx context.Context, rawURL string) (*VideoMeta, error) {
+	q := url.Values{}
+	q.Set("url", rawURL)
+
+	body, err := c.get(ctx, "/v1/pinterest/pin", q)
+	if err != nil {
+		return nil, err
+	}
+	var r pinterestPinResponse
+	if err := json.Unmarshal(body, &r); err != nil {
+		return nil, fmt.Errorf("parse pinterest response: %w", err)
+	}
+	if r.EntityID == "" {
+		return nil, fmt.Errorf("pinterest response missing pin detail")
+	}
+
+	desc := r.Description
+	if desc == "" {
+		desc = r.CloseupDescription
+	}
+
+	return &VideoMeta{
+		Platform:   PlatformPinterest,
+		VideoID:    r.EntityID,
+		Caption:    joinTitleDescription(r.Title, desc),
+		MediaURL:   "", // pins are description-driven → text-extraction path
+		DurationMS: 0,
+	}, nil
+}
+
+// joinTitleDescription combines a title and description into a single text
+// block, dropping either if empty.
+func joinTitleDescription(title, description string) string {
+	t := strings.TrimSpace(title)
+	d := strings.TrimSpace(description)
+	switch {
+	case t != "" && d != "":
+		return t + "\n\n" + d
+	case t != "":
+		return t
+	default:
+		return d
+	}
 }
 
 // sanitizeJSONControlChars escapes raw control characters (U+0000–U+001F) that

--- a/internal/video/scrapecreators_test.go
+++ b/internal/video/scrapecreators_test.go
@@ -240,6 +240,66 @@ func TestFetchVideo_Facebook_NotAVideo(t *testing.T) {
 	}
 }
 
+func TestFetchVideo_YouTube(t *testing.T) {
+	const fixture = `{"success":true,"id":"b5-8lr_F8dM","title":"Honey Garlic Chicken","description":"5 ingredients: chicken, honey, garlic, soy sauce, butter. Ready in 20 minutes.","durationMs":32000,"durationFormatted":"00:00:32"}`
+	c := NewScrapeCreatorsClient("k")
+	var gotURL string
+	c.httpDo = func(req *http.Request) (*http.Response, error) {
+		gotURL = req.URL.String()
+		return &http.Response{StatusCode: 200, Body: io.NopCloser(strings.NewReader(fixture))}, nil
+	}
+
+	m, err := c.FetchVideo(context.Background(), "https://www.youtube.com/watch?v=b5-8lr_F8dM")
+	if err != nil {
+		t.Fatalf("FetchVideo error: %v", err)
+	}
+	if !strings.Contains(gotURL, "/v1/youtube/video") {
+		t.Errorf("request URL = %q", gotURL)
+	}
+	if m.Platform != PlatformYouTube {
+		t.Errorf("platform = %q, want youtube", m.Platform)
+	}
+	if m.VideoID != "b5-8lr_F8dM" {
+		t.Errorf("video id = %q", m.VideoID)
+	}
+	if !strings.Contains(m.Caption, "Honey Garlic Chicken") ||
+		!strings.Contains(m.Caption, "5 ingredients") {
+		t.Errorf("caption should combine title + description: %q", m.Caption)
+	}
+	if m.MediaURL != "" {
+		t.Errorf("media url = %q, want empty (text path)", m.MediaURL)
+	}
+	if m.DurationMS != 32000 {
+		t.Errorf("duration = %d, want 32000", m.DurationMS)
+	}
+}
+
+func TestFetchVideo_Pinterest(t *testing.T) {
+	const fixture = `{"success":true,"entityId":"1124351863225567517","title":"Cowboy Butter Chicken Linguine","description":"Tender chicken tossed in a rich, buttery garlic sauce over linguine.","closeupDescription":null}`
+	c := NewScrapeCreatorsClient("k")
+	c.httpDo = func(req *http.Request) (*http.Response, error) {
+		return &http.Response{StatusCode: 200, Body: io.NopCloser(strings.NewReader(fixture))}, nil
+	}
+
+	m, err := c.FetchVideo(context.Background(), "https://www.pinterest.com/pin/1124351863225567517/")
+	if err != nil {
+		t.Fatalf("FetchVideo error: %v", err)
+	}
+	if m.Platform != PlatformPinterest {
+		t.Errorf("platform = %q, want pinterest", m.Platform)
+	}
+	if m.VideoID != "1124351863225567517" {
+		t.Errorf("video id = %q, want the entityId", m.VideoID)
+	}
+	if !strings.Contains(m.Caption, "Cowboy Butter Chicken Linguine") ||
+		!strings.Contains(m.Caption, "buttery garlic sauce") {
+		t.Errorf("caption should combine title + description: %q", m.Caption)
+	}
+	if m.MediaURL != "" {
+		t.Errorf("media url = %q, want empty (text path)", m.MediaURL)
+	}
+}
+
 func TestSanitizeJSONControlChars(t *testing.T) {
 	// Raw newline + tab inside a string value → must become valid, parseable JSON.
 	raw := []byte("{\"text\":\"a\nb\tc\",\"keep\":\"x\\ny\",\"n\":7}")


### PR DESCRIPTION
## What

Completes platform coverage. TikTok/Instagram/Facebook sample video frames, but **YouTube** exposes no downloadable media (ScrapeCreators returns metadata only) and **Pinterest** is image-dominant. Both carry the recipe in their **title + description**, so this adds a media-less *text-extraction* path.

- **Orchestration**: when `FetchVideo` returns no `MediaURL`, extract the recipe from the title/description/transcript via `TextProvider.ExtractRecipeFromText` instead of sampling frames. Video platforms are unchanged. Cost is just the flat text overhead (no frame cost); no thumbnail (no frames to grab one from).
- **`fetchYouTube`**: `GET /v1/youtube/video` → `id`, `title`, `description`, `durationMs`; caption = title + description. (No transcript call — that endpoint is unreliable and the description carries the recipe for cooking channels.)
- **`fetchPinterest`**: `GET /v1/pinterest/pin` → `entityId`, `title`, `description`/`closeupDescription`; caption = title + description.

**All five platforms (TikTok, Instagram, Facebook, YouTube, Pinterest) now resolve.**

## Tests (offline, race-clean)

- YouTube + Pinterest client parsing (caption = title+description, `MediaURL` empty, duration).
- Text-path orchestration: asserts the frame sampler and vision provider are **not** called, the recipe is created from `ExtractRecipeFromText`, there's no thumbnail, and the cost is just the flat text overhead.

## Follow-ups

- Pinterest *video* pins (rare) and the YouTube transcript endpoint could later enrich the text path; the description-based extraction covers the common case today.
- Live e2e for Facebook + YouTube + Pinterest after this deploys.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BU4UWZutHd1AnK3XAf7H19