### PR TITLE
Record per-call AI token usage + cost (ai_usage_logs)

### DIFF
--- a/internal/ai/anthropic.go
+++ b/internal/ai/anthropic.go
@@ -601,6 +601,10 @@ func (p *AnthropicProvider) createMessageWithRetry(ctx context.Context, params a
 	for i := 0; i < maxRetries; i++ {
 		resp, err := p.client.Messages.New(ctx, params)
 		if err == nil {
+			recordUsage(ctx, TokenUsage{
+				InputTokens:  int(resp.Usage.InputTokens),
+				OutputTokens: int(resp.Usage.OutputTokens),
+			})
 			return resp, nil
 		}
 

--- a/internal/ai/cost_test.go
+++ b/internal/ai/cost_test.go
@@ -1,0 +1,82 @@
+package ai
+
+import (
+	"context"
+	"testing"
+	"time"
+)
+
+func TestPricingTable_Cost(t *testing.T) {
+	p := DefaultPricing
+	oneM := TokenUsage{InputTokens: 1_000_000, OutputTokens: 1_000_000}
+
+	// A dated Haiku ID resolves to the claude-haiku-4 family ($1 in + $5 out).
+	if got := p.Cost("claude-haiku-4-5-20251001", oneM); got != 6.00 {
+		t.Errorf("haiku cost = %v, want 6.00", got)
+	}
+	// Exact match.
+	if got := p.Cost("gpt-4o-mini", oneM); got != 0.75 {
+		t.Errorf("gpt-4o-mini cost = %v, want 0.75", got)
+	}
+	// Unknown model → 0 (still recorded; tokens let the dashboard price it).
+	if got := p.Cost("mystery-model", oneM); got != 0 {
+		t.Errorf("unknown model cost = %v, want 0", got)
+	}
+}
+
+func TestCostMiddleware_RecordsUsage(t *testing.T) {
+	var got UsageRecord
+	called := false
+	mw := &CostMiddleware{
+		Pricing: DefaultPricing,
+		Sink:    func(r UsageRecord) { got = r; called = true },
+	}
+	mw.After(context.Background(), AIOperationResult{
+		Operation: AIOperation{Name: "ExtractRecipeFromText", Provider: "anthropic", Model: "claude-haiku-4-5-20251001"},
+		Duration:  100 * time.Millisecond,
+		Usage:     TokenUsage{InputTokens: 1_000_000, OutputTokens: 1_000_000},
+	})
+	if !called {
+		t.Fatal("sink was not called")
+	}
+	if got.Model != "claude-haiku-4-5-20251001" || got.Operation != "ExtractRecipeFromText" {
+		t.Errorf("record = %+v", got)
+	}
+	if got.CostUSD != 6.00 {
+		t.Errorf("cost = %v, want 6.00", got.CostUSD)
+	}
+	if got.DurationMS != 100 {
+		t.Errorf("duration = %d ms, want 100", got.DurationMS)
+	}
+}
+
+func TestCostMiddleware_SkipsZeroUsage(t *testing.T) {
+	called := false
+	mw := &CostMiddleware{Sink: func(UsageRecord) { called = true }}
+	mw.After(context.Background(), AIOperationResult{
+		Operation: AIOperation{Model: "claude-haiku-4-5"},
+		Usage:     TokenUsage{}, // no tokens consumed (e.g. an early failure)
+	})
+	if called {
+		t.Error("sink must not be called for a zero-usage call")
+	}
+}
+
+type capturingMW struct{ captured AIOperationResult }
+
+func (m *capturingMW) Before(ctx context.Context, op AIOperation) context.Context { return ctx }
+func (m *capturingMW) After(ctx context.Context, r AIOperationResult)             { m.captured = r }
+
+func TestRunWithMiddleware_FlowsUsageFromCall(t *testing.T) {
+	mw := &capturingMW{}
+	_, _ = runWithMiddleware(context.Background(), mw,
+		AIOperation{Name: "X", StartTime: time.Now()},
+		func(ctx context.Context) (string, error) {
+			// A provider reports usage mid-call; it must reach After().
+			recordUsage(ctx, TokenUsage{InputTokens: 42, OutputTokens: 7})
+			return "ok", nil
+		})
+	if mw.captured.Usage.InputTokens != 42 || mw.captured.Usage.OutputTokens != 7 {
+		t.Errorf("usage = %+v, want {42 7}", mw.captured.Usage)
+	}
+}

--- a/internal/ai/middleware.go
+++ b/internal/ai/middleware.go
@@ -16,11 +16,32 @@ type AIOperation struct {
 	StartTime time.Time
 }
 
+// TokenUsage is the token consumption reported by a provider call.
+type TokenUsage struct {
+	InputTokens      int
+	OutputTokens     int
+	CacheInputTokens int
+}
+
 // AIOperationResult captures the outcome of an AI call.
 type AIOperationResult struct {
 	Operation AIOperation
 	Duration  time.Duration
 	Err       error
+	Usage     TokenUsage
+}
+
+type usageKeyType struct{}
+
+// usageKey marks the per-call usage sink stored in the context.
+var usageKey usageKeyType
+
+// recordUsage reports a provider call's token usage to the in-flight sink so the
+// middleware can meter cost. A no-op if no sink is in the context.
+func recordUsage(ctx context.Context, u TokenUsage) {
+	if sink, ok := ctx.Value(usageKey).(*TokenUsage); ok && sink != nil {
+		*sink = u
+	}
 }
 
 // AIMiddleware intercepts AI calls for observability and control.
@@ -83,6 +104,10 @@ func (c *MiddlewareChain) After(ctx context.Context, result AIOperationResult) {
 // runWithMiddleware executes an AI operation with middleware hooks.
 // If mw is nil, the operation runs without middleware.
 func runWithMiddleware[T any](ctx context.Context, mw AIMiddleware, op AIOperation, fn func(context.Context) (T, error)) (T, error) {
+	// Install a usage sink the provider call fills via recordUsage.
+	var usage TokenUsage
+	ctx = context.WithValue(ctx, usageKey, &usage)
+
 	if mw != nil {
 		ctx = mw.Before(ctx, op)
 	}
@@ -94,8 +119,59 @@ func runWithMiddleware[T any](ctx context.Context, mw AIMiddleware, op AIOperati
 			Operation: op,
 			Duration:  time.Since(op.StartTime),
 			Err:       err,
+			Usage:     usage,
 		})
 	}
 
 	return result, err
+}
+
+// UsageRecord is one metered AI call handed to a CostMiddleware sink.
+type UsageRecord struct {
+	Operation        string
+	Provider         string
+	Model            string
+	InputTokens      int
+	OutputTokens     int
+	CacheInputTokens int
+	CostUSD          float64
+	DurationMS       int64
+	Success          bool
+}
+
+// CostMiddleware meters each AI call's token usage + cost and hands it to a sink
+// (e.g. a DB insert). Pricing defaults to DefaultPricing when nil.
+type CostMiddleware struct {
+	Pricing PricingTable
+	Sink    func(UsageRecord)
+}
+
+func (m *CostMiddleware) Before(ctx context.Context, op AIOperation) context.Context {
+	return ctx
+}
+
+func (m *CostMiddleware) After(ctx context.Context, result AIOperationResult) {
+	if m.Sink == nil {
+		return
+	}
+	u := result.Usage
+	// Only record calls that consumed tokens (skip failures with no spend).
+	if u.InputTokens == 0 && u.OutputTokens == 0 {
+		return
+	}
+	pricing := m.Pricing
+	if pricing == nil {
+		pricing = DefaultPricing
+	}
+	m.Sink(UsageRecord{
+		Operation:        result.Operation.Name,
+		Provider:         result.Operation.Provider,
+		Model:            result.Operation.Model,
+		InputTokens:      u.InputTokens,
+		OutputTokens:     u.OutputTokens,
+		CacheInputTokens: u.CacheInputTokens,
+		CostUSD:          pricing.Cost(result.Operation.Model, u),
+		DurationMS:       result.Duration.Milliseconds(),
+		Success:          result.Err == nil,
+	})
 }

--- a/internal/ai/pricing.go
+++ b/internal/ai/pricing.go
@@ -1,0 +1,60 @@
+package ai
+
+import "strings"
+
+// ModelPrice is the USD price per 1M tokens for a model.
+type ModelPrice struct {
+	InputPerM      float64
+	OutputPerM     float64
+	CacheInputPerM float64 // price for cached/read input tokens (usually ~0.1x input)
+}
+
+// PricingTable maps a model ID to its price. Used to meter the actual cost of a
+// call; the dashboard computes counterfactual ("what model X would have cost")
+// pricing itself from the stored token counts + its own editable rate card.
+type PricingTable map[string]ModelPrice
+
+// DefaultPricing seeds known model prices (USD per 1M tokens, list prices as of
+// 2026). Keys are matched by prefix so dated model IDs (…-20251001) resolve.
+var DefaultPricing = PricingTable{
+	"claude-sonnet-4":       {InputPerM: 3.00, OutputPerM: 15.00, CacheInputPerM: 0.30},
+	"claude-haiku-4":        {InputPerM: 1.00, OutputPerM: 5.00, CacheInputPerM: 0.10},
+	"claude-opus-4":         {InputPerM: 5.00, OutputPerM: 25.00, CacheInputPerM: 0.50},
+	"gpt-4o-mini":           {InputPerM: 0.15, OutputPerM: 0.60, CacheInputPerM: 0.075},
+	"gpt-4.1-mini":          {InputPerM: 0.40, OutputPerM: 1.60, CacheInputPerM: 0.10},
+	"gpt-4.1-nano":          {InputPerM: 0.10, OutputPerM: 0.40, CacheInputPerM: 0.025},
+	"gemini-2.0-flash":      {InputPerM: 0.10, OutputPerM: 0.40, CacheInputPerM: 0.025},
+	"gemini-2.0-flash-lite": {InputPerM: 0.075, OutputPerM: 0.30, CacheInputPerM: 0.0},
+	"deepseek-chat":         {InputPerM: 0.27, OutputPerM: 1.10, CacheInputPerM: 0.07},
+}
+
+// priceFor resolves a model's price, matching by longest prefix so dated IDs
+// (e.g. "claude-haiku-4-5-20251001") map to their family price. Returns false
+// when unknown.
+func (p PricingTable) priceFor(model string) (ModelPrice, bool) {
+	if mp, ok := p[model]; ok {
+		return mp, true
+	}
+	var best string
+	for key := range p {
+		if strings.HasPrefix(model, key) && len(key) > len(best) {
+			best = key
+		}
+	}
+	if best == "" {
+		return ModelPrice{}, false
+	}
+	return p[best], true
+}
+
+// Cost returns the USD cost of a call's token usage on the given model. Unknown
+// models cost 0 (still recorded — the token counts let the dashboard price it).
+func (p PricingTable) Cost(model string, u TokenUsage) float64 {
+	mp, ok := p.priceFor(model)
+	if !ok {
+		return 0
+	}
+	return float64(u.InputTokens)/1e6*mp.InputPerM +
+		float64(u.OutputTokens)/1e6*mp.OutputPerM +
+		float64(u.CacheInputTokens)/1e6*mp.CacheInputPerM
+}

--- a/internal/db/db.go
+++ b/internal/db/db.go
@@ -62,6 +62,7 @@ func connectToDatabaseWithRetry(databaseURL string) (*gorm.DB, error) {
 		&models.CanonicalRecipe{},
 		&models.VideoExtractionCache{},
 		&models.VideoImport{},
+		&models.AIUsageLog{},
 	); migrateErr != nil {
 		return nil, fmt.Errorf("database auto-migration failed: %w", migrateErr)
 	}

--- a/internal/models/ai_usage.go
+++ b/internal/models/ai_usage.go
@@ -1,0 +1,24 @@
+package models
+
+import "time"
+
+// AIUsageLog records one AI provider call: which model/operation, the token
+// usage it consumed, the metered cost, latency and outcome. It's the data
+// behind the dashboard's model cost comparison and counterfactual ("what would
+// model X have cost") pricing — those are computed from the stored token counts.
+type AIUsageLog struct {
+	ID        uint      `gorm:"primarykey"`
+	CreatedAt time.Time `gorm:"index"`
+
+	Operation string `gorm:"size:64;index"` // e.g. "ExtractRecipeFromText"
+	Provider  string `gorm:"size:32;index"` // e.g. "anthropic"
+	Model     string `gorm:"size:96;index"` // e.g. "claude-haiku-4-5-20251001"
+
+	InputTokens      int
+	OutputTokens     int
+	CacheInputTokens int
+
+	CostUSD    float64 // metered cost for the actual model (from the price table)
+	DurationMS int64   // call latency
+	Success    bool    `gorm:"index"`
+}

--- a/internal/repository/ai_usage.go
+++ b/internal/repository/ai_usage.go
@@ -1,0 +1,21 @@
+package repository
+
+import (
+	"github.com/windoze95/saltybytes-api/internal/models"
+	"gorm.io/gorm"
+)
+
+// AIUsageRepository persists AI call usage/cost records.
+type AIUsageRepository struct {
+	DB *gorm.DB
+}
+
+// NewAIUsageRepository creates a new AIUsageRepository.
+func NewAIUsageRepository(db *gorm.DB) *AIUsageRepository {
+	return &AIUsageRepository{DB: db}
+}
+
+// Insert records a single AI usage row.
+func (r *AIUsageRepository) Insert(log *models.AIUsageLog) error {
+	return r.DB.Create(log).Error
+}

--- a/internal/router/router.go
+++ b/internal/router/router.go
@@ -10,6 +10,7 @@ import (
 	"github.com/windoze95/saltybytes-api/internal/handlers"
 	"github.com/windoze95/saltybytes-api/internal/logger"
 	"github.com/windoze95/saltybytes-api/internal/middleware"
+	"github.com/windoze95/saltybytes-api/internal/models"
 	"github.com/windoze95/saltybytes-api/internal/repository"
 	"github.com/windoze95/saltybytes-api/internal/service"
 	"github.com/windoze95/saltybytes-api/internal/video"
@@ -66,8 +67,31 @@ func SetupRouter(cfg *config.Config, database *gorm.DB) *gin.Engine {
 	textProvider := ai.NewAnthropicProvider(cfg.EnvVars.AnthropicAPIKey, cfg.EnvVars.AnthropicModel, cfg.Prompts)
 	imageProvider := ai.NewDALLEProvider(cfg.EnvVars.OpenAIAPIKey)
 
-	// AI observability middleware
-	aiMW := ai.NewMiddlewareChain(&ai.LoggingMiddleware{})
+	// AI observability + cost metering. The cost middleware records every AI
+	// call's tokens + metered cost to ai_usage_logs (off the request path) —
+	// the data behind the dashboard's model cost comparison + counterfactuals.
+	aiUsageRepo := repository.NewAIUsageRepository(database)
+	costMW := &ai.CostMiddleware{
+		Pricing: ai.DefaultPricing,
+		Sink: func(rec ai.UsageRecord) {
+			go func() {
+				if err := aiUsageRepo.Insert(&models.AIUsageLog{
+					Operation:        rec.Operation,
+					Provider:         rec.Provider,
+					Model:            rec.Model,
+					InputTokens:      rec.InputTokens,
+					OutputTokens:     rec.OutputTokens,
+					CacheInputTokens: rec.CacheInputTokens,
+					CostUSD:          rec.CostUSD,
+					DurationMS:       rec.DurationMS,
+					Success:          rec.Success,
+				}); err != nil {
+					logger.Get().Warn("failed to record AI usage", zap.Error(err))
+				}
+			}()
+		},
+	}
+	aiMW := ai.NewMiddlewareChain(&ai.LoggingMiddleware{}, costMW)
 	textProvider.WithMiddleware(aiMW)
 
 	// Recipe-related routes setup


### PR DESCRIPTION
Foundation for the dashboard AI-model cost comparison. Step 1 of the model-swap work.

## What

Every AI call already returns `Usage.{InputTokens, OutputTokens}` and runs through the `AIMiddleware` — but the usage was thrown away. This captures it.

- `recordUsage` flows a provider call's token usage through a context sink into `AIOperationResult.Usage`; the Anthropic provider reports it on every message.
- `CostMiddleware` meters each call (tokens × a per-model price table) and hands a `UsageRecord` to a sink; the router persists it to `ai_usage_logs` **off the request path** (async goroutine — no added latency).
- `PricingTable` seeds list prices for Claude / GPT / Gemini / DeepSeek, **prefix-matched** so dated IDs (`claude-haiku-4-5-20251001`) resolve to their family price.
- New additive `AIUsageLog` model: `operation, provider, model, input/output tokens, cost_usd, duration_ms, success`.

## Why this shape

The dashboard reads `ai_usage_logs` directly and computes **counterfactuals from the stored token counts** (tokens × any model's price) — so "we spent $X on Haiku; it'd have been $Y on gpt-4o-mini" works without changing what we actually run.

## Tests (offline, race-clean)

Pricing (prefix match + unknown→0), middleware metering + zero-usage skip, and the critical path: a mid-call `recordUsage` reaches `After()`. Additive table; dashboard-safe.

> Next: the swappable OpenAI-compatible cheap-tier provider, then the dashboard AI-models page.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BU4UWZutHd1AnK3XAf7H19