### PR TITLE
Add a gated Whisper fallback for thin frames extractions

### DIFF
--- a/internal/handlers/import_video_handler_test.go
+++ b/internal/handlers/import_video_handler_test.go
@@ -34,6 +34,10 @@ func (f *fakeFrameSampler) Sample(ctx context.Context, mediaURL string, duration
 	return [][]byte{{0xFF, 0xD8, 0x01}, {0xFF, 0xD8, 0x02}}, nil
 }
 
+func (f *fakeFrameSampler) ExtractAudio(ctx context.Context, mediaURL string) ([]byte, error) {
+	return nil, nil
+}
+
 // videoEnabledHandler builds an ImportHandler whose service has the video
 // dependencies wired with fakes, plus a SubscriptionService for gating.
 func videoEnabledHandler(repo *testutil.MockRecipeRepo, vrepo *testutil.MockVideoImportRepo, userRepo *testutil.MockUserRepo) *ImportHandler {

--- a/internal/service/import_video.go
+++ b/internal/service/import_video.go
@@ -20,10 +20,12 @@ type VideoFetcher interface {
 	FetchVideo(ctx context.Context, rawURL string) (*video.VideoMeta, error)
 }
 
-// VideoFrameSampler downloads a video and returns representative JPEG frames.
-// Satisfied by *video.FrameSampler.
+// VideoFrameSampler downloads a video and returns representative JPEG frames,
+// and (for the last-resort Whisper escalation) its audio track. Satisfied by
+// *video.FrameSampler.
 type VideoFrameSampler interface {
 	Sample(ctx context.Context, mediaURL string, durationMS int) ([][]byte, error)
+	ExtractAudio(ctx context.Context, mediaURL string) ([]byte, error)
 }
 
 const (
@@ -34,15 +36,37 @@ const (
 	// videoTextOverheadUSD is a conservative flat allowance for the transcript/
 	// caption input tokens plus the extraction's output tokens.
 	videoTextOverheadUSD = 0.02
+	// whisperCostPerMin is OpenAI Whisper's per-minute transcription price.
+	whisperCostPerMin = 0.006
 	// videoProcessTimeout bounds the whole async pipeline for one fresh import.
 	videoProcessTimeout = 5 * time.Minute
 )
 
 // estimateVideoCost approximates the metered spend of a fresh video extraction.
 // It is intentionally an over-estimate so the daily-budget kill switch trips
-// early rather than late. Cache hits cost nothing and are recorded as 0.
-func estimateVideoCost(numFrames int) float64 {
-	return float64(numFrames)*sonnetCostPerFrame + videoTextOverheadUSD
+// early rather than late. When the Whisper fallback fired, the frames are
+// re-sent on a second extraction and audio is transcribed, so both are added.
+// Cache hits cost nothing and are recorded as 0.
+func estimateVideoCost(numFrames int, usedWhisper bool, durationMS int) float64 {
+	cost := float64(numFrames)*sonnetCostPerFrame + videoTextOverheadUSD
+	if usedWhisper {
+		cost += float64(numFrames)*sonnetCostPerFrame + videoTextOverheadUSD // re-extraction
+		cost += (float64(durationMS) / 60000.0) * whisperCostPerMin
+	}
+	return cost
+}
+
+// recipeNeedsMoreContext reports whether a frames+caption extraction produced a
+// plausible recipe (a titled dish with at least one ingredient — so a recipe
+// clearly exists) that is nonetheless too thin to trust (few ingredients or no
+// steps). It gates the Whisper fallback: true means "a recipe is there but we
+// need more detail"; false means either a solid recipe or no recipe at all
+// (don't waste Whisper on a video that likely has no recipe to fetch).
+func recipeNeedsMoreContext(r *ai.RecipeResult) bool {
+	if r == nil || r.Title == "" || len(r.Ingredients) == 0 {
+		return false
+	}
+	return len(r.Ingredients) < 4 || len(r.Instructions) < 2
 }
 
 // videoImportConfigured reports whether the video-import dependencies are wired.
@@ -175,6 +199,7 @@ func (s *ImportService) processVideoImport(jobID uint, rawURL string, user *mode
 
 	var chosen *ai.RecipeResult
 	var frames [][]byte
+	usedWhisper := false
 
 	if meta.MediaURL != "" {
 		// The media URL comes from a third-party scraper; treat it as untrusted
@@ -202,6 +227,24 @@ func (s *ImportService) processVideoImport(jobID uint, rawURL string, user *mode
 			return
 		}
 		chosen = results[0] // a single video yields a single recipe
+
+		// Last-resort Whisper: only when the frames+caption pass yielded a
+		// plausible-but-thin recipe AND the scraper gave no transcript to work
+		// with. The spoken audio is then the only untapped source of detail.
+		// Gated this tightly so Whisper never runs on the common (good) path
+		// nor on videos that likely have no recipe at all.
+		if s.SpeechProvider != nil && meta.Transcript == "" && recipeNeedsMoreContext(chosen) {
+			if audio, aErr := s.VideoFrameSampler.ExtractAudio(ctx, meta.MediaURL); aErr == nil && len(audio) > 0 {
+				if transcript, tErr := s.SpeechProvider.TranscribeAudio(ctx, audio, "m4a"); tErr == nil && strings.TrimSpace(transcript) != "" {
+					meta.Transcript = transcript
+					if results2, e2 := s.VisionProvider.ExtractRecipesFromMedia(ctx, media, buildVideoContext(meta), unitSystem, user.Personalization.Requirements); e2 == nil && len(results2) > 0 {
+						chosen = results2[0]
+						usedWhisper = true
+						log.Info("video import used the whisper fallback for extra context", zap.String("video_key", videoKey))
+					}
+				}
+			}
+		}
 	} else {
 		if strings.TrimSpace(contextText) == "" {
 			fail("no_content", "this link did not contain a recipe", fmt.Errorf("no media or text for %s", videoKey))
@@ -252,7 +295,7 @@ func (s *ImportService) processVideoImport(jobID uint, rawURL string, user *mode
 
 	job.Status = models.VideoImportDone
 	job.RecipeID = &recipeID
-	job.CostUSD = estimateVideoCost(len(frames))
+	job.CostUSD = estimateVideoCost(len(frames), usedWhisper, meta.DurationMS)
 	job.CacheHit = false
 	if err := s.VideoRepo.UpdateImport(job); err != nil {
 		log.Error("failed to persist completed video import", zap.Error(err))

--- a/internal/service/import_video_test.go
+++ b/internal/service/import_video_test.go
@@ -28,14 +28,22 @@ func (f *fakeVideoFetcher) FetchVideo(ctx context.Context, rawURL string) (*vide
 }
 
 type fakeFrameSampler struct {
-	frames [][]byte
-	err    error
-	calls  int
+	frames     [][]byte
+	err        error
+	calls      int
+	audio      []byte
+	audioErr   error
+	audioCalls int
 }
 
 func (f *fakeFrameSampler) Sample(ctx context.Context, mediaURL string, durationMS int) ([][]byte, error) {
 	f.calls++
 	return f.frames, f.err
+}
+
+func (f *fakeFrameSampler) ExtractAudio(ctx context.Context, mediaURL string) ([]byte, error) {
+	f.audioCalls++
+	return f.audio, f.audioErr
 }
 
 func tiktokMeta() *video.VideoMeta {
@@ -408,6 +416,139 @@ func TestVideoImport_TextPath(t *testing.T) {
 	}
 	if done.CostUSD <= 0 || done.CostUSD > 0.05 {
 		t.Errorf("text-path cost = %v, want ~the flat text overhead", done.CostUSD)
+	}
+}
+
+func TestVideoImport_WhisperEscalation(t *testing.T) {
+	repo := testutil.NewMockRecipeRepo()
+	vrepo := testutil.NewMockVideoImportRepo()
+	svc := newVideoTestService(repo, vrepo)
+
+	// No scraper transcript → the spoken audio is the only untapped source.
+	svc.VideoFetcher = &fakeVideoFetcher{meta: &video.VideoMeta{
+		Platform:   video.PlatformInstagram,
+		VideoID:    "ig1",
+		Caption:    "quick dinner",
+		Transcript: "",
+		MediaURL:   "https://203.0.113.10/v.mp4",
+		DurationMS: 60000,
+	}}
+	sampler := &fakeFrameSampler{frames: [][]byte{{0xFF, 1}, {0xFF, 2}}, audio: []byte("aac-bytes")}
+	svc.VideoFrameSampler = sampler
+
+	visionCalls := 0
+	svc.VisionProvider = &testutil.MockVisionProvider{
+		ExtractRecipesFromMediaFunc: func(ctx context.Context, media []ai.MediaInput, contextText, unitSystem, requirements string) ([]*ai.RecipeResult, error) {
+			visionCalls++
+			if visionCalls == 1 {
+				// Thin but plausible: a titled dish with a single ingredient.
+				return []*ai.RecipeResult{{Title: "Mystery Dish", Ingredients: []ai.IngredientResult{{Name: "chicken"}}}}, nil
+			}
+			if !strings.Contains(contextText, "stir for five minutes") {
+				t.Errorf("re-extraction context missing the whisper transcript: %q", contextText)
+			}
+			return []*ai.RecipeResult{testutil.TestRecipeResult()}, nil
+		},
+	}
+	whisperCalls := 0
+	svc.SpeechProvider = &testutil.MockSpeechProvider{
+		TranscribeAudioFunc: func(ctx context.Context, data []byte, format string) (string, error) {
+			whisperCalls++
+			if format != "m4a" {
+				t.Errorf("transcribe format = %q, want m4a", format)
+			}
+			return "Add the chicken and stir for five minutes.", nil
+		},
+	}
+
+	job, err := svc.StartVideoImport(context.Background(), "https://www.instagram.com/reel/ig1/", testutil.TestUser())
+	if err != nil {
+		t.Fatalf("StartVideoImport: %v", err)
+	}
+	done := waitForVideoJob(t, svc, job.ID)
+	if done.Status != models.VideoImportDone {
+		t.Fatalf("status=%q (%s)", done.Status, done.Error)
+	}
+	if whisperCalls != 1 {
+		t.Errorf("whisper called %d times, want 1", whisperCalls)
+	}
+	if sampler.audioCalls != 1 {
+		t.Errorf("ExtractAudio called %d times, want 1", sampler.audioCalls)
+	}
+	if visionCalls != 2 {
+		t.Errorf("vision called %d times, want 2 (initial + re-extraction)", visionCalls)
+	}
+	if done.CostUSD <= estimateVideoCost(2, false, 60000) {
+		t.Errorf("cost %v should exceed the non-whisper estimate (whisper + re-extraction)", done.CostUSD)
+	}
+}
+
+func TestVideoImport_NoWhisperWhenResultIsSolid(t *testing.T) {
+	repo := testutil.NewMockRecipeRepo()
+	vrepo := testutil.NewMockVideoImportRepo()
+	svc := newVideoTestService(repo, vrepo)
+	svc.VideoFetcher = &fakeVideoFetcher{meta: &video.VideoMeta{
+		Platform: video.PlatformInstagram, VideoID: "ig2", Caption: "dinner",
+		Transcript: "", MediaURL: "https://203.0.113.10/v.mp4", DurationMS: 30000,
+	}}
+	sampler := &fakeFrameSampler{frames: [][]byte{{0xFF, 1}}, audio: []byte("aac")}
+	svc.VideoFrameSampler = sampler
+	svc.VisionProvider = &testutil.MockVisionProvider{
+		ExtractRecipesFromMediaFunc: func(ctx context.Context, media []ai.MediaInput, contextText, unitSystem, requirements string) ([]*ai.RecipeResult, error) {
+			return []*ai.RecipeResult{testutil.TestRecipeResult()}, nil // 4 ingredients, 3 steps → solid
+		},
+	}
+	svc.SpeechProvider = &testutil.MockSpeechProvider{
+		TranscribeAudioFunc: func(ctx context.Context, data []byte, format string) (string, error) {
+			t.Error("whisper should NOT run when the first extraction is solid")
+			return "", nil
+		},
+	}
+	job, err := svc.StartVideoImport(context.Background(), "https://www.instagram.com/reel/ig2/", testutil.TestUser())
+	if err != nil {
+		t.Fatalf("StartVideoImport: %v", err)
+	}
+	done := waitForVideoJob(t, svc, job.ID)
+	if done.Status != models.VideoImportDone {
+		t.Fatalf("status=%q", done.Status)
+	}
+	if sampler.audioCalls != 0 {
+		t.Errorf("ExtractAudio called %d times, want 0", sampler.audioCalls)
+	}
+}
+
+func TestVideoImport_NoWhisperWhenTranscriptPresent(t *testing.T) {
+	repo := testutil.NewMockRecipeRepo()
+	vrepo := testutil.NewMockVideoImportRepo()
+	svc := newVideoTestService(repo, vrepo)
+	svc.VideoFetcher = &fakeVideoFetcher{meta: &video.VideoMeta{
+		Platform: video.PlatformTikTok, VideoID: "tt1", Caption: "dinner",
+		Transcript: "the scraper already provided the words", // present → don't tap audio
+		MediaURL:   "https://203.0.113.10/v.mp4", DurationMS: 30000,
+	}}
+	sampler := &fakeFrameSampler{frames: [][]byte{{0xFF, 1}}, audio: []byte("aac")}
+	svc.VideoFrameSampler = sampler
+	svc.VisionProvider = &testutil.MockVisionProvider{
+		ExtractRecipesFromMediaFunc: func(ctx context.Context, media []ai.MediaInput, contextText, unitSystem, requirements string) ([]*ai.RecipeResult, error) {
+			return []*ai.RecipeResult{{Title: "Thin", Ingredients: []ai.IngredientResult{{Name: "x"}}}}, nil // thin
+		},
+	}
+	svc.SpeechProvider = &testutil.MockSpeechProvider{
+		TranscribeAudioFunc: func(ctx context.Context, data []byte, format string) (string, error) {
+			t.Error("whisper should NOT run when a transcript already exists")
+			return "", nil
+		},
+	}
+	job, err := svc.StartVideoImport(context.Background(), "https://www.tiktok.com/@x/video/tt1", testutil.TestUser())
+	if err != nil {
+		t.Fatalf("StartVideoImport: %v", err)
+	}
+	done := waitForVideoJob(t, svc, job.ID)
+	if done.Status != models.VideoImportDone {
+		t.Fatalf("status=%q", done.Status)
+	}
+	if sampler.audioCalls != 0 {
+		t.Errorf("ExtractAudio called %d times, want 0", sampler.audioCalls)
 	}
 }
 

--- a/internal/video/frames.go
+++ b/internal/video/frames.go
@@ -133,6 +133,52 @@ func (s *FrameSampler) Sample(ctx context.Context, mediaURL string, durationMS i
 	return frames, nil
 }
 
+// ExtractAudio downloads mediaURL and returns its audio as a mono 16 kHz m4a
+// (small, Whisper-friendly). It re-downloads the media rather than reusing a
+// Sample download so the common path never pays for audio it won't use — this
+// runs only on the rare last-resort Whisper escalation.
+func (s *FrameSampler) ExtractAudio(ctx context.Context, mediaURL string) ([]byte, error) {
+	dir, err := os.MkdirTemp("", "vidaudio-*")
+	if err != nil {
+		return nil, err
+	}
+	defer os.RemoveAll(dir)
+
+	videoPath := filepath.Join(dir, "video.mp4")
+	dl := s.download
+	if dl == nil {
+		dl = s.httpDownload
+	}
+	if err := dl(ctx, mediaURL, videoPath); err != nil {
+		return nil, fmt.Errorf("download for audio: %w", err)
+	}
+
+	run := s.runFFmpeg
+	if run == nil {
+		run = realFFmpeg
+	}
+	audioPath := filepath.Join(dir, "audio.m4a")
+	if err := run(ctx, audioArgs(videoPath, audioPath)); err != nil {
+		return nil, fmt.Errorf("ffmpeg audio extraction: %w", err)
+	}
+
+	b, err := os.ReadFile(audioPath)
+	if err != nil {
+		return nil, err
+	}
+	if len(b) == 0 {
+		return nil, errors.New("extracted empty audio")
+	}
+	return b, nil
+}
+
+func audioArgs(inPath, outPath string) []string {
+	return []string{
+		"-hide_banner", "-loglevel", "error", "-i", inPath,
+		"-vn", "-ac", "1", "-ar", "16000", "-c:a", "aac", "-b:a", "64k", "-y", outPath,
+	}
+}
+
 // computeFPS returns the sampling rate (frames/sec) for even sampling so that a
 // video of the given duration yields about maxFrames frames, clamped to a sane
 // range for very short or very long videos.

--- a/internal/video/frames_test.go
+++ b/internal/video/frames_test.go
@@ -108,6 +108,31 @@ func TestFrameSampler_DownloadError(t *testing.T) {
 	}
 }
 
+func TestFrameSampler_ExtractAudio(t *testing.T) {
+	s := NewFrameSampler()
+	s.download = writeFakeVideo
+	s.runFFmpeg = func(ctx context.Context, args []string) error {
+		out := args[len(args)-1] // the audio output path
+		return os.WriteFile(out, []byte("fake-audio-bytes"), 0o600)
+	}
+	audio, err := s.ExtractAudio(context.Background(), "https://x/v.mp4")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(audio) != "fake-audio-bytes" {
+		t.Errorf("audio = %q, want the extracted bytes", audio)
+	}
+}
+
+func TestFrameSampler_ExtractAudio_DownloadError(t *testing.T) {
+	s := NewFrameSampler()
+	s.download = func(ctx context.Context, url, dest string) error { return fmt.Errorf("boom") }
+	s.runFFmpeg = func(ctx context.Context, args []string) error { return nil }
+	if _, err := s.ExtractAudio(context.Background(), "https://x/v.mp4"); err == nil {
+		t.Fatal("expected error on download failure")
+	}
+}
+
 func TestSafeDialControl(t *testing.T) {
 	cases := []struct {
 		addr    string


### PR DESCRIPTION
## What

A **last-resort** Whisper escalation, per the requirement that it only run as an edge-case backstop — never on the common path, and never on a video that likely has no recipe.

When a frames+caption extraction comes back thin, transcribe the spoken audio for the missing detail and re-extract. Escalation requires **all** of:

1. The first pass yielded a **plausible recipe** (titled dish + ≥1 ingredient) — so a recipe clearly exists ("don't Whisper a non-recipe").
2. …but it's **thin** (< 4 ingredients or < 2 steps) — extra context is genuinely needed.
3. The scraper returned **no transcript** — the spoken audio is the only untapped source. (TikTok usually has a transcript → won't escalate; Instagram/Facebook often don't → will, when thin.)

Then it pulls the audio (`FrameSampler.ExtractAudio`: re-download + ffmpeg → mono 16 kHz m4a, only on this rare path so the common path pays nothing), runs Whisper, and re-extracts with the transcript added.

## Cost

`estimateVideoCost` now accounts for the escalation: the frames are re-sent on the second extraction, plus Whisper's per-minute price. The tight gate keeps this rare, and the daily-budget kill switch still bounds it.

## Tests (offline, race-clean)

- `ExtractAudio` (+ download-error).
- Escalation **fires** on thin + no-transcript (asserts audio pulled, Whisper called once, two extractions, transcript threaded into the re-extraction, higher cost).
- Escalation does **not** fire when the first result is solid, nor when a transcript already exists.

ffmpeg is already in the runtime image (PR #88), so no Dockerfile change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BU4UWZutHd1AnK3XAf7H19