### PR TITLE
Proactive cache warming: POST /v1/recipes/search/warm

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -44,6 +44,13 @@ type EnvVars struct {
 	// extractions; once the day's metered cost exceeds it, fresh extractions are
 	// refused (cache hits still serve). The kill switch.
 	VideoImportDailyBudgetUSD float64 `env:"VIDEO_IMPORT_DAILY_BUDGET_USD" envDefault:"25" optional:"true"`
+	// RecipeWarmingConcurrency bounds how many search results extract in parallel
+	// during proactive cache warming.
+	RecipeWarmingConcurrency int `env:"RECIPE_WARMING_CONCURRENCY" envDefault:"6" optional:"true"`
+	// RecipeWarmingDailyLimit is a daily kill-switch on the number of proactive
+	// warm extractions (a runaway guard, intentionally high — not a normal cap;
+	// JSON-LD/AI gap-fill runs freely under it). 0 disables the ceiling.
+	RecipeWarmingDailyLimit int `env:"RECIPE_WARMING_DAILY_LIMIT" envDefault:"5000" optional:"true"`
 }
 
 // LoadConfig parses environment variables into the Config struct.

--- a/internal/handlers/search.go
+++ b/internal/handlers/search.go
@@ -16,6 +16,7 @@ import (
 type SearchHandler struct {
 	Service       *service.SearchService
 	MultiResolver *service.MultiRecipeResolver // nil-safe
+	WarmService   *service.WarmService         // nil-safe
 }
 
 // NewSearchHandler creates a new SearchHandler.
@@ -117,6 +118,36 @@ func (h *SearchHandler) ResolveMultiRecipe(c *gin.Context) {
 		"status":     entry.GetStatus(),
 		"recipes":    entry.GetCards(),
 	})
+}
+
+// WarmRecipes handles POST /v1/recipes/search/warm. It proactively extracts and
+// caches the given recipe URLs (in parallel, in the background) so later taps
+// are instant cache hits, and returns each URL's current warm status. The call
+// is idempotent — cached and in-flight URLs are never re-extracted — so the
+// client can also poll it to watch statuses flip to "cached".
+func (h *SearchHandler) WarmRecipes(c *gin.Context) {
+	if h.WarmService == nil {
+		c.JSON(http.StatusOK, gin.H{"statuses": gin.H{}})
+		return
+	}
+
+	var req struct {
+		URLs []string `json:"urls"`
+	}
+	if err := c.ShouldBindJSON(&req); err != nil {
+		c.JSON(http.StatusBadRequest, gin.H{"error": "invalid request: " + err.Error()})
+		return
+	}
+	if len(req.URLs) == 0 {
+		c.JSON(http.StatusOK, gin.H{"statuses": gin.H{}})
+		return
+	}
+	const maxURLs = 20
+	if len(req.URLs) > maxURLs {
+		req.URLs = req.URLs[:maxURLs]
+	}
+
+	c.JSON(http.StatusOK, gin.H{"statuses": h.WarmService.WarmURLs(req.URLs)})
 }
 
 // CheckMultiRecipe handles POST /v1/recipes/search/check-multi

