### PR TITLE
Serve single-recipe previews from cache (stop re-extracting on every open)

### DIFF
--- a/internal/handlers/import.go
+++ b/internal/handlers/import.go
@@ -557,6 +557,9 @@ func (h *ImportHandler) PreviewFromURL(c *gin.Context) {
 	if result.Recipe != nil && result.Recipe.UnitSystem != "" {
 		response["unit_system"] = result.Recipe.UnitSystem
 	}
+	if result.FromCache {
+		response["from_cache"] = true
+	}
 	c.JSON(http.StatusOK, response)
 }
 

--- a/internal/models/canonical_recipe.go
+++ b/internal/models/canonical_recipe.go
@@ -28,4 +28,10 @@ type CanonicalRecipe struct {
 	FetchedAt        time.Time        `gorm:"index;not null"`
 	Embedding        *string          `gorm:"type:vector(1536)" json:"-"`
 	PromptVersion    string           `gorm:"size:16"`
+	// IsMultiPage marks this URL as a collection/listicle (an index of links to
+	// separate recipes) rather than a single recipe. Such rows are markers with
+	// empty RecipeData and must never be served as a recipe — they keep
+	// collection URLs out of the single-recipe cache fast path so they still
+	// expand into their individual recipes.
+	IsMultiPage bool `gorm:"default:false"`
 }

--- a/internal/repository/canonical_recipe.go
+++ b/internal/repository/canonical_recipe.go
@@ -42,7 +42,7 @@ func (r *CanonicalRecipeRepository) GetByNormalizedURL(normalizedURL string) (*m
 func (r *CanonicalRecipeRepository) Upsert(entry *models.CanonicalRecipe) error {
 	return r.DB.Clauses(clause.OnConflict{
 		Columns:   []clause.Column{{Name: "normalized_url"}},
-		DoUpdates: clause.AssignmentColumns([]string{"recipe_data", "extraction_method", "fetched_at", "last_accessed_at", "original_url", "embedding", "prompt_version"}),
+		DoUpdates: clause.AssignmentColumns([]string{"recipe_data", "extraction_method", "fetched_at", "last_accessed_at", "original_url", "embedding", "prompt_version", "is_multi_page"}),
 	}).Create(entry).Error
 }
 

--- a/internal/service/import.go
+++ b/internal/service/import.go
@@ -162,7 +162,7 @@ func (s *ImportService) ImportFromURL(ctx context.Context, rawURL string, user *
 	if s.CanonicalRepo != nil {
 		normalizedURL, normErr := NormalizeURL(rawURL)
 		if normErr == nil {
-			if canonical, err := s.CanonicalRepo.GetByNormalizedURL(normalizedURL); err == nil {
+			if canonical, err := s.CanonicalRepo.GetByNormalizedURL(normalizedURL); err == nil && !canonical.IsMultiPage {
 				log.Info("import from canonical cache hit")
 				go s.CanonicalRepo.IncrementHitCount(canonical.ID)
 				canonicalID := canonical.ID
@@ -763,6 +763,10 @@ type PreviewResult struct {
 	IsMulti     bool              `json:"is_multi"`
 	MultiID     string            `json:"multi_id,omitempty"`
 	MultiCards  []MultiRecipeCard `json:"recipes,omitempty"`
+	// FromCache is true when the recipe was served from the canonical cache
+	// (an instant load), so the client can show "loading saved recipe" rather
+	// than an "extracting" state.
+	FromCache bool `json:"from_cache,omitempty"`
 }
 
 // PreviewFromURL fetches a page and extracts recipe data without saving.
@@ -779,7 +783,7 @@ func (s *ImportService) PreviewFromURL(ctx context.Context, rawURL string) (*mod
 	if s.CanonicalRepo != nil {
 		normalizedURL, normErr := NormalizeURL(rawURL)
 		if normErr == nil {
-			if canonical, err := s.CanonicalRepo.GetByNormalizedURL(normalizedURL); err == nil {
+			if canonical, err := s.CanonicalRepo.GetByNormalizedURL(normalizedURL); err == nil && !canonical.IsMultiPage {
 				log.Info("preview canonical cache hit")
 				go s.CanonicalRepo.IncrementHitCount(canonical.ID)
 				data := canonical.RecipeData
@@ -847,25 +851,13 @@ func (s *ImportService) PreviewFromURLWithMultiCheck(ctx context.Context, rawURL
 		}
 	}
 
-	// Use canonical cache when:
-	// - no resolver (multi detection unavailable), OR
-	// - resolver confirms this URL was already checked and is NOT multi-recipe
-	// This prevents previously-cached listicle URLs from bypassing detection,
-	// while still caching confirmed single-recipe URLs.
-	canUseCanonicalCache := resolver == nil
-	if !canUseCanonicalCache {
-		if checked := resolver.Registry.Get(rawURL); checked != nil {
-			status := checked.GetStatus()
-			cards := checked.GetCards()
-			if (status == "resolved" || status == "failed") && len(cards) <= 1 {
-				canUseCanonicalCache = true // confirmed single-recipe
-			}
-		}
-	}
-	if s.CanonicalRepo != nil && canUseCanonicalCache {
-		normalizedURL, normErr := NormalizeURL(rawURL)
-		if normErr == nil {
-			if canonical, err := s.CanonicalRepo.GetByNormalizedURL(normalizedURL); err == nil {
+	// Serve a previously-extracted single recipe straight from the cache (an
+	// instant load — no re-extraction). The IsMultiPage marker keeps
+	// collection/listicle URLs out of this fast path so they still expand into
+	// their individual recipes.
+	if s.CanonicalRepo != nil {
+		if normalizedURL, normErr := NormalizeURL(rawURL); normErr == nil {
+			if canonical, err := s.CanonicalRepo.GetByNormalizedURL(normalizedURL); err == nil && !canonical.IsMultiPage {
 				log.Info("preview canonical cache hit")
 				go s.CanonicalRepo.IncrementHitCount(canonical.ID)
 				data := canonical.RecipeData
@@ -873,7 +865,7 @@ func (s *ImportService) PreviewFromURLWithMultiCheck(ctx context.Context, rawURL
 					data.SourceURL = rawURL
 				}
 				canonicalID := canonical.ID
-				return &PreviewResult{Recipe: &data, CanonicalID: &canonicalID}, nil
+				return &PreviewResult{Recipe: &data, CanonicalID: &canonicalID, FromCache: true}, nil
 			}
 		}
 	}
@@ -889,6 +881,25 @@ func (s *ImportService) PreviewFromURLWithMultiCheck(ctx context.Context, rawURL
 	if resolver != nil {
 		entry := resolver.ResolveFromHTML(ctx, rawURL, html)
 		if entry != nil {
+			// Durably mark this URL as a collection so future previews skip the
+			// single-recipe cache and re-expand it (the in-memory registry is
+			// lost on restart).
+			if s.CanonicalRepo != nil {
+				if normalizedURL, normErr := NormalizeURL(rawURL); normErr == nil {
+					now := time.Now()
+					if err := s.CanonicalRepo.Upsert(&models.CanonicalRecipe{
+						NormalizedURL:    normalizedURL,
+						OriginalURL:      rawURL,
+						IsMultiPage:      true,
+						RecipeData:       models.RecipeDef{},
+						ExtractionMethod: models.ExtractionJSONLD,
+						FetchedAt:        now,
+						LastAccessedAt:   now,
+					}); err != nil {
+						log.Warn("failed to mark multi-recipe page", zap.Error(err))
+					}
+				}
+			}
 			return &PreviewResult{
 				IsMulti:    true,
 				MultiID:    entry.ID,

--- a/internal/service/import_service_test.go
+++ b/internal/service/import_service_test.go
@@ -292,6 +292,65 @@ func TestPreviewFromURL_OldCanonicalStillServed(t *testing.T) {
 	}
 }
 
+func TestPreviewFromURLWithMultiCheck_ServesCachedSingle(t *testing.T) {
+	repo := testutil.NewMockRecipeRepo()
+	canonical := testutil.TestCanonicalRecipe() // IsMultiPage defaults to false
+	fetched := false
+	svc := newTestImportService(repo, nil, nil)
+	svc.CanonicalRepo = &testutil.MockCanonicalRecipeRepo{
+		GetByNormalizedURLFunc: func(string) (*models.CanonicalRecipe, error) { return canonical, nil },
+	}
+	svc.HTTPFetchOverride = func(ctx context.Context, url string) ([]byte, int, error) {
+		fetched = true
+		return []byte("<html></html>"), 200, nil
+	}
+	// A resolver is present (the realistic case) — previously this disabled the
+	// canonical cache for any URL not already in the in-memory registry, so the
+	// recipe re-extracted on every open. It must now serve straight from cache.
+	resolver := NewMultiRecipeResolver(NewMultiRecipeRegistry(), svc)
+
+	result, err := svc.PreviewFromURLWithMultiCheck(context.Background(), "https://example.com/classic-pancakes", resolver)
+	if err != nil {
+		t.Fatalf("PreviewFromURLWithMultiCheck error: %v", err)
+	}
+	if result.IsMulti {
+		t.Error("should not be multi")
+	}
+	if result.Recipe == nil || result.Recipe.Title != "Classic Pancakes" {
+		t.Errorf("recipe = %+v, want the cached 'Classic Pancakes'", result.Recipe)
+	}
+	if !result.FromCache {
+		t.Error("expected FromCache=true (served from the canonical cache)")
+	}
+	if fetched {
+		t.Error("must NOT fetch when served from cache")
+	}
+}
+
+func TestPreviewFromURLWithMultiCheck_SkipsMultiPageMarker(t *testing.T) {
+	repo := testutil.NewMockRecipeRepo()
+	marker := &models.CanonicalRecipe{NormalizedURL: "x", IsMultiPage: true, RecipeData: models.RecipeDef{}}
+	fetched := false
+	svc := newTestImportService(repo, nil, nil)
+	svc.CanonicalRepo = &testutil.MockCanonicalRecipeRepo{
+		GetByNormalizedURLFunc: func(string) (*models.CanonicalRecipe, error) { return marker, nil },
+	}
+	svc.HTTPFetchOverride = func(ctx context.Context, url string) ([]byte, int, error) {
+		fetched = true
+		return nil, 404, nil // fail extraction so we can prove the marker wasn't served
+	}
+
+	// A collection marker must never be served as a recipe — preview must skip
+	// it and proceed to (re-)fetch/expand.
+	_, err := svc.PreviewFromURLWithMultiCheck(context.Background(), "https://example.com/30-beef-dinners", nil)
+	if err == nil {
+		t.Fatal("expected the marker to be skipped and the fetch to proceed (404)")
+	}
+	if !fetched {
+		t.Error("a multi-page marker must NOT be served as a recipe — a fetch was expected")
+	}
+}
+
 func TestImportFromURL_OldCanonicalStillServed(t *testing.T) {
 	repo := testutil.NewMockRecipeRepo()
 	old := testutil.TestOldCanonicalRecipe()


### PR DESCRIPTION
## The bug

Re-opening an already-extracted recipe re-extracted it every time (~16–18s) instead of loading from the DB. Measured:

| Preview | Time |
|---|---|
| already-extracted recipe (#1 / #2) | **18.2s / 16.4s** ← re-extracts |
| collection page | 0.2s (cached) |

**Cause:** `PreviewFromURLWithMultiCheck` (the app's preview path) gated the canonical cache behind a `canUseCanonicalCache` guard that only allowed it for URLs already in the **in-memory** multi-recipe registry. Single recipes are never registered there, so the canonical cache (DB) was **written but never read** for them.

## Fix

- **Serve cached single recipes instantly** — remove the over-broad guard; on a cache hit, return the recipe with a new `from_cache` flag (so the client can show "loading saved recipe" rather than "extracting").
- **Durable `IsMultiPage` marker** (additive column) — when a page is detected as a collection/listicle, mark its URL so future previews skip the single-recipe cache and re-expand it (the in-memory registry is lost on restart). Markers carry empty recipe data and are **never served as a recipe** — every canonical read (import / preview / multi-check) now skips them.

## Tests (offline, race-clean)

- Cached single recipe is served **with a resolver present** (the exact case the old guard broke) and **without re-fetching**.
- A multi-page marker is **skipped**, never served as a recipe (a fetch is forced instead).

Column is additive (AutoMigrate); dashboard-safe. (This is the caching half; the honest progressive-status UI follows in the app.)

> Verify after deploy: re-previewing an already-extracted recipe should return in well under a second with `from_cache: true`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BU4UWZutHd1AnK3XAf7H19