### PR TITLE
Warm: cooldown failed URLs instead of re-kicking every poll

### DIFF
--- a/internal/service/warm.go
+++ b/internal/service/warm.go
@@ -15,7 +15,13 @@ const (
 	WarmExtracting = "extracting" // being warmed now (or just kicked off)
 	WarmMulti      = "multi"      // a collection page (expands on tap)
 	WarmUncached   = "uncached"   // not warmed (skipped: bad URL or safety cap)
+	WarmFailed     = "failed"     // recently failed to extract (in cooldown)
 )
+
+// warmFailCooldown is how long a URL that failed to warm (e.g. a bot-blocked
+// page) is reported terminal before another attempt, so we don't re-kick a
+// failing extraction on every poll.
+const warmFailCooldown = 15 * time.Minute
 
 // WarmService proactively extracts and caches recipe URLs (cache warming) so a
 // later preview/import is an instant cache hit. Extraction runs in parallel,
@@ -28,6 +34,7 @@ type WarmService struct {
 
 	sem      chan struct{}
 	inflight sync.Map // normalizedURL -> struct{}{}
+	failed   sync.Map // normalizedURL -> int64 (unix-nano cooldown expiry)
 
 	mu       sync.Mutex
 	day      string
@@ -81,6 +88,15 @@ func (w *WarmService) statusAndKick(rawURL string) string {
 		return WarmCached
 	}
 
+	// Recently failed? Report it terminal during the cooldown instead of
+	// re-kicking a failing/blocked page on every poll.
+	if exp, ok := w.failed.Load(normalizedURL); ok {
+		if time.Now().UnixNano() < exp.(int64) {
+			return WarmFailed
+		}
+		w.failed.Delete(normalizedURL)
+	}
+
 	// Already being warmed by another request/goroutine?
 	if _, loaded := w.inflight.LoadOrStore(normalizedURL, struct{}{}); loaded {
 		return WarmExtracting
@@ -107,7 +123,11 @@ func (w *WarmService) warmOne(rawURL, normalizedURL string) {
 	defer cancel()
 
 	if err := w.Import.WarmURL(ctx, w.Resolver, rawURL); err != nil {
+		// Remember the failure so we stop hammering a blocked/failing page.
+		w.failed.Store(normalizedURL, time.Now().Add(warmFailCooldown).UnixNano())
 		logger.Get().Info("cache warming skipped", zap.String("url", rawURL), zap.Error(err))
+	} else {
+		w.failed.Delete(normalizedURL)
 	}
 }
 

--- a/internal/service/warm_test.go
+++ b/internal/service/warm_test.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/windoze95/saltybytes-api/internal/ai"
 	"github.com/windoze95/saltybytes-api/internal/models"
@@ -149,6 +150,40 @@ func TestWarmURLs_Statuses(t *testing.T) {
 	}
 	if got := statuses["https://site.com/new-dish"]; got != WarmExtracting {
 		t.Errorf("new URL = %q, want %q", got, WarmExtracting)
+	}
+}
+
+func TestWarmURLs_FailedCooldown(t *testing.T) {
+	canon := &testutil.MockCanonicalRecipeRepo{
+		GetByNormalizedURLFunc: func(string) (*models.CanonicalRecipe, error) {
+			return nil, errors.New("miss")
+		},
+		UpsertFunc: func(*models.CanonicalRecipe) error { return nil },
+	}
+	imp := newTestImportService(testutil.NewMockRecipeRepo(), nil, nil)
+	imp.CanonicalRepo = canon
+	imp.HTTPFetchOverride = func(context.Context, string) ([]byte, int, error) {
+		return nil, 0, errors.New("blocked")
+	}
+	resolver := NewMultiRecipeResolver(NewMultiRecipeRegistry(), imp)
+	w := NewWarmService(imp, resolver, 2, 0)
+
+	const url = "https://site.com/blocked"
+	if got := w.WarmURLs([]string{url})[url]; got != WarmExtracting {
+		t.Fatalf("first warm = %q, want %q", got, WarmExtracting)
+	}
+	// Once the background warm fails it enters cooldown and reports terminal —
+	// it must not re-kick on every poll.
+	var status string
+	for i := 0; i < 200; i++ {
+		status = w.WarmURLs([]string{url})[url]
+		if status == WarmFailed {
+			break
+		}
+		time.Sleep(5 * time.Millisecond)
+	}
+	if status != WarmFailed {
+		t.Errorf("after a failed warm, status = %q, want %q", status, WarmFailed)
 	}
 }
 


### PR DESCRIPTION
## The edge case

Live test of warming: 3 of 4 sites cached within 5s. The 4th (`allrecipes.com` — bot-blocked, and Firecrawl is out of credits) couldn't be fetched, so since `/warm` is polled, it **re-kicked a failing extraction on every poll** and reported `extracting` forever (stuck spinner + wasted fetches).

## Fix

- On a warm failure, record the URL with a **15-minute cooldown**; while in cooldown `/warm` returns `failed` (terminal) and never re-extracts it.
- A successful warm clears any prior failure.

The client maps `failed` to a cleared badge, so the result just looks like a normal un-warmed, tappable result instead of a stuck spinner.

## Test

A URL whose fetch fails flips to `failed` and stays terminal (no re-kick). Race-clean; full suite green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BU4UWZutHd1AnK3XAf7H19