### PR TITLE
feat(ai): live-switchable light-tier model registry + validation probe

### DIFF
--- a/internal/ai/light_factory.go
+++ b/internal/ai/light_factory.go
@@ -1,0 +1,134 @@
+package ai
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"github.com/windoze95/saltybytes-api/internal/config"
+)
+
+// Default endpoints and models per light-tier provider. Used when a spec leaves
+// them blank. Centralised here so the env-default path (router) and the
+// DB-driven live-switch (model manager) resolve identically.
+const (
+	geminiDefaultBaseURL   = "https://generativelanguage.googleapis.com/v1beta/openai"
+	deepseekDefaultBaseURL = "https://api.deepseek.com"
+
+	openAIDefaultModel   = "gpt-4o-mini"
+	geminiDefaultModel   = "gemini-2.0-flash"
+	deepseekDefaultModel = "deepseek-chat"
+)
+
+// LightProviderSpec identifies a light-tier model: which provider, which model
+// id, and an optional endpoint override. The zero Provider ("") is treated as
+// "anthropic" (the Haiku default).
+type LightProviderSpec struct {
+	Provider string `json:"provider"` // anthropic|openai|gemini|deepseek
+	Model    string `json:"model"`
+	BaseURL  string `json:"base_url"`
+}
+
+// LightKeys carries the API keys (sourced from env/SSM, never the DB) used to
+// build a light-tier provider, plus the Anthropic light-model default.
+type LightKeys struct {
+	AnthropicAPIKey     string
+	AnthropicLightModel string
+	OpenAIAPIKey        string
+	GeminiAPIKey        string
+	DeepSeekAPIKey      string
+}
+
+// BuildLightProvider constructs the cheap "light" tier TextProvider for a spec.
+// Anthropic uses the Claude Haiku client; openai/gemini/deepseek use the shared
+// OpenAI-compatible provider with the appropriate base URL. mw (cost metering +
+// logging) is attached when non-nil. Returns an error when the required API key
+// for the selected provider is missing or the provider name is unknown — so a
+// misconfigured switch fails loudly instead of silently doing nothing.
+func BuildLightProvider(spec LightProviderSpec, keys LightKeys, prompts *config.Prompts, mw AIMiddleware) (TextProvider, error) {
+	switch spec.Provider {
+	case "openai":
+		if keys.OpenAIAPIKey == "" {
+			return nil, fmt.Errorf("light provider openai selected but OPENAI_API_KEY is not set")
+		}
+		model := spec.Model
+		if model == "" {
+			model = openAIDefaultModel
+		}
+		p := NewOpenAICompatProvider(keys.OpenAIAPIKey, spec.BaseURL, model, "openai", prompts)
+		if mw != nil {
+			p.WithMiddleware(mw)
+		}
+		return p, nil
+	case "gemini":
+		if keys.GeminiAPIKey == "" {
+			return nil, fmt.Errorf("light provider gemini selected but GEMINI_API_KEY is not set")
+		}
+		baseURL := spec.BaseURL
+		if baseURL == "" {
+			baseURL = geminiDefaultBaseURL
+		}
+		model := spec.Model
+		if model == "" {
+			model = geminiDefaultModel
+		}
+		p := NewOpenAICompatProvider(keys.GeminiAPIKey, baseURL, model, "gemini", prompts)
+		if mw != nil {
+			p.WithMiddleware(mw)
+		}
+		return p, nil
+	case "deepseek":
+		if keys.DeepSeekAPIKey == "" {
+			return nil, fmt.Errorf("light provider deepseek selected but DEEPSEEK_API_KEY is not set")
+		}
+		baseURL := spec.BaseURL
+		if baseURL == "" {
+			baseURL = deepseekDefaultBaseURL
+		}
+		model := spec.Model
+		if model == "" {
+			model = deepseekDefaultModel
+		}
+		p := NewOpenAICompatProvider(keys.DeepSeekAPIKey, baseURL, model, "deepseek", prompts)
+		if mw != nil {
+			p.WithMiddleware(mw)
+		}
+		return p, nil
+	case "anthropic", "":
+		model := spec.Model
+		if model == "" {
+			model = keys.AnthropicLightModel
+		}
+		p := NewAnthropicLightProvider(keys.AnthropicAPIKey, model, prompts)
+		if mw != nil {
+			p.WithMiddleware(mw)
+		}
+		return p, nil
+	default:
+		return nil, fmt.Errorf("unknown light provider %q", spec.Provider)
+	}
+}
+
+// validationProbeText is a trivial recipe used by ValidateModel. It is small but
+// complete enough that any working extraction model returns a structured recipe.
+const validationProbeText = "Buttered toast.\nIngredients: 2 slices of bread, 1 tablespoon butter.\nSteps: 1. Toast the bread until golden. 2. Spread the butter evenly."
+
+// ValidateModel runs a live validation probe against a spec: it builds the
+// provider and performs one real minimal extraction. Success proves the model
+// id exists, the API key works, the endpoint is reachable, and the model
+// supports the forced function-calling the app relies on. A non-nil error means
+// the model must NOT be activated (fail-closed). The probe is unmetered (no
+// middleware) so it never pollutes production usage stats, and is bounded by a
+// timeout so a hung endpoint can't block a switch indefinitely.
+func ValidateModel(ctx context.Context, spec LightProviderSpec, keys LightKeys, prompts *config.Prompts) error {
+	p, err := BuildLightProvider(spec, keys, prompts, nil)
+	if err != nil {
+		return err
+	}
+	ctx, cancel := context.WithTimeout(ctx, 45*time.Second)
+	defer cancel()
+	if _, err := p.ExtractRecipeFromText(ctx, validationProbeText, "metric"); err != nil {
+		return fmt.Errorf("validation probe failed: %w", err)
+	}
+	return nil
+}

--- a/internal/ai/light_factory_test.go
+++ b/internal/ai/light_factory_test.go
@@ -1,0 +1,41 @@
+package ai
+
+import "testing"
+
+func TestBuildLightProvider_RequiresKey(t *testing.T) {
+	prompts := testPrompts()
+	noKeys := LightKeys{}
+
+	for _, provider := range []string{"openai", "gemini", "deepseek"} {
+		if _, err := BuildLightProvider(LightProviderSpec{Provider: provider}, noKeys, prompts, nil); err == nil {
+			t.Errorf("BuildLightProvider(%s) with no key: expected error, got nil", provider)
+		}
+	}
+}
+
+func TestBuildLightProvider_BuildsWithKeys(t *testing.T) {
+	prompts := testPrompts()
+	keys := LightKeys{
+		AnthropicAPIKey: "k",
+		OpenAIAPIKey:    "k",
+		GeminiAPIKey:    "k",
+		DeepSeekAPIKey:  "k",
+	}
+
+	for _, provider := range []string{"openai", "gemini", "deepseek", "anthropic", ""} {
+		p, err := BuildLightProvider(LightProviderSpec{Provider: provider}, keys, prompts, nil)
+		if err != nil {
+			t.Errorf("BuildLightProvider(%q): unexpected error %v", provider, err)
+			continue
+		}
+		if p == nil {
+			t.Errorf("BuildLightProvider(%q): nil provider", provider)
+		}
+	}
+}
+
+func TestBuildLightProvider_UnknownProvider(t *testing.T) {
+	if _, err := BuildLightProvider(LightProviderSpec{Provider: "bananas"}, LightKeys{}, testPrompts(), nil); err == nil {
+		t.Error("BuildLightProvider(bananas): expected error for unknown provider")
+	}
+}

--- a/internal/ai/pricing.go
+++ b/internal/ai/pricing.go
@@ -28,6 +28,13 @@ var DefaultPricing = PricingTable{
 	"deepseek-chat":         {InputPerM: 0.27, OutputPerM: 1.10, CacheInputPerM: 0.07},
 }
 
+// Lookup resolves a model's published price by longest-prefix match, returning
+// false when the model is unknown. Exported so the model registry can seed an
+// option's list prices from the default table.
+func (p PricingTable) Lookup(model string) (ModelPrice, bool) {
+	return p.priceFor(model)
+}
+
 // priceFor resolves a model's price, matching by longest prefix so dated IDs
 // (e.g. "claude-haiku-4-5-20251001") map to their family price. Returns false
 // when unknown.

--- a/internal/ai/switchable.go
+++ b/internal/ai/switchable.go
@@ -1,0 +1,78 @@
+package ai
+
+import (
+	"context"
+	"sync"
+)
+
+// SwitchableTextProvider is a TextProvider whose underlying implementation can
+// be swapped at runtime, atomically and concurrency-safely. It backs the live
+// model switch: the model manager builds a new light-tier provider (after a
+// green validation probe) and calls Set to redirect all in-flight and future
+// calls to it, with no restart. Every method simply delegates to the current
+// provider under a read lock.
+type SwitchableTextProvider struct {
+	mu      sync.RWMutex
+	current TextProvider
+}
+
+// Compile-time assurance it satisfies the full TextProvider interface.
+var _ TextProvider = (*SwitchableTextProvider)(nil)
+
+// NewSwitchableTextProvider wraps an initial provider.
+func NewSwitchableTextProvider(initial TextProvider) *SwitchableTextProvider {
+	return &SwitchableTextProvider{current: initial}
+}
+
+// Set atomically swaps the active provider. A nil provider is ignored so a
+// caller can never accidentally blank the tier.
+func (s *SwitchableTextProvider) Set(p TextProvider) {
+	if p == nil {
+		return
+	}
+	s.mu.Lock()
+	s.current = p
+	s.mu.Unlock()
+}
+
+func (s *SwitchableTextProvider) get() TextProvider {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	return s.current
+}
+
+func (s *SwitchableTextProvider) GenerateRecipe(ctx context.Context, req RecipeRequest) (*RecipeResult, error) {
+	return s.get().GenerateRecipe(ctx, req)
+}
+
+func (s *SwitchableTextProvider) RegenerateRecipe(ctx context.Context, req RegenerateRequest) (*RecipeResult, error) {
+	return s.get().RegenerateRecipe(ctx, req)
+}
+
+func (s *SwitchableTextProvider) ForkRecipe(ctx context.Context, req ForkRequest) (*RecipeResult, error) {
+	return s.get().ForkRecipe(ctx, req)
+}
+
+func (s *SwitchableTextProvider) AnalyzeAllergens(ctx context.Context, req AllergenRequest) (*AllergenResult, error) {
+	return s.get().AnalyzeAllergens(ctx, req)
+}
+
+func (s *SwitchableTextProvider) ClassifyVoiceIntent(ctx context.Context, transcript string) (*VoiceIntent, error) {
+	return s.get().ClassifyVoiceIntent(ctx, transcript)
+}
+
+func (s *SwitchableTextProvider) EstimatePortions(ctx context.Context, recipeDef interface{}) (*PortionEstimate, error) {
+	return s.get().EstimatePortions(ctx, recipeDef)
+}
+
+func (s *SwitchableTextProvider) ExtractRecipeFromText(ctx context.Context, text string, unitSystem string) (*RecipeResult, error) {
+	return s.get().ExtractRecipeFromText(ctx, text, unitSystem)
+}
+
+func (s *SwitchableTextProvider) CookingQA(ctx context.Context, question string, recipeContext string) (string, error) {
+	return s.get().CookingQA(ctx, question, recipeContext)
+}
+
+func (s *SwitchableTextProvider) DietaryInterview(ctx context.Context, messages []Message, memberName string) (*DietaryInterviewResult, error) {
+	return s.get().DietaryInterview(ctx, messages, memberName)
+}

--- a/internal/ai/switchable_test.go
+++ b/internal/ai/switchable_test.go
@@ -1,0 +1,73 @@
+package ai
+
+import (
+	"context"
+	"testing"
+)
+
+// switchStub is a minimal TextProvider whose ExtractRecipeFromText returns its
+// own name as the recipe title, so a test can tell which delegate handled a call.
+type switchStub struct{ name string }
+
+func (s switchStub) GenerateRecipe(context.Context, RecipeRequest) (*RecipeResult, error) {
+	return &RecipeResult{Title: s.name}, nil
+}
+func (s switchStub) RegenerateRecipe(context.Context, RegenerateRequest) (*RecipeResult, error) {
+	return &RecipeResult{Title: s.name}, nil
+}
+func (s switchStub) ForkRecipe(context.Context, ForkRequest) (*RecipeResult, error) {
+	return &RecipeResult{Title: s.name}, nil
+}
+func (s switchStub) AnalyzeAllergens(context.Context, AllergenRequest) (*AllergenResult, error) {
+	return &AllergenResult{}, nil
+}
+func (s switchStub) ClassifyVoiceIntent(context.Context, string) (*VoiceIntent, error) {
+	return &VoiceIntent{}, nil
+}
+func (s switchStub) EstimatePortions(context.Context, interface{}) (*PortionEstimate, error) {
+	return &PortionEstimate{}, nil
+}
+func (s switchStub) ExtractRecipeFromText(context.Context, string, string) (*RecipeResult, error) {
+	return &RecipeResult{Title: s.name}, nil
+}
+func (s switchStub) CookingQA(context.Context, string, string) (string, error) {
+	return s.name, nil
+}
+func (s switchStub) DietaryInterview(context.Context, []Message, string) (*DietaryInterviewResult, error) {
+	return &DietaryInterviewResult{}, nil
+}
+
+func TestSwitchableTextProvider_Delegates(t *testing.T) {
+	sw := NewSwitchableTextProvider(switchStub{name: "first"})
+
+	got, err := sw.ExtractRecipeFromText(context.Background(), "x", "metric")
+	if err != nil {
+		t.Fatalf("ExtractRecipeFromText: %v", err)
+	}
+	if got.Title != "first" {
+		t.Errorf("title = %q, want %q", got.Title, "first")
+	}
+
+	// Swap the underlying provider and confirm the next call routes to it.
+	sw.Set(switchStub{name: "second"})
+	got, err = sw.ExtractRecipeFromText(context.Background(), "x", "metric")
+	if err != nil {
+		t.Fatalf("ExtractRecipeFromText after Set: %v", err)
+	}
+	if got.Title != "second" {
+		t.Errorf("after Set, title = %q, want %q", got.Title, "second")
+	}
+}
+
+func TestSwitchableTextProvider_SetNilIgnored(t *testing.T) {
+	sw := NewSwitchableTextProvider(switchStub{name: "keep"})
+	sw.Set(nil) // must not blank the tier
+
+	got, err := sw.CookingQA(context.Background(), "q", "")
+	if err != nil {
+		t.Fatalf("CookingQA: %v", err)
+	}
+	if got != "keep" {
+		t.Errorf("after Set(nil), got %q, want %q", got, "keep")
+	}
+}

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -40,6 +40,10 @@ type EnvVars struct {
 	LightBaseURL   string `env:"LIGHT_BASE_URL" optional:"true"`
 	GeminiAPIKey   string `env:"GEMINI_API_KEY" optional:"true"`
 	DeepSeekAPIKey string `env:"DEEPSEEK_API_KEY" optional:"true"`
+	// AdminToken guards the admin API (the dashboard's live model-switch +
+	// registry endpoints). When empty the admin API is disabled entirely, so a
+	// deploy without the secret can never expose those endpoints.
+	AdminToken string `env:"ADMIN_TOKEN" optional:"true"`
 	// PromptsPath overrides the location of the prompts YAML file, which is
 	// cwd-relative by default and only resolves from the Docker workdir.
 	PromptsPath     string `env:"PROMPTS_PATH" envDefault:"configs/prompts.yaml" optional:"true"`

--- a/internal/db/db.go
+++ b/internal/db/db.go
@@ -63,6 +63,8 @@ func connectToDatabaseWithRetry(databaseURL string) (*gorm.DB, error) {
 		&models.VideoExtractionCache{},
 		&models.VideoImport{},
 		&models.AIUsageLog{},
+		&models.AIModelOption{},
+		&models.AIConfig{},
 	); migrateErr != nil {
 		return nil, fmt.Errorf("database auto-migration failed: %w", migrateErr)
 	}

--- a/internal/handlers/admin_ai.go
+++ b/internal/handlers/admin_ai.go
@@ -1,0 +1,145 @@
+package handlers
+
+import (
+	"net/http"
+
+	"github.com/gin-gonic/gin"
+	"github.com/windoze95/saltybytes-api/internal/models"
+	"github.com/windoze95/saltybytes-api/internal/service"
+)
+
+// AdminAIHandler exposes the light-tier model registry + live switch to the
+// admin dashboard. All routes sit behind RequireAdminToken.
+type AdminAIHandler struct {
+	Manager *service.AIModelManager
+}
+
+// NewAdminAIHandler creates a new AdminAIHandler.
+func NewAdminAIHandler(manager *service.AIModelManager) *AdminAIHandler {
+	return &AdminAIHandler{Manager: manager}
+}
+
+// modelOptionRequest is the editable shape of a registry entry. API keys are
+// never accepted here — they live in env/SSM.
+type modelOptionRequest struct {
+	Provider           string  `json:"provider"`
+	ModelID            string  `json:"model_id"`
+	Label              string  `json:"label"`
+	BaseURL            string  `json:"base_url"`
+	InputPricePerMTok  float64 `json:"input_price_per_mtok"`
+	OutputPricePerMTok float64 `json:"output_price_per_mtok"`
+	Enabled            bool    `json:"enabled"`
+}
+
+func (r modelOptionRequest) toModel() *models.AIModelOption {
+	return &models.AIModelOption{
+		Provider:           r.Provider,
+		ModelID:            r.ModelID,
+		Label:              r.Label,
+		BaseURL:            r.BaseURL,
+		InputPricePerMTok:  r.InputPricePerMTok,
+		OutputPricePerMTok: r.OutputPricePerMTok,
+		Enabled:            r.Enabled,
+	}
+}
+
+// ListModels returns every registered model option plus the active selection.
+func (h *AdminAIHandler) ListModels(c *gin.Context) {
+	opts, err := h.Manager.ListModels()
+	if err != nil {
+		c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
+		return
+	}
+	c.JSON(http.StatusOK, gin.H{
+		"models": opts,
+		"active": h.Manager.GetActive(),
+	})
+}
+
+// CreateModel validation-probes a candidate then saves it. The probe outcome is
+// recorded on the returned option (validated + validation_error); a failed probe
+// still saves the option (so it's visible) but it cannot be activated until it
+// probes green.
+func (h *AdminAIHandler) CreateModel(c *gin.Context) {
+	var req modelOptionRequest
+	if err := c.ShouldBindJSON(&req); err != nil {
+		c.JSON(http.StatusBadRequest, gin.H{"error": "invalid request body"})
+		return
+	}
+	if req.Provider == "" || req.ModelID == "" {
+		c.JSON(http.StatusBadRequest, gin.H{"error": "provider and model_id are required"})
+		return
+	}
+
+	opt := req.toModel()
+	if err := h.Manager.AddModel(c.Request.Context(), opt); err != nil {
+		c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
+		return
+	}
+	c.JSON(http.StatusOK, opt)
+}
+
+// UpdateModel edits an option, re-probing if the model identity changed.
+func (h *AdminAIHandler) UpdateModel(c *gin.Context) {
+	id, err := parseUintParam(c.Param("id"))
+	if err != nil {
+		c.JSON(http.StatusBadRequest, gin.H{"error": "invalid id"})
+		return
+	}
+	var req modelOptionRequest
+	if err := c.ShouldBindJSON(&req); err != nil {
+		c.JSON(http.StatusBadRequest, gin.H{"error": "invalid request body"})
+		return
+	}
+	opt, err := h.Manager.UpdateModel(c.Request.Context(), id, req.toModel())
+	if err != nil {
+		c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
+		return
+	}
+	c.JSON(http.StatusOK, opt)
+}
+
+// DeleteModel removes an option.
+func (h *AdminAIHandler) DeleteModel(c *gin.Context) {
+	id, err := parseUintParam(c.Param("id"))
+	if err != nil {
+		c.JSON(http.StatusBadRequest, gin.H{"error": "invalid id"})
+		return
+	}
+	if err := h.Manager.DeleteModel(id); err != nil {
+		c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
+		return
+	}
+	c.JSON(http.StatusOK, gin.H{"status": "ok"})
+}
+
+// GetActive returns the currently-active light-tier spec.
+func (h *AdminAIHandler) GetActive(c *gin.Context) {
+	c.JSON(http.StatusOK, gin.H{"active": h.Manager.GetActive()})
+}
+
+// activateRequest selects which registered option to activate.
+type activateRequest struct {
+	ID uint `json:"id"`
+}
+
+// SetActive switches the live light tier to a registered option after a green
+// validation probe. On a failed probe it returns 400 and leaves the active
+// model unchanged (fail-closed) — a misconfigured switch can never break prod.
+func (h *AdminAIHandler) SetActive(c *gin.Context) {
+	var req activateRequest
+	if err := c.ShouldBindJSON(&req); err != nil || req.ID == 0 {
+		c.JSON(http.StatusBadRequest, gin.H{"error": "id is required"})
+		return
+	}
+	opt, err := h.Manager.Activate(c.Request.Context(), req.ID)
+	if err != nil {
+		// Validation/probe failure → 400 with the reason; active model untouched.
+		c.JSON(http.StatusBadRequest, gin.H{"error": err.Error()})
+		return
+	}
+	c.JSON(http.StatusOK, gin.H{
+		"active": h.Manager.GetActive(),
+		"option": opt,
+	})
+}

--- a/internal/middleware/admin.go
+++ b/internal/middleware/admin.go
@@ -1,0 +1,38 @@
+package middleware
+
+import (
+	"crypto/subtle"
+	"net/http"
+	"strings"
+
+	"github.com/gin-gonic/gin"
+)
+
+// RequireAdminToken guards the admin API. The dashboard authenticates by sending
+// the shared admin token in the X-Admin-Token header (or Authorization: Bearer).
+// When no token is configured the admin API is disabled entirely (503) — it is
+// never left open. The compare is constant-time to avoid leaking the token via
+// timing.
+func RequireAdminToken(token string) gin.HandlerFunc {
+	return func(c *gin.Context) {
+		if token == "" {
+			c.JSON(http.StatusServiceUnavailable, gin.H{"error": "admin API disabled (ADMIN_TOKEN not configured)"})
+			c.Abort()
+			return
+		}
+
+		got := c.GetHeader("X-Admin-Token")
+		if got == "" {
+			if h := c.GetHeader("Authorization"); strings.HasPrefix(h, "Bearer ") {
+				got = strings.TrimPrefix(h, "Bearer ")
+			}
+		}
+
+		if subtle.ConstantTimeCompare([]byte(got), []byte(token)) != 1 {
+			c.JSON(http.StatusUnauthorized, gin.H{"error": "unauthorized"})
+			c.Abort()
+			return
+		}
+		c.Next()
+	}
+}

--- a/internal/models/ai_model_option.go
+++ b/internal/models/ai_model_option.go
@@ -1,0 +1,53 @@
+package models
+
+import "time"
+
+// AIModelOption is a user-managed entry in the swappable "light tier" model
+// registry. The dashboard lets an operator add OpenAI/Gemini/DeepSeek/Anthropic
+// models here (just provider + model id + display/price metadata; API keys stay
+// in SSM, never in the DB) and switch the active one live. Persisted in RDS so
+// the registry survives container restarts and image updates.
+//
+// Validated/ValidationError/LastValidatedAt record the outcome of the live
+// validation probe (a real minimal extraction) run when the option is added or
+// activated — a model can only go live after a green probe (fail-closed).
+//
+// The fields are additive and the table is read by the dashboard directly, so
+// keep changes additive (see the dashboard-schema-coupling note).
+type AIModelOption struct {
+	ID        uint      `gorm:"primarykey" json:"id"`
+	CreatedAt time.Time `json:"created_at"`
+	UpdatedAt time.Time `json:"updated_at"`
+
+	// (provider, model_id) is unique so concurrent first-boot seeding across
+	// multiple instances can't create duplicate registry rows.
+	Provider string `gorm:"size:32;uniqueIndex:idx_ai_model_options_provider_model,priority:1" json:"provider"` // anthropic|openai|gemini|deepseek
+	ModelID  string `gorm:"size:96;uniqueIndex:idx_ai_model_options_provider_model,priority:2" json:"model_id"` // e.g. "gpt-4o-mini"
+	Label    string `gorm:"size:96" json:"label"`                                                               // human-friendly name
+	BaseURL  string `gorm:"size:255" json:"base_url"`                                                           // optional endpoint override
+
+	// List prices (USD per 1M tokens) for dashboard counterfactual comparison.
+	InputPricePerMTok  float64 `json:"input_price_per_mtok"`
+	OutputPricePerMTok float64 `json:"output_price_per_mtok"`
+
+	Enabled bool `gorm:"default:true" json:"enabled"`
+
+	// Validation-probe outcome.
+	Validated       bool       `json:"validated"`
+	ValidationError string     `gorm:"size:512" json:"validation_error"`
+	LastValidatedAt *time.Time `json:"last_validated_at"`
+}
+
+// AIConfig is the single-row table holding the currently-active light-tier
+// selection. It stores the resolved spec (provider/model/base URL) rather than a
+// foreign key to AIModelOption, so the running provider keeps working even if
+// the option row is later edited or deleted. Seeded from the env default on
+// first boot; updated by the dashboard live-switch after a green probe.
+type AIConfig struct {
+	ID        uint      `gorm:"primarykey" json:"id"` // always 1 (single row)
+	UpdatedAt time.Time `json:"updated_at"`
+
+	ActiveProvider string `gorm:"size:32" json:"active_provider"`
+	ActiveModel    string `gorm:"size:96" json:"active_model"`
+	ActiveBaseURL  string `gorm:"size:255" json:"active_base_url"`
+}

--- a/internal/repository/ai_model_option.go
+++ b/internal/repository/ai_model_option.go
@@ -1,0 +1,79 @@
+package repository
+
+import (
+	"errors"
+
+	"github.com/windoze95/saltybytes-api/internal/models"
+	"gorm.io/gorm"
+	"gorm.io/gorm/clause"
+)
+
+// AIModelOptionRepository persists the swappable light-tier model registry
+// (ai_model_options) and the single active-selection row (ai_config).
+type AIModelOptionRepository struct {
+	DB *gorm.DB
+}
+
+// NewAIModelOptionRepository creates a new AIModelOptionRepository.
+func NewAIModelOptionRepository(db *gorm.DB) *AIModelOptionRepository {
+	return &AIModelOptionRepository{DB: db}
+}
+
+// ListOptions returns every registered model option, newest first.
+func (r *AIModelOptionRepository) ListOptions() ([]models.AIModelOption, error) {
+	var opts []models.AIModelOption
+	if err := r.DB.Order("created_at DESC").Find(&opts).Error; err != nil {
+		return nil, err
+	}
+	return opts, nil
+}
+
+// GetOption returns a single option by ID, or (nil, nil) if it does not exist.
+func (r *AIModelOptionRepository) GetOption(id uint) (*models.AIModelOption, error) {
+	var opt models.AIModelOption
+	err := r.DB.First(&opt, id).Error
+	if errors.Is(err, gorm.ErrRecordNotFound) {
+		return nil, nil
+	}
+	if err != nil {
+		return nil, err
+	}
+	return &opt, nil
+}
+
+// CreateOption inserts a new option.
+func (r *AIModelOptionRepository) CreateOption(opt *models.AIModelOption) error {
+	return r.DB.Create(opt).Error
+}
+
+// UpdateOption persists all fields of an existing option.
+func (r *AIModelOptionRepository) UpdateOption(opt *models.AIModelOption) error {
+	return r.DB.Save(opt).Error
+}
+
+// DeleteOption removes an option by ID.
+func (r *AIModelOptionRepository) DeleteOption(id uint) error {
+	return r.DB.Delete(&models.AIModelOption{}, id).Error
+}
+
+// GetConfig returns the single active-config row, or (nil, nil) if unset.
+func (r *AIModelOptionRepository) GetConfig() (*models.AIConfig, error) {
+	var cfg models.AIConfig
+	err := r.DB.Order("id").First(&cfg).Error
+	if errors.Is(err, gorm.ErrRecordNotFound) {
+		return nil, nil
+	}
+	if err != nil {
+		return nil, err
+	}
+	return &cfg, nil
+}
+
+// UpsertConfig writes the single active-config row (id=1), inserting or updating.
+func (r *AIModelOptionRepository) UpsertConfig(cfg *models.AIConfig) error {
+	cfg.ID = 1
+	return r.DB.Clauses(clause.OnConflict{
+		Columns:   []clause.Column{{Name: "id"}},
+		DoUpdates: clause.AssignmentColumns([]string{"active_provider", "active_model", "active_base_url", "updated_at"}),
+	}).Create(cfg).Error
+}

--- a/internal/router/router.go
+++ b/internal/router/router.go
@@ -1,6 +1,7 @@
 package router
 
 import (
+	"context"
 	"time"
 
 	"github.com/gin-contrib/cors"
@@ -19,48 +20,15 @@ import (
 	"gorm.io/gorm"
 )
 
-// buildLightTextProvider constructs the cheap "light" tier text provider from
-// config. Defaults to Anthropic Haiku; LIGHT_PROVIDER=openai/gemini/deepseek
-// runs a cheaper OpenAI-compatible model instead. The middleware (cost metering
-// + logging) is attached so usage is recorded regardless of provider.
-func buildLightTextProvider(cfg *config.Config, mw ai.AIMiddleware) ai.TextProvider {
-	switch cfg.EnvVars.LightProvider {
-	case "openai":
-		model := cfg.EnvVars.LightModel
-		if model == "" {
-			model = "gpt-4o-mini"
-		}
-		p := ai.NewOpenAICompatProvider(cfg.EnvVars.OpenAIAPIKey, cfg.EnvVars.LightBaseURL, model, "openai", cfg.Prompts)
-		p.WithMiddleware(mw)
-		return p
-	case "gemini":
-		baseURL := cfg.EnvVars.LightBaseURL
-		if baseURL == "" {
-			baseURL = "https://generativelanguage.googleapis.com/v1beta/openai"
-		}
-		model := cfg.EnvVars.LightModel
-		if model == "" {
-			model = "gemini-2.0-flash"
-		}
-		p := ai.NewOpenAICompatProvider(cfg.EnvVars.GeminiAPIKey, baseURL, model, "gemini", cfg.Prompts)
-		p.WithMiddleware(mw)
-		return p
-	case "deepseek":
-		baseURL := cfg.EnvVars.LightBaseURL
-		if baseURL == "" {
-			baseURL = "https://api.deepseek.com"
-		}
-		model := cfg.EnvVars.LightModel
-		if model == "" {
-			model = "deepseek-chat"
-		}
-		p := ai.NewOpenAICompatProvider(cfg.EnvVars.DeepSeekAPIKey, baseURL, model, "deepseek", cfg.Prompts)
-		p.WithMiddleware(mw)
-		return p
-	default:
-		p := ai.NewAnthropicLightProvider(cfg.EnvVars.AnthropicAPIKey, cfg.EnvVars.AnthropicLightModel, cfg.Prompts)
-		p.WithMiddleware(mw)
-		return p
+// lightKeysFromConfig collects the light-tier API keys from config. Keys come
+// from env/SSM only — never the DB.
+func lightKeysFromConfig(cfg *config.Config) ai.LightKeys {
+	return ai.LightKeys{
+		AnthropicAPIKey:     cfg.EnvVars.AnthropicAPIKey,
+		AnthropicLightModel: cfg.EnvVars.AnthropicLightModel,
+		OpenAIAPIKey:        cfg.EnvVars.OpenAIAPIKey,
+		GeminiAPIKey:        cfg.EnvVars.GeminiAPIKey,
+		DeepSeekAPIKey:      cfg.EnvVars.DeepSeekAPIKey,
 	}
 }
 
@@ -149,8 +117,22 @@ func SetupRouter(cfg *config.Config, database *gorm.DB) *gin.Engine {
 	recipeHandler := handlers.NewRecipeHandler(recipeService)
 	recipeHandler.SubService = subService
 
+	// Light-tier model manager: owns the swappable cheap provider behind a
+	// single SwitchableTextProvider. It seeds the registry + active selection
+	// from the env default, applies whatever the DB marks active, and polls so a
+	// dashboard live-switch on one instance propagates to the others.
+	aiModelOptionRepo := repository.NewAIModelOptionRepository(database)
+	envLightSpec := ai.LightProviderSpec{
+		Provider: cfg.EnvVars.LightProvider,
+		Model:    cfg.EnvVars.LightModel,
+		BaseURL:  cfg.EnvVars.LightBaseURL,
+	}
+	modelManager := service.NewAIModelManager(aiModelOptionRepo, lightKeysFromConfig(cfg), cfg.Prompts, aiMW, envLightSpec)
+	modelManager.Load(context.Background())
+	modelManager.StartRefresh(context.Background(), 30*time.Second)
+	previewProvider := modelManager.Provider()
+
 	// Import-related routes setup
-	previewProvider := buildLightTextProvider(cfg, aiMW)
 	canonicalRepo := repository.NewCanonicalRecipeRepository(database)
 	importService := service.NewImportService(cfg, recipeRepo, recipeService, textProvider, textProvider, previewProvider)
 	importService.CanonicalRepo = canonicalRepo
@@ -170,6 +152,23 @@ func SetupRouter(cfg *config.Config, database *gorm.DB) *gin.Engine {
 		logger.Get().Info("video-link import enabled")
 	} else {
 		logger.Get().Info("video-link import disabled (no ScrapeCreators API key configured)")
+	}
+
+	// Admin API: light-tier model registry + live switch, used by the operator
+	// dashboard. Guarded by the shared ID header AND a dedicated admin token; the
+	// whole group is disabled (503) when ADMIN_TOKEN is unset, so it is never
+	// exposed by accident.
+	adminAIHandler := handlers.NewAdminAIHandler(modelManager)
+	apiAdmin := r.Group("/v1/admin")
+	apiAdmin.Use(middleware.CheckIDHeader(cfg.EnvVars.IDHeader))
+	apiAdmin.Use(middleware.RequireAdminToken(cfg.EnvVars.AdminToken))
+	{
+		apiAdmin.GET("/ai/models", adminAIHandler.ListModels)
+		apiAdmin.POST("/ai/models", adminAIHandler.CreateModel)
+		apiAdmin.PUT("/ai/models/:id", adminAIHandler.UpdateModel)
+		apiAdmin.DELETE("/ai/models/:id", adminAIHandler.DeleteModel)
+		apiAdmin.GET("/ai/active", adminAIHandler.GetActive)
+		apiAdmin.PUT("/ai/active", adminAIHandler.SetActive)
 	}
 
 	// Group for API routes that don't require token verification

--- a/internal/service/ai_model_manager.go
+++ b/internal/service/ai_model_manager.go
@@ -1,0 +1,336 @@
+package service
+
+import (
+	"context"
+	"fmt"
+	"sync"
+	"time"
+
+	"github.com/windoze95/saltybytes-api/internal/ai"
+	"github.com/windoze95/saltybytes-api/internal/config"
+	"github.com/windoze95/saltybytes-api/internal/logger"
+	"github.com/windoze95/saltybytes-api/internal/models"
+	"go.uber.org/zap"
+)
+
+// AIModelOptionRepo is the persistence surface the model manager needs. Backed
+// by repository.AIModelOptionRepository in production; faked in tests.
+type AIModelOptionRepo interface {
+	ListOptions() ([]models.AIModelOption, error)
+	GetOption(id uint) (*models.AIModelOption, error)
+	CreateOption(opt *models.AIModelOption) error
+	UpdateOption(opt *models.AIModelOption) error
+	DeleteOption(id uint) error
+	GetConfig() (*models.AIConfig, error)
+	UpsertConfig(cfg *models.AIConfig) error
+}
+
+// AIModelManager owns the live light-tier model selection. It exposes a single
+// SwitchableTextProvider (handed to the import/normalize services) and drives
+// what that provider points at:
+//
+//   - Load: on boot, seed the registry + active config from the env default,
+//     then apply whatever the DB says is active.
+//   - StartRefresh: poll the DB so a switch made on one instance propagates to
+//     the others (the API runs multiple ECS tasks).
+//   - Activate: validate a candidate with a live probe and, only on success,
+//     persist it as active and switch the running provider (fail-closed).
+//
+// API keys live in LightKeys (from env/SSM), never in the DB.
+type AIModelManager struct {
+	repo     AIModelOptionRepo
+	keys     ai.LightKeys
+	prompts  *config.Prompts
+	mw       ai.AIMiddleware
+	sw       *ai.SwitchableTextProvider
+	fallback ai.LightProviderSpec
+
+	// validate runs the live probe; overridable in tests to avoid network.
+	validate func(ctx context.Context, spec ai.LightProviderSpec) error
+
+	mu     sync.RWMutex
+	active ai.LightProviderSpec
+}
+
+// NewAIModelManager builds the manager and its initial provider from the env
+// default spec. If that spec can't be built (e.g. a non-anthropic provider was
+// selected without its key), it falls back to the Anthropic Haiku default so
+// the app always boots with a working light tier.
+func NewAIModelManager(repo AIModelOptionRepo, keys ai.LightKeys, prompts *config.Prompts, mw ai.AIMiddleware, fallback ai.LightProviderSpec) *AIModelManager {
+	m := &AIModelManager{
+		repo:     repo,
+		keys:     keys,
+		prompts:  prompts,
+		mw:       mw,
+		fallback: fallback,
+	}
+	m.validate = func(ctx context.Context, spec ai.LightProviderSpec) error {
+		return ai.ValidateModel(ctx, spec, m.keys, m.prompts)
+	}
+
+	provider, err := ai.BuildLightProvider(fallback, keys, prompts, mw)
+	if err != nil {
+		logger.Get().Warn("ai model manager: env light provider unbuildable, falling back to anthropic",
+			zap.String("provider", fallback.Provider), zap.Error(err))
+		fallback = ai.LightProviderSpec{Provider: "anthropic"}
+		m.fallback = fallback
+		provider, _ = ai.BuildLightProvider(fallback, keys, prompts, mw)
+	}
+	m.sw = ai.NewSwitchableTextProvider(provider)
+	m.active = fallback
+	return m
+}
+
+// Provider returns the switchable TextProvider to hand to dependent services.
+func (m *AIModelManager) Provider() ai.TextProvider { return m.sw }
+
+// GetActive returns the spec currently driving the light tier.
+func (m *AIModelManager) GetActive() ai.LightProviderSpec {
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+	return m.active
+}
+
+// Load seeds the registry/active-config from the env default on first boot and
+// then applies whatever the DB marks active. Best-effort: any DB error is
+// logged and leaves the env-default provider running.
+func (m *AIModelManager) Load(ctx context.Context) {
+	if opts, err := m.repo.ListOptions(); err != nil {
+		logger.Get().Warn("ai model manager: list options failed during load", zap.Error(err))
+	} else if len(opts) == 0 {
+		m.seedDefaults()
+	}
+
+	cfg, err := m.repo.GetConfig()
+	if err != nil {
+		logger.Get().Warn("ai model manager: get config failed during load", zap.Error(err))
+		return
+	}
+	if cfg == nil || cfg.ActiveProvider == "" {
+		// No active selection yet — persist the env default as active.
+		if err := m.repo.UpsertConfig(&models.AIConfig{
+			ActiveProvider: m.fallback.Provider,
+			ActiveModel:    m.fallback.Model,
+			ActiveBaseURL:  m.fallback.BaseURL,
+		}); err != nil {
+			logger.Get().Warn("ai model manager: seed active config failed", zap.Error(err))
+		}
+		return
+	}
+
+	spec := ai.LightProviderSpec{Provider: cfg.ActiveProvider, Model: cfg.ActiveModel, BaseURL: cfg.ActiveBaseURL}
+	if err := m.applySpec(spec); err != nil {
+		logger.Get().Warn("ai model manager: DB-active spec unbuildable, keeping env default",
+			zap.String("provider", spec.Provider), zap.String("model", spec.Model), zap.Error(err))
+	}
+}
+
+// StartRefresh polls the active config every interval and applies a change made
+// elsewhere (another instance's live switch). It does NOT re-probe — the spec
+// was already validated when written — it only rebuilds the provider.
+func (m *AIModelManager) StartRefresh(ctx context.Context, interval time.Duration) {
+	if interval <= 0 {
+		interval = 30 * time.Second
+	}
+	go func() {
+		t := time.NewTicker(interval)
+		defer t.Stop()
+		for {
+			select {
+			case <-ctx.Done():
+				return
+			case <-t.C:
+				m.Refresh()
+			}
+		}
+	}()
+}
+
+// Refresh reconciles the running provider with the DB's active config.
+func (m *AIModelManager) Refresh() {
+	cfg, err := m.repo.GetConfig()
+	if err != nil || cfg == nil || cfg.ActiveProvider == "" {
+		return
+	}
+	spec := ai.LightProviderSpec{Provider: cfg.ActiveProvider, Model: cfg.ActiveModel, BaseURL: cfg.ActiveBaseURL}
+
+	m.mu.RLock()
+	unchanged := spec == m.active
+	m.mu.RUnlock()
+	if unchanged {
+		return
+	}
+
+	if err := m.applySpec(spec); err != nil {
+		logger.Get().Warn("ai model manager: refresh could not apply active spec, keeping current",
+			zap.String("provider", spec.Provider), zap.String("model", spec.Model), zap.Error(err))
+		return
+	}
+	logger.Get().Info("ai model manager: light tier switched via DB config",
+		zap.String("provider", spec.Provider), zap.String("model", spec.Model))
+}
+
+// applySpec builds the provider for spec and atomically swaps it in.
+func (m *AIModelManager) applySpec(spec ai.LightProviderSpec) error {
+	provider, err := ai.BuildLightProvider(spec, m.keys, m.prompts, m.mw)
+	if err != nil {
+		return err
+	}
+	m.sw.Set(provider)
+	m.mu.Lock()
+	m.active = spec
+	m.mu.Unlock()
+	return nil
+}
+
+// ListModels returns the registry.
+func (m *AIModelManager) ListModels() ([]models.AIModelOption, error) {
+	return m.repo.ListOptions()
+}
+
+// AddModel validates a candidate with a live probe, then persists it with the
+// probe outcome recorded. The option is saved even when the probe fails (so the
+// operator sees it in the list, marked invalid with the error) — only a real
+// DB write failure returns an error here.
+func (m *AIModelManager) AddModel(ctx context.Context, opt *models.AIModelOption) error {
+	spec := ai.LightProviderSpec{Provider: opt.Provider, Model: opt.ModelID, BaseURL: opt.BaseURL}
+	now := time.Now()
+	opt.LastValidatedAt = &now
+	if err := m.validate(ctx, spec); err != nil {
+		opt.Validated = false
+		opt.ValidationError = err.Error()
+	} else {
+		opt.Validated = true
+		opt.ValidationError = ""
+	}
+	return m.repo.CreateOption(opt)
+}
+
+// UpdateModel applies editable fields to an option. If the model identity
+// (provider/model/base URL) changed it re-runs the validation probe.
+func (m *AIModelManager) UpdateModel(ctx context.Context, id uint, in *models.AIModelOption) (*models.AIModelOption, error) {
+	existing, err := m.repo.GetOption(id)
+	if err != nil {
+		return nil, err
+	}
+	if existing == nil {
+		return nil, fmt.Errorf("model option %d not found", id)
+	}
+
+	identityChanged := existing.Provider != in.Provider || existing.ModelID != in.ModelID || existing.BaseURL != in.BaseURL
+
+	existing.Provider = in.Provider
+	existing.ModelID = in.ModelID
+	existing.BaseURL = in.BaseURL
+	existing.Label = in.Label
+	existing.InputPricePerMTok = in.InputPricePerMTok
+	existing.OutputPricePerMTok = in.OutputPricePerMTok
+	existing.Enabled = in.Enabled
+
+	if identityChanged {
+		spec := ai.LightProviderSpec{Provider: existing.Provider, Model: existing.ModelID, BaseURL: existing.BaseURL}
+		now := time.Now()
+		existing.LastValidatedAt = &now
+		if verr := m.validate(ctx, spec); verr != nil {
+			existing.Validated = false
+			existing.ValidationError = verr.Error()
+		} else {
+			existing.Validated = true
+			existing.ValidationError = ""
+		}
+	}
+
+	if err := m.repo.UpdateOption(existing); err != nil {
+		return nil, err
+	}
+	return existing, nil
+}
+
+// DeleteModel removes an option. Safe even if it is the active one — the active
+// config stores the resolved spec independently, so the running provider is
+// unaffected.
+func (m *AIModelManager) DeleteModel(id uint) error {
+	return m.repo.DeleteOption(id)
+}
+
+// Activate switches the live light tier to the given option — probe FIRST, and
+// only on a green probe persist it as active and swap the running provider. A
+// failed probe records the failure on the option and returns an error WITHOUT
+// touching the active selection (fail-closed: a bad model can never go live).
+func (m *AIModelManager) Activate(ctx context.Context, id uint) (*models.AIModelOption, error) {
+	opt, err := m.repo.GetOption(id)
+	if err != nil {
+		return nil, err
+	}
+	if opt == nil {
+		return nil, fmt.Errorf("model option %d not found", id)
+	}
+
+	spec := ai.LightProviderSpec{Provider: opt.Provider, Model: opt.ModelID, BaseURL: opt.BaseURL}
+	now := time.Now()
+	opt.LastValidatedAt = &now
+
+	if verr := m.validate(ctx, spec); verr != nil {
+		opt.Validated = false
+		opt.ValidationError = verr.Error()
+		_ = m.repo.UpdateOption(opt)
+		return nil, fmt.Errorf("validation failed, active model unchanged: %w", verr)
+	}
+
+	opt.Validated = true
+	opt.ValidationError = ""
+	_ = m.repo.UpdateOption(opt)
+
+	if err := m.applySpec(spec); err != nil {
+		return nil, fmt.Errorf("model validated but provider build failed: %w", err)
+	}
+	if err := m.repo.UpsertConfig(&models.AIConfig{
+		ActiveProvider: spec.Provider,
+		ActiveModel:    spec.Model,
+		ActiveBaseURL:  spec.BaseURL,
+	}); err != nil {
+		logger.Get().Warn("ai model manager: activated provider but failed to persist active config",
+			zap.String("provider", spec.Provider), zap.String("model", spec.Model), zap.Error(err))
+	}
+	logger.Get().Info("ai model manager: light tier activated",
+		zap.String("provider", spec.Provider), zap.String("model", spec.Model))
+	return opt, nil
+}
+
+// seedDefaults populates an empty registry with a curated set of light-tier
+// candidates so the dashboard has something to compare/switch out of the box.
+// The entry matching the env default is marked validated (it is what's running);
+// the rest are left unvalidated until probed via the dashboard.
+func (m *AIModelManager) seedDefaults() {
+	type seed struct{ provider, model, label string }
+	anthropicModel := m.keys.AnthropicLightModel
+	if anthropicModel == "" {
+		anthropicModel = ai.DefaultAnthropicLightModel
+	}
+	seeds := []seed{
+		{"anthropic", anthropicModel, "Claude Haiku 4.5"},
+		{"openai", "gpt-4o-mini", "GPT-4o mini"},
+		{"gemini", "gemini-2.0-flash", "Gemini 2.0 Flash"},
+		{"deepseek", "deepseek-chat", "DeepSeek Chat"},
+	}
+	for _, s := range seeds {
+		opt := &models.AIModelOption{
+			Provider: s.provider,
+			ModelID:  s.model,
+			Label:    s.label,
+			Enabled:  true,
+		}
+		if mp, ok := ai.DefaultPricing.Lookup(s.model); ok {
+			opt.InputPricePerMTok = mp.InputPerM
+			opt.OutputPricePerMTok = mp.OutputPerM
+		}
+		// Reflect the running default as already-validated.
+		if s.provider == m.fallback.Provider && (m.fallback.Model == "" || m.fallback.Model == s.model) {
+			opt.Validated = true
+		}
+		if err := m.repo.CreateOption(opt); err != nil {
+			logger.Get().Warn("ai model manager: seed option failed",
+				zap.String("provider", s.provider), zap.String("model", s.model), zap.Error(err))
+		}
+	}
+}

--- a/internal/service/ai_model_manager_test.go
+++ b/internal/service/ai_model_manager_test.go
@@ -1,0 +1,166 @@
+package service
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/windoze95/saltybytes-api/internal/ai"
+	"github.com/windoze95/saltybytes-api/internal/config"
+	"github.com/windoze95/saltybytes-api/internal/models"
+)
+
+// fakeOptionRepo is an in-memory AIModelOptionRepo for manager tests.
+type fakeOptionRepo struct {
+	opts   []models.AIModelOption
+	nextID uint
+	cfg    *models.AIConfig
+}
+
+func newFakeOptionRepo() *fakeOptionRepo { return &fakeOptionRepo{nextID: 1} }
+
+func (r *fakeOptionRepo) ListOptions() ([]models.AIModelOption, error) {
+	out := make([]models.AIModelOption, len(r.opts))
+	copy(out, r.opts)
+	return out, nil
+}
+
+func (r *fakeOptionRepo) GetOption(id uint) (*models.AIModelOption, error) {
+	for i := range r.opts {
+		if r.opts[i].ID == id {
+			cp := r.opts[i]
+			return &cp, nil
+		}
+	}
+	return nil, nil
+}
+
+func (r *fakeOptionRepo) CreateOption(opt *models.AIModelOption) error {
+	opt.ID = r.nextID
+	r.nextID++
+	r.opts = append(r.opts, *opt)
+	return nil
+}
+
+func (r *fakeOptionRepo) UpdateOption(opt *models.AIModelOption) error {
+	for i := range r.opts {
+		if r.opts[i].ID == opt.ID {
+			r.opts[i] = *opt
+			return nil
+		}
+	}
+	return errors.New("not found")
+}
+
+func (r *fakeOptionRepo) DeleteOption(id uint) error {
+	for i := range r.opts {
+		if r.opts[i].ID == id {
+			r.opts = append(r.opts[:i], r.opts[i+1:]...)
+			return nil
+		}
+	}
+	return nil
+}
+
+func (r *fakeOptionRepo) GetConfig() (*models.AIConfig, error) { return r.cfg, nil }
+
+func (r *fakeOptionRepo) UpsertConfig(cfg *models.AIConfig) error {
+	cfg.ID = 1
+	cp := *cfg
+	r.cfg = &cp
+	return nil
+}
+
+// newTestManager builds a manager with all keys present (so any provider builds)
+// and an anthropic fallback. The validator is overridden per-test.
+func newTestManager(repo AIModelOptionRepo) *AIModelManager {
+	keys := ai.LightKeys{
+		AnthropicAPIKey: "k", AnthropicLightModel: ai.DefaultAnthropicLightModel,
+		OpenAIAPIKey: "k", GeminiAPIKey: "k", DeepSeekAPIKey: "k",
+	}
+	return NewAIModelManager(repo, keys, &config.Prompts{}, nil, ai.LightProviderSpec{Provider: "anthropic"})
+}
+
+func TestAIModelManager_LoadSeedsDefaultsAndActiveConfig(t *testing.T) {
+	repo := newFakeOptionRepo()
+	m := newTestManager(repo)
+	m.Load(context.Background())
+
+	opts, _ := repo.ListOptions()
+	if len(opts) != 4 {
+		t.Fatalf("expected 4 seeded options, got %d", len(opts))
+	}
+	if repo.cfg == nil || repo.cfg.ActiveProvider != "anthropic" {
+		t.Fatalf("expected active config seeded to anthropic, got %+v", repo.cfg)
+	}
+}
+
+func TestAIModelManager_ActivateSuccessSwitchesAndPersists(t *testing.T) {
+	repo := newFakeOptionRepo()
+	m := newTestManager(repo)
+	m.validate = func(context.Context, ai.LightProviderSpec) error { return nil } // green probe
+
+	opt := &models.AIModelOption{Provider: "openai", ModelID: "gpt-4o-mini", Label: "GPT-4o mini", Enabled: true}
+	_ = repo.CreateOption(opt)
+
+	got, err := m.Activate(context.Background(), opt.ID)
+	if err != nil {
+		t.Fatalf("Activate: %v", err)
+	}
+	if !got.Validated {
+		t.Errorf("activated option should be validated")
+	}
+	if active := m.GetActive(); active.Provider != "openai" || active.Model != "gpt-4o-mini" {
+		t.Errorf("active = %+v, want openai/gpt-4o-mini", active)
+	}
+	if repo.cfg == nil || repo.cfg.ActiveProvider != "openai" || repo.cfg.ActiveModel != "gpt-4o-mini" {
+		t.Errorf("persisted config = %+v, want openai/gpt-4o-mini", repo.cfg)
+	}
+}
+
+func TestAIModelManager_ActivateFailedProbeIsFailClosed(t *testing.T) {
+	repo := newFakeOptionRepo()
+	m := newTestManager(repo)
+	m.validate = func(context.Context, ai.LightProviderSpec) error { return errors.New("model_not_found") }
+
+	before := m.GetActive()
+
+	opt := &models.AIModelOption{Provider: "openai", ModelID: "bogus-model", Enabled: true}
+	_ = repo.CreateOption(opt)
+
+	_, err := m.Activate(context.Background(), opt.ID)
+	if err == nil {
+		t.Fatal("expected Activate to fail on a red probe")
+	}
+	// Active model must be unchanged.
+	if after := m.GetActive(); after != before {
+		t.Errorf("active changed on failed probe: before=%+v after=%+v", before, after)
+	}
+	// Active config must NOT have been written.
+	if repo.cfg != nil {
+		t.Errorf("active config should not be set after a failed probe, got %+v", repo.cfg)
+	}
+	// The option should be recorded as invalid with the error.
+	stored, _ := repo.GetOption(opt.ID)
+	if stored.Validated || stored.ValidationError == "" {
+		t.Errorf("failed option should be marked invalid with an error, got %+v", stored)
+	}
+}
+
+func TestAIModelManager_AddModelSavesProbeOutcome(t *testing.T) {
+	repo := newFakeOptionRepo()
+	m := newTestManager(repo)
+	m.validate = func(context.Context, ai.LightProviderSpec) error { return errors.New("unreachable") }
+
+	opt := &models.AIModelOption{Provider: "gemini", ModelID: "gemini-2.0-flash", Enabled: true}
+	if err := m.AddModel(context.Background(), opt); err != nil {
+		t.Fatalf("AddModel should still save on a failed probe: %v", err)
+	}
+	stored, _ := repo.GetOption(opt.ID)
+	if stored == nil {
+		t.Fatal("option was not saved")
+	}
+	if stored.Validated || stored.ValidationError == "" {
+		t.Errorf("expected unvalidated option with error, got %+v", stored)
+	}
+}


### PR DESCRIPTION
## Phase 2b — live model switch + registry + validation probe

Makes the cheap **light tier** (preview / extraction / cache-warming / multi-detect) switchable **live from the dashboard**, backed by a persisted registry in RDS and gated by a real validation probe. Full recipe generation/regen/fork stay on Claude Sonnet (untouched).

### What's new
- **`ai_model_options`** (`models.AIModelOption`) — operator-managed registry of light-tier candidates (provider + model id + label/prices; **API keys stay in env/SSM, never the DB**). `(provider, model_id)` unique.
- **`ai_config`** (`models.AIConfig`) — single row holding the active spec (provider/model/base URL). Stores the resolved spec, not an FK, so the running provider survives an option edit/delete. Survives container restarts + image updates.
- **`ai.BuildLightProvider` / `ai.ValidateModel`** — per-provider construction factored out of the router; the probe runs one real minimal extraction (proves model id + key + reachability + forced function-calling), unmetered and time-bounded.
- **`ai.SwitchableTextProvider`** — atomic, concurrency-safe `TextProvider` whose delegate swaps at runtime → no-restart live switch.
- **`service.AIModelManager`** — owns the switchable provider; seeds registry + active config from the env default on boot, applies the DB-active spec, and polls every 30s so a switch on one ECS task propagates to the others.
- **Admin API** behind the ID header + a constant-time `ADMIN_TOKEN` check (whole group returns **503 when `ADMIN_TOKEN` is unset** — never exposed by accident):
  - `GET/POST/PUT/DELETE /v1/admin/ai/models`
  - `GET/PUT /v1/admin/ai/active`

### Fail-closed switching
`Activate` **probes first**; only on green does it persist the active config and swap the running provider. A red probe records the error on the option and **leaves the active model untouched** — a misconfigured switch can't break prod.

### Tests
Switchable delegation/Set-nil, `BuildLightProvider` key + unknown-provider guards, manager activate-success / **activate-fail-closed** / add-records-probe-outcome. Whole suite stays offline + green (`go test ./... -count=1`).

### Deploy note
Needs `ADMIN_TOKEN` in SSM (`/saltybytes/prod/ADMIN_TOKEN`) + task-def `secrets[]` wiring before the dashboard can drive it. Until then the admin API is safely dark; the env-var path (`LIGHT_PROVIDER`/`LIGHT_MODEL`) still works as before.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
https://claude.ai/code/session_01BU4UWZutHd1AnK3XAf7H19