--- a/internal/router/router.go
+++ b/internal/router/router.go
@@ -225,10 +225,16 @@ func SetupRouter(cfg *config.Config, database *gorm.DB) *gin.Engine {
 	multiResolver := service.NewMultiRecipeResolver(multiRegistry, importService)
 	importHandler.MultiResolver = multiResolver
 
-	searchHandler := &handlers.SearchHandler{Service: searchService, MultiResolver: multiResolver}
+	// Proactive cache warming — extract+cache search results before the user
+	// taps, so taps are instant and the (user-agnostic) cache pays off for the
+	// next searcher.
+	warmService := service.NewWarmService(importService, multiResolver, cfg.EnvVars.RecipeWarmingConcurrency, cfg.EnvVars.RecipeWarmingDailyLimit)
+
+	searchHandler := &handlers.SearchHandler{Service: searchService, MultiResolver: multiResolver, WarmService: warmService}
 	apiProtected.GET("/recipes/search", middleware.AttachUserToContext(userService), searchHandler.SearchRecipes)
 	apiProtected.GET("/recipes/search/resolve/:multi_id", middleware.AttachUserToContext(userService), searchHandler.ResolveMultiRecipe)
 	apiProtected.POST("/recipes/search/check-multi", middleware.AttachUserToContext(userService), searchHandler.CheckMultiRecipe)
+	apiProtected.POST("/recipes/search/warm", middleware.AttachUserToContext(userService), searchHandler.WarmRecipes)
 
 	// Vector similarity routes
 	similarityHandler := handlers.NewSimilarityHandler(vectorRepo, embedProvider, recipeService)

--- a/internal/service/import.go
+++ b/internal/service/import.go
@@ -828,6 +828,88 @@ func (s *ImportService) PreviewFromURL(ctx context.Context, rawURL string) (*mod
 	return recipeDef, canonicalID, nil
 }
 
+// WarmURL extracts and caches a single recipe URL proactively (cache warming),
+// so a later preview/import is an instant cache hit. It is safe against
+// collection pages: if the URL is a multi-recipe page it is only marked
+// IsMultiPage (so it still expands later) rather than extracting every
+// sub-recipe. JSON-LD is used first (free); AI fills the gap when a page has no
+// structured data. The caller is expected to have already skipped cached and
+// in-flight URLs.
+func (s *ImportService) WarmURL(ctx context.Context, resolver *MultiRecipeResolver, rawURL string) error {
+	if err := ValidateExternalURL(rawURL); err != nil {
+		return err
+	}
+	normalizedURL, err := NormalizeURL(rawURL)
+	if err != nil {
+		return err
+	}
+	// Re-check the cache (a concurrent warm/import may have filled it).
+	if _, err := s.CanonicalRepo.GetByNormalizedURL(normalizedURL); err == nil {
+		return nil
+	}
+
+	html, err := s.fetchHTML(ctx, rawURL)
+	if err != nil {
+		return err
+	}
+
+	now := time.Now()
+	markMulti := func() error {
+		return s.CanonicalRepo.Upsert(&models.CanonicalRecipe{
+			NormalizedURL:    normalizedURL,
+			OriginalURL:      rawURL,
+			IsMultiPage:      true,
+			RecipeData:       models.RecipeDef{},
+			ExtractionMethod: models.ExtractionJSONLD,
+			FetchedAt:        now,
+			LastAccessedAt:   now,
+		})
+	}
+
+	// A JSON-LD listicle (multiple recipes in structured data)? Mark it and stop
+	// — free, and never warm every sub-recipe.
+	if len(extractAllJSONLDRecipes(html, rawURL)) > 1 {
+		return markMulti()
+	}
+
+	// A single JSON-LD recipe is the common, free case — cache it without AI.
+	recipeDef, _, _, method := s.extractRecipeFromHTML(html, rawURL)
+	if recipeDef == nil {
+		// No structured data. Only here do we spend AI: first confirm it isn't a
+		// link-style collection (so a listicle isn't mis-cached as one recipe),
+		// then extract.
+		if resolver != nil && resolver.DetectMultiFromHTML(ctx, rawURL, html) {
+			return markMulti()
+		}
+		provider := s.PreviewProvider
+		if provider == nil {
+			provider = s.TextProvider
+		}
+		if provider == nil {
+			return fmt.Errorf("no text provider configured for warming")
+		}
+		result, aiErr := provider.ExtractRecipeFromText(ctx, html, ai.UnitSystemPreserveSource)
+		if aiErr != nil {
+			return aiErr
+		}
+		def := recipeResultToRecipeDef(result)
+		def.SourceURL = rawURL
+		ensureUnitSystem(&def)
+		recipeDef = &def
+		method = models.ExtractionHaiku
+	}
+
+	return s.CanonicalRepo.Upsert(&models.CanonicalRecipe{
+		NormalizedURL:    normalizedURL,
+		OriginalURL:      rawURL,
+		RecipeData:       *recipeDef,
+		ExtractionMethod: method,
+		FetchedAt:        now,
+		LastAccessedAt:   now,
+		Embedding:        s.canonicalEmbedding(ctx, recipeDef),
+	})
+}
+
 // PreviewFromURLWithMultiCheck is like PreviewFromURL but also detects
 // multi-recipe pages. When multiple JSON-LD recipes are found, it returns
 // a PreviewResult with IsMulti=true and individual cards instead of

--- a/internal/service/multi_recipe.go
+++ b/internal/service/multi_recipe.go
@@ -515,25 +515,36 @@ func NewMultiRecipeResolver(registry *MultiRecipeRegistry, importService *Import
 	}
 }
 
-// ResolveFromHTML detects and begins resolving a multi-recipe page from fetched HTML.
-// Uses JSON-LD detection first, then falls back to AI-based detection.
-// Returns the entry if multi-recipe, or nil if single-recipe.
-func (r *MultiRecipeResolver) ResolveFromHTML(ctx context.Context, sourceURL string, html string) *MultiRecipeEntry {
-	// Try JSON-LD detection first (fast, no AI call)
+// detectCards returns the recipe cards found on a page: JSON-LD first (free),
+// then an AI fallback when JSON-LD finds 0-1. Detection only — no registration
+// or extraction.
+func (r *MultiRecipeResolver) detectCards(ctx context.Context, sourceURL string, html string) []MultiRecipeCard {
 	cards := extractAllJSONLDRecipes(html, sourceURL)
-
-	// Fall back to AI detection if JSON-LD found 0-1 recipes
 	if len(cards) <= 1 {
 		provider := r.ImportService.PreviewProvider
 		if provider == nil {
 			provider = r.ImportService.TextProvider
 		}
-		aiCards := detectMultipleRecipesFromHTML(ctx, provider, html, sourceURL)
-		if aiCards != nil {
+		if aiCards := detectMultipleRecipesFromHTML(ctx, provider, html, sourceURL); aiCards != nil {
 			cards = aiCards
 		}
 	}
+	return cards
+}
 
+// DetectMultiFromHTML reports whether the page holds multiple recipes, without
+// registering or extracting anything. Cache-warming uses this to mark a
+// collection page (so it still expands later) without paying to extract every
+// sub-recipe.
+func (r *MultiRecipeResolver) DetectMultiFromHTML(ctx context.Context, sourceURL string, html string) bool {
+	return len(r.detectCards(ctx, sourceURL, html)) > 1
+}
+
+// ResolveFromHTML detects and begins resolving a multi-recipe page from fetched HTML.
+// Uses JSON-LD detection first, then falls back to AI-based detection.
+// Returns the entry if multi-recipe, or nil if single-recipe.
+func (r *MultiRecipeResolver) ResolveFromHTML(ctx context.Context, sourceURL string, html string) *MultiRecipeEntry {
+	cards := r.detectCards(ctx, sourceURL, html)
 	if len(cards) <= 1 {
 		return nil
 	}

--- a/internal/service/warm.go
+++ b/internal/service/warm.go
@@ -1,0 +1,131 @@
+package service
+
+import (
+	"context"
+	"sync"
+	"time"
+
+	"github.com/windoze95/saltybytes-api/internal/logger"
+	"go.uber.org/zap"
+)
+
+// Warm status values returned per URL.
+const (
+	WarmCached     = "cached"     // already in the canonical cache (instant)
+	WarmExtracting = "extracting" // being warmed now (or just kicked off)
+	WarmMulti      = "multi"      // a collection page (expands on tap)
+	WarmUncached   = "uncached"   // not warmed (skipped: bad URL or safety cap)
+)
+
+// WarmService proactively extracts and caches recipe URLs (cache warming) so a
+// later preview/import is an instant cache hit. Extraction runs in parallel,
+// bounded by a concurrency limit, deduped against in-flight work, and capped by
+// a daily safety ceiling that guards against runaway cost (JSON-LD stays free
+// either way).
+type WarmService struct {
+	Import   *ImportService
+	Resolver *MultiRecipeResolver
+
+	sem      chan struct{}
+	inflight sync.Map // normalizedURL -> struct{}{}
+
+	mu       sync.Mutex
+	day      string
+	count    int
+	maxDaily int // <= 0 means unlimited (a high kill-switch, not a normal cap)
+}
+
+// NewWarmService builds a WarmService. concurrency defaults to 5; maxDaily <= 0
+// disables the safety ceiling.
+func NewWarmService(imp *ImportService, resolver *MultiRecipeResolver, concurrency, maxDaily int) *WarmService {
+	if concurrency <= 0 {
+		concurrency = 5
+	}
+	return &WarmService{
+		Import:   imp,
+		Resolver: resolver,
+		sem:      make(chan struct{}, concurrency),
+		maxDaily: maxDaily,
+	}
+}
+
+// WarmURLs returns the current warm status of each URL, kicking off background
+// extraction for any that are uncached and not already in flight. It is
+// idempotent — calling it repeatedly with the same URLs is cheap (cached and
+// in-flight URLs are never re-extracted), so it doubles as a status poll.
+func (w *WarmService) WarmURLs(urls []string) map[string]string {
+	out := make(map[string]string, len(urls))
+	for _, rawURL := range urls {
+		if rawURL == "" {
+			continue
+		}
+		out[rawURL] = w.statusAndKick(rawURL)
+	}
+	return out
+}
+
+func (w *WarmService) statusAndKick(rawURL string) string {
+	if w.Import == nil || w.Import.CanonicalRepo == nil {
+		return WarmUncached
+	}
+	normalizedURL, err := NormalizeURL(rawURL)
+	if err != nil {
+		return WarmUncached
+	}
+
+	// Already cached?
+	if canonical, err := w.Import.CanonicalRepo.GetByNormalizedURL(normalizedURL); err == nil {
+		if canonical.IsMultiPage {
+			return WarmMulti
+		}
+		return WarmCached
+	}
+
+	// Already being warmed by another request/goroutine?
+	if _, loaded := w.inflight.LoadOrStore(normalizedURL, struct{}{}); loaded {
+		return WarmExtracting
+	}
+
+	// Safety ceiling — back out of the in-flight claim if we're over budget so
+	// the URL can still be warmed later (or extracted lazily on tap).
+	if !w.allow() {
+		w.inflight.Delete(normalizedURL)
+		return WarmUncached
+	}
+
+	go w.warmOne(rawURL, normalizedURL)
+	return WarmExtracting
+}
+
+func (w *WarmService) warmOne(rawURL, normalizedURL string) {
+	defer w.inflight.Delete(normalizedURL)
+
+	w.sem <- struct{}{}
+	defer func() { <-w.sem }()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 60*time.Second)
+	defer cancel()
+
+	if err := w.Import.WarmURL(ctx, w.Resolver, rawURL); err != nil {
+		logger.Get().Info("cache warming skipped", zap.String("url", rawURL), zap.Error(err))
+	}
+}
+
+// allow enforces the daily safety ceiling. It resets at the UTC day boundary.
+func (w *WarmService) allow() bool {
+	if w.maxDaily <= 0 {
+		return true
+	}
+	w.mu.Lock()
+	defer w.mu.Unlock()
+	day := time.Now().UTC().Format("2006-01-02")
+	if day != w.day {
+		w.day = day
+		w.count = 0
+	}
+	if w.count >= w.maxDaily {
+		return false
+	}
+	w.count++
+	return true
+}

--- a/internal/service/warm_test.go
+++ b/internal/service/warm_test.go
@@ -1,0 +1,178 @@
+package service
+
+import (
+	"context"
+	"errors"
+	"strings"
+	"testing"
+
+	"github.com/windoze95/saltybytes-api/internal/ai"
+	"github.com/windoze95/saltybytes-api/internal/models"
+	"github.com/windoze95/saltybytes-api/internal/testutil"
+)
+
+// twoRecipeJSONLDHTML is a page exposing two distinct recipes in JSON-LD (a
+// structured-data listicle).
+func twoRecipeJSONLDHTML() string {
+	return `<html><head>
+<script type="application/ld+json">{"@context":"https://schema.org","@type":"Recipe","name":"Beef Stew","recipeIngredient":["beef"],"recipeInstructions":[{"@type":"HowToStep","text":"cook"}]}</script>
+<script type="application/ld+json">{"@context":"https://schema.org","@type":"Recipe","name":"Chicken Soup","recipeIngredient":["chicken"],"recipeInstructions":[{"@type":"HowToStep","text":"simmer"}]}</script>
+</head><body></body></html>`
+}
+
+func warmRepoCapturing(upserted **models.CanonicalRecipe) *testutil.MockCanonicalRecipeRepo {
+	return &testutil.MockCanonicalRecipeRepo{
+		GetByNormalizedURLFunc: func(string) (*models.CanonicalRecipe, error) {
+			return nil, errors.New("miss")
+		},
+		UpsertFunc: func(e *models.CanonicalRecipe) error { *upserted = e; return nil },
+	}
+}
+
+func TestWarmURL_JSONLDSingle_CachesWithoutAI(t *testing.T) {
+	var upserted *models.CanonicalRecipe
+	// A provider that fails the test if any AI method runs — a JSON-LD page must
+	// warm for free.
+	provider := &testutil.MockTextProvider{
+		CookingQAFunc: func(context.Context, string, string) (string, error) {
+			t.Error("CookingQA should not run for a JSON-LD page")
+			return "", nil
+		},
+		ExtractRecipeFromTextFunc: func(context.Context, string, string) (*ai.RecipeResult, error) {
+			t.Error("AI extraction should not run for a JSON-LD page")
+			return nil, nil
+		},
+	}
+	imp := newTestImportService(testutil.NewMockRecipeRepo(), provider, nil)
+	imp.CanonicalRepo = warmRepoCapturing(&upserted)
+	imp.HTTPFetchOverride = func(context.Context, string) ([]byte, int, error) {
+		return []byte(jsonLDHTML()), 200, nil
+	}
+	resolver := NewMultiRecipeResolver(NewMultiRecipeRegistry(), imp)
+
+	if err := imp.WarmURL(context.Background(), resolver, "https://site.com/pancakes"); err != nil {
+		t.Fatalf("WarmURL: %v", err)
+	}
+	if upserted == nil {
+		t.Fatal("expected a canonical upsert")
+	}
+	if upserted.IsMultiPage {
+		t.Error("a single recipe must not be marked multi")
+	}
+	if upserted.RecipeData.Title != "Classic Pancakes" {
+		t.Errorf("cached title = %q, want 'Classic Pancakes'", upserted.RecipeData.Title)
+	}
+}
+
+func TestWarmURL_JSONLDListicle_MarksMulti(t *testing.T) {
+	var upserted *models.CanonicalRecipe
+	imp := newTestImportService(testutil.NewMockRecipeRepo(), nil, nil)
+	imp.CanonicalRepo = warmRepoCapturing(&upserted)
+	imp.HTTPFetchOverride = func(context.Context, string) ([]byte, int, error) {
+		return []byte(twoRecipeJSONLDHTML()), 200, nil
+	}
+	resolver := NewMultiRecipeResolver(NewMultiRecipeRegistry(), imp)
+
+	if err := imp.WarmURL(context.Background(), resolver, "https://site.com/30-dinners"); err != nil {
+		t.Fatalf("WarmURL: %v", err)
+	}
+	if upserted == nil || !upserted.IsMultiPage {
+		t.Fatalf("expected an IsMultiPage marker, got %+v", upserted)
+	}
+	if len(upserted.RecipeData.Ingredients) != 0 {
+		t.Error("a multi marker must carry empty recipe data (no sub-recipe extraction)")
+	}
+}
+
+func TestWarmURL_NoJSONLD_UsesAI(t *testing.T) {
+	var upserted *models.CanonicalRecipe
+	provider := &testutil.MockTextProvider{
+		CookingQAFunc: func(context.Context, string, string) (string, error) {
+			return "SINGLE", nil // not a collection
+		},
+		ExtractRecipeFromTextFunc: func(context.Context, string, string) (*ai.RecipeResult, error) {
+			return testutil.TestRecipeResult(), nil
+		},
+	}
+	imp := newTestImportService(testutil.NewMockRecipeRepo(), provider, nil)
+	imp.CanonicalRepo = warmRepoCapturing(&upserted)
+	imp.HTTPFetchOverride = func(context.Context, string) ([]byte, int, error) {
+		return []byte(plainHTML()), 200, nil
+	}
+	resolver := NewMultiRecipeResolver(NewMultiRecipeRegistry(), imp)
+
+	if err := imp.WarmURL(context.Background(), resolver, "https://site.com/plain"); err != nil {
+		t.Fatalf("WarmURL: %v", err)
+	}
+	if upserted == nil || upserted.IsMultiPage {
+		t.Fatalf("expected a single-recipe cache write, got %+v", upserted)
+	}
+	if upserted.ExtractionMethod != models.ExtractionHaiku {
+		t.Errorf("method = %q, want the AI (haiku) fallback", upserted.ExtractionMethod)
+	}
+}
+
+func TestWarmURLs_Statuses(t *testing.T) {
+	multi := &models.CanonicalRecipe{NormalizedURL: "m", IsMultiPage: true, RecipeData: models.RecipeDef{}}
+	single := testutil.TestCanonicalRecipe()
+	canon := &testutil.MockCanonicalRecipeRepo{
+		GetByNormalizedURLFunc: func(norm string) (*models.CanonicalRecipe, error) {
+			switch {
+			case strings.Contains(norm, "cached"):
+				return single, nil
+			case strings.Contains(norm, "collection"):
+				return multi, nil
+			default:
+				return nil, errors.New("miss")
+			}
+		},
+		UpsertFunc: func(*models.CanonicalRecipe) error { return nil },
+	}
+	imp := newTestImportService(testutil.NewMockRecipeRepo(), nil, nil)
+	imp.CanonicalRepo = canon
+	imp.HTTPFetchOverride = func(context.Context, string) ([]byte, int, error) {
+		return []byte(jsonLDHTML()), 200, nil // the background warm of the uncached URL is harmless
+	}
+	resolver := NewMultiRecipeResolver(NewMultiRecipeRegistry(), imp)
+	w := NewWarmService(imp, resolver, 2, 0)
+
+	statuses := w.WarmURLs([]string{
+		"https://site.com/cached-pie",
+		"https://site.com/collection-30",
+		"https://site.com/new-dish",
+	})
+	if got := statuses["https://site.com/cached-pie"]; got != WarmCached {
+		t.Errorf("cached URL = %q, want %q", got, WarmCached)
+	}
+	if got := statuses["https://site.com/collection-30"]; got != WarmMulti {
+		t.Errorf("collection URL = %q, want %q", got, WarmMulti)
+	}
+	if got := statuses["https://site.com/new-dish"]; got != WarmExtracting {
+		t.Errorf("new URL = %q, want %q", got, WarmExtracting)
+	}
+}
+
+func TestWarmURLs_SafetyCeiling(t *testing.T) {
+	canon := &testutil.MockCanonicalRecipeRepo{
+		GetByNormalizedURLFunc: func(string) (*models.CanonicalRecipe, error) {
+			return nil, errors.New("miss")
+		},
+		UpsertFunc: func(*models.CanonicalRecipe) error { return nil },
+	}
+	imp := newTestImportService(testutil.NewMockRecipeRepo(), nil, nil)
+	imp.CanonicalRepo = canon
+	imp.HTTPFetchOverride = func(context.Context, string) ([]byte, int, error) {
+		return []byte(jsonLDHTML()), 200, nil
+	}
+	resolver := NewMultiRecipeResolver(NewMultiRecipeRegistry(), imp)
+	w := NewWarmService(imp, resolver, 2, 1) // ceiling: 1 warm/day
+
+	first := w.WarmURLs([]string{"https://site.com/a"})
+	if got := first["https://site.com/a"]; got != WarmExtracting {
+		t.Fatalf("first URL = %q, want %q", got, WarmExtracting)
+	}
+	second := w.WarmURLs([]string{"https://site.com/b"})
+	if got := second["https://site.com/b"]; got != WarmUncached {
+		t.Errorf("second URL (over ceiling) = %q, want %q", got, WarmUncached)
+	}
+}


### PR DESCRIPTION
## What

Extract + cache search results **before** anyone taps them. Because the canonical cache is user-agnostic, each extraction is paid once and reused by everyone after — so a search warms the cache for the next searcher too. This is the backend half; the app drives it scroll-ahead.

## Endpoint

`POST /v1/recipes/search/warm` `{ "urls": [...] }` → `{ "statuses": { url: "cached"|"extracting"|"multi"|"uncached" } }`

- **Idempotent** — cached and in-flight URLs are never re-extracted, so the client can poll it to watch statuses flip to `cached`. Doubles as trigger + status.
- For each uncached, not-in-flight URL it kicks off **parallel** background extraction.

## Cost-awareness (per the agreed policy)

`ImportService.WarmURL` spends as little as possible and is collection-safe:
- **JSON-LD listicle** → marked `IsMultiPage` (so it still expands on tap); **never** warms every sub-recipe.
- **Single JSON-LD recipe** → cached for **free** (no AI).
- **Only a page with no structured data spends AI** — and only after an AI multi-detect first, so a pure-HTML listicle can't be mis-cached as one recipe (which would make it un-expandable via the #96 cache).

No cap that stops AI from filling JSON-LD's gaps; the governors are scroll-ahead (client), dedup, a concurrency limit (`RECIPE_WARMING_CONCURRENCY`, default 6), and a high daily kill-switch (`RECIPE_WARMING_DAILY_LIMIT`, default 5000 — runaway guard, not a normal cap).

Refactored detection out of `ResolveFromHTML` into `detectCards`/`DetectMultiFromHTML` so warming reuses detection without triggering sub-recipe extraction.

## Tests (offline, race-clean)

JSON-LD single caches without AI · JSON-LD listicle marks multi (empty data) · no-JSON-LD uses AI · status logic (cached/multi/extracting) · safety ceiling. Config is additive.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BU4UWZutHd1AnK3XAf7H19