### PR TITLE
fix(ai): price gemini-2.5-flash + gemini-3.5-flash in the cost table

### DIFF
--- a/internal/ai/pricing.go
+++ b/internal/ai/pricing.go
@@ -25,6 +25,8 @@ var DefaultPricing = PricingTable{
 	"gpt-4.1-nano":          {InputPerM: 0.10, OutputPerM: 0.40, CacheInputPerM: 0.025},
 	"gemini-2.0-flash":      {InputPerM: 0.10, OutputPerM: 0.40, CacheInputPerM: 0.025},
 	"gemini-2.0-flash-lite": {InputPerM: 0.075, OutputPerM: 0.30, CacheInputPerM: 0.0},
+	"gemini-2.5-flash":      {InputPerM: 0.30, OutputPerM: 2.50, CacheInputPerM: 0.075},
+	"gemini-3.5-flash":      {InputPerM: 1.50, OutputPerM: 9.00, CacheInputPerM: 0.375},
 	"deepseek-chat":         {InputPerM: 0.27, OutputPerM: 1.10, CacheInputPerM: 0.07},
 }
 


### PR DESCRIPTION
The light tier now runs **gemini-2.5-flash** in prod (switched via the dashboard admin API). `CostMiddleware` prices calls from `DefaultPricing`, which didn't know the 2.5/3.5 flash models — so recorded `cost_usd` would log as **$0** and the dashboard would under-report Gemini spend.

Adds list prices (USD per 1M tokens):
- `gemini-2.5-flash` — $0.30 in / $2.50 out
- `gemini-3.5-flash` — $1.50 in / $9.00 out

Prefix-matched like the rest of the table. `go test ./... -count=1` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
https://claude.ai/code/session_01BU4UWZutHd1AnK3XAf7H19