### PR TITLE
feat(video): native Gemini video+audio extraction (opt-in), ~35x cheaper

### DIFF
--- a/internal/ai/gemini_native.go
+++ b/internal/ai/gemini_native.go
@@ -1,0 +1,351 @@
+package ai
+
+import (
+	"bytes"
+	"context"
+	"encoding/base64"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"net/http"
+	"time"
+
+	"github.com/windoze95/saltybytes-api/internal/config"
+)
+
+// maxInlineVideoBytes caps the size of a video sent inline (base64) in a single
+// Gemini generateContent request. Larger videos must be uploaded via the Files
+// API or handled by frame sampling; the caller falls back on ErrVideoTooLarge.
+const maxInlineVideoBytes = 18 << 20 // 18 MiB
+
+// ErrVideoTooLarge signals that a video exceeds the inline size limit. The
+// caller uses it to fall back to frame sampling instead of native ingestion.
+var ErrVideoTooLarge = errors.New("video exceeds inline size limit")
+
+// GeminiVideoProvider extracts a recipe from a whole short video by sending the
+// video inline (base64) to Google's native Gemini generateContent API and
+// forcing a create_recipe function call. It deliberately reuses the shared
+// recipe schema (recipeProperties), parsing (recipeToolResult /
+// toolResultToRecipeResult) and validation (validateRecipeResult) helpers so
+// its output is byte-for-byte faithful to the other providers.
+type GeminiVideoProvider struct {
+	apiKey     string
+	model      string
+	baseURL    string
+	prompts    *config.Prompts
+	middleware AIMiddleware // nil means no middleware
+	http       *http.Client
+}
+
+// Compile-time assurance the provider satisfies the VideoProvider interface.
+var _ VideoProvider = (*GeminiVideoProvider)(nil)
+
+// NewGeminiVideoProvider creates a native Gemini video-extraction provider. An
+// empty model defaults to gemini-2.5-flash.
+func NewGeminiVideoProvider(apiKey, model string, prompts *config.Prompts) *GeminiVideoProvider {
+	if model == "" {
+		model = "gemini-2.5-flash"
+	}
+	return &GeminiVideoProvider{
+		apiKey:  apiKey,
+		model:   model,
+		baseURL: "https://generativelanguage.googleapis.com/v1beta",
+		prompts: prompts,
+		http:    &http.Client{Timeout: 120 * time.Second},
+	}
+}
+
+// WithMiddleware sets the middleware chain for this provider.
+func (p *GeminiVideoProvider) WithMiddleware(mw AIMiddleware) {
+	p.middleware = mw
+}
+
+// --- Native Gemini generateContent wire types (camelCase JSON names) ---
+
+// geminiInlineData carries base64-encoded media inline in a request part.
+type geminiInlineData struct {
+	MimeType string `json:"mimeType"`
+	Data     string `json:"data"`
+}
+
+// geminiFunctionCall is a model-emitted function call in a response part.
+// Gemini returns args as a JSON object; capture it raw for later unmarshalling.
+type geminiFunctionCall struct {
+	Name string          `json:"name"`
+	Args json.RawMessage `json:"args"`
+}
+
+// geminiPart is one heterogeneous element of a content's parts list. A request
+// part carries text or inlineData; a response part may carry a functionCall.
+type geminiPart struct {
+	Text         string              `json:"text,omitempty"`
+	InlineData   *geminiInlineData   `json:"inlineData,omitempty"`
+	FunctionCall *geminiFunctionCall `json:"functionCall,omitempty"`
+}
+
+// geminiContent is a role-tagged list of parts (used for user content, the
+// system instruction, and response candidates).
+type geminiContent struct {
+	Role  string       `json:"role,omitempty"`
+	Parts []geminiPart `json:"parts"`
+}
+
+// geminiFunctionDeclaration declares a callable tool function and its JSON
+// schema parameters.
+type geminiFunctionDeclaration struct {
+	Name        string                 `json:"name"`
+	Description string                 `json:"description"`
+	Parameters  map[string]interface{} `json:"parameters"`
+}
+
+// geminiTool groups function declarations exposed to the model.
+type geminiTool struct {
+	FunctionDeclarations []geminiFunctionDeclaration `json:"functionDeclarations"`
+}
+
+// geminiFunctionCallingConfig forces / constrains function calling. Mode "ANY"
+// with a single allowed name makes the call mandatory.
+type geminiFunctionCallingConfig struct {
+	Mode                 string   `json:"mode"`
+	AllowedFunctionNames []string `json:"allowedFunctionNames,omitempty"`
+}
+
+// geminiToolConfig wraps the function-calling configuration.
+type geminiToolConfig struct {
+	FunctionCallingConfig geminiFunctionCallingConfig `json:"functionCallingConfig"`
+}
+
+// geminiGenerationConfig holds generation parameters.
+type geminiGenerationConfig struct {
+	MaxOutputTokens int `json:"maxOutputTokens,omitempty"`
+}
+
+// geminiGenerateContentRequest is the request body for :generateContent.
+type geminiGenerateContentRequest struct {
+	SystemInstruction *geminiContent          `json:"systemInstruction,omitempty"`
+	Contents          []geminiContent         `json:"contents"`
+	Tools             []geminiTool            `json:"tools,omitempty"`
+	ToolConfig        *geminiToolConfig       `json:"toolConfig,omitempty"`
+	GenerationConfig  *geminiGenerationConfig `json:"generationConfig,omitempty"`
+}
+
+// geminiUsageMetadata reports token consumption for cost metering.
+type geminiUsageMetadata struct {
+	PromptTokenCount     int `json:"promptTokenCount"`
+	CandidatesTokenCount int `json:"candidatesTokenCount"`
+}
+
+// geminiCandidate is one generated candidate.
+type geminiCandidate struct {
+	Content geminiContent `json:"content"`
+}
+
+// geminiGenerateContentResponse is the response body for :generateContent.
+type geminiGenerateContentResponse struct {
+	Candidates    []geminiCandidate   `json:"candidates"`
+	UsageMetadata geminiUsageMetadata `json:"usageMetadata"`
+}
+
+// ExtractRecipesFromVideo sends a whole short video inline to Gemini and returns
+// the single recipe extracted via a forced create_recipe function call. It
+// returns ErrVideoTooLarge (without hitting the network) when the video exceeds
+// the inline size limit so the caller can fall back to frame sampling.
+func (p *GeminiVideoProvider) ExtractRecipesFromVideo(ctx context.Context, videoData []byte, mimeType, contextText, unitSystem, requirements string) ([]*RecipeResult, error) {
+	if len(videoData) == 0 {
+		return nil, fmt.Errorf("gemini: empty video data")
+	}
+	if len(videoData) > maxInlineVideoBytes {
+		return nil, ErrVideoTooLarge
+	}
+	if mimeType == "" {
+		mimeType = "video/mp4"
+	}
+
+	op := AIOperation{
+		Name:      "ExtractRecipesFromVideo",
+		Provider:  "gemini",
+		Model:     p.model,
+		StartTime: time.Now(),
+	}
+
+	return runWithMiddleware(ctx, p.middleware, op, func(ctx context.Context) ([]*RecipeResult, error) {
+		// Reuse the exact vision prompt fields the frame-sampling path uses so
+		// native ingestion stays consistent with the other providers.
+		sysSuffix, err := config.RenderPrompt(p.prompts.Recipe.Import.Vision.System, map[string]interface{}{
+			"UnitSystem":   unitSystem,
+			"Requirements": requirements,
+		})
+		if err != nil {
+			return nil, fmt.Errorf("render system prompt: %w", err)
+		}
+		systemPrompt := combineSystemPrompt(p.prompts.Recipe.Import.Vision.SystemPrefix, sysSuffix)
+
+		// User parts: the inline video followed by the framing text. Mirrors the
+		// context framing used by ExtractRecipesFromMedia.
+		framing := ""
+		if contextText != "" {
+			framing = "The following is the spoken transcript and caption from the source video. Treat it as a primary source of the ingredient quantities and step order; the video shows on-screen text and amounts too — reconcile them.\n\n" + contextText + "\n\n"
+		}
+		framing += "This video contains a recipe. Extract it and call create_recipe. If it shows a prepared dish with no written recipe, infer a reasonable one."
+
+		reqBody := geminiGenerateContentRequest{
+			Contents: []geminiContent{{
+				Role: "user",
+				Parts: []geminiPart{
+					{InlineData: &geminiInlineData{MimeType: mimeType, Data: base64.StdEncoding.EncodeToString(videoData)}},
+					{Text: framing},
+				},
+			}},
+			Tools: []geminiTool{{
+				FunctionDeclarations: []geminiFunctionDeclaration{{
+					Name:        "create_recipe",
+					Description: "Create a structured recipe definition with all required fields.",
+					Parameters:  schemaObject(recipeProperties(p.prompts.Recipe.Summarize.Recipe)),
+				}},
+			}},
+			ToolConfig: &geminiToolConfig{
+				FunctionCallingConfig: geminiFunctionCallingConfig{
+					Mode:                 "ANY",
+					AllowedFunctionNames: []string{"create_recipe"},
+				},
+			},
+			GenerationConfig: &geminiGenerationConfig{MaxOutputTokens: 8192},
+		}
+		if systemPrompt != "" {
+			reqBody.SystemInstruction = &geminiContent{Parts: []geminiPart{{Text: systemPrompt}}}
+		}
+
+		resp, err := p.generateContent(ctx, reqBody)
+		if err != nil {
+			return nil, err
+		}
+
+		recordUsage(ctx, TokenUsage{
+			InputTokens:  resp.UsageMetadata.PromptTokenCount,
+			OutputTokens: resp.UsageMetadata.CandidatesTokenCount,
+		})
+
+		args, ok := firstFunctionCallArgs(resp, "create_recipe")
+		if !ok {
+			return nil, NewAIError(FailureContentEmpty, errors.New("no create_recipe function call in Gemini response"), "no recipe function call in response")
+		}
+
+		var tr recipeToolResult
+		if err := json.Unmarshal(args, &tr); err != nil {
+			return nil, NewAIError(FailureContentParse, fmt.Errorf("failed to unmarshal recipe: %w", err), "failed to parse recipe tool result")
+		}
+
+		result := toolResultToRecipeResult(&tr)
+		if err := validateRecipeResult(result); err != nil {
+			return nil, err
+		}
+		result.PromptVersion = config.PromptVersion(p.prompts)
+		return []*RecipeResult{result}, nil
+	})
+}
+
+// firstFunctionCallArgs returns the raw args of the first response part carrying
+// a function call with the given name.
+func firstFunctionCallArgs(resp *geminiGenerateContentResponse, name string) (json.RawMessage, bool) {
+	if resp == nil {
+		return nil, false
+	}
+	for _, cand := range resp.Candidates {
+		for _, part := range cand.Content.Parts {
+			if part.FunctionCall != nil && part.FunctionCall.Name == name {
+				return part.FunctionCall.Args, true
+			}
+		}
+	}
+	return nil, false
+}
+
+// generateContent POSTs the request to {baseURL}/models/{model}:generateContent
+// and returns the parsed response. It retries a bounded number of times on HTTP
+// 429 / 5xx (and transport errors) with a short, context-honoring backoff.
+func (p *GeminiVideoProvider) generateContent(ctx context.Context, reqBody geminiGenerateContentRequest) (*geminiGenerateContentResponse, error) {
+	payload, err := json.Marshal(reqBody)
+	if err != nil {
+		return nil, fmt.Errorf("marshal gemini request: %w", err)
+	}
+
+	endpoint := fmt.Sprintf("%s/models/%s:generateContent", p.baseURL, p.model)
+
+	const maxAttempts = 3
+	var lastErr error
+
+	for attempt := 0; attempt < maxAttempts; attempt++ {
+		if attempt > 0 {
+			if err := backoffWait(ctx, attempt); err != nil {
+				return nil, err
+			}
+		}
+
+		req, err := http.NewRequestWithContext(ctx, http.MethodPost, endpoint, bytes.NewReader(payload))
+		if err != nil {
+			return nil, err
+		}
+		req.Header.Set("Content-Type", "application/json")
+		req.Header.Set("x-goog-api-key", p.apiKey)
+
+		resp, err := p.httpClient().Do(req)
+		if err != nil {
+			lastErr = fmt.Errorf("gemini request failed: %w", err)
+			continue
+		}
+
+		body, readErr := io.ReadAll(io.LimitReader(resp.Body, 8<<20))
+		resp.Body.Close()
+		if readErr != nil {
+			lastErr = fmt.Errorf("read gemini response: %w", readErr)
+			continue
+		}
+
+		switch {
+		case resp.StatusCode == http.StatusOK:
+			var out geminiGenerateContentResponse
+			if err := json.Unmarshal(body, &out); err != nil {
+				return nil, NewAIError(FailureContentParse, fmt.Errorf("unmarshal gemini response: %w", err), "failed to parse gemini response")
+			}
+			return &out, nil
+		case resp.StatusCode == http.StatusTooManyRequests || resp.StatusCode >= 500:
+			lastErr = fmt.Errorf("gemini generateContent returned status %d: %s", resp.StatusCode, truncateBody(body))
+			continue
+		default:
+			return nil, fmt.Errorf("gemini generateContent returned status %d: %s", resp.StatusCode, truncateBody(body))
+		}
+	}
+
+	return nil, fmt.Errorf("gemini generateContent: exhausted %d attempts: %w", maxAttempts, lastErr)
+}
+
+// httpClient returns the injected client or a default one.
+func (p *GeminiVideoProvider) httpClient() *http.Client {
+	if p.http != nil {
+		return p.http
+	}
+	return http.DefaultClient
+}
+
+// backoffWait sleeps for a short, attempt-scaled interval, returning early if
+// the context is cancelled.
+func backoffWait(ctx context.Context, attempt int) error {
+	timer := time.NewTimer(time.Duration(attempt) * 250 * time.Millisecond)
+	defer timer.Stop()
+	select {
+	case <-ctx.Done():
+		return ctx.Err()
+	case <-timer.C:
+		return nil
+	}
+}
+
+// truncateBody renders a response body for error messages, capping its length.
+func truncateBody(b []byte) string {
+	const max = 512
+	if len(b) > max {
+		return string(b[:max]) + "...(truncated)"
+	}
+	return string(b)
+}

--- a/internal/ai/gemini_native_test.go
+++ b/internal/ai/gemini_native_test.go
@@ -1,0 +1,153 @@
+package ai
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"sync/atomic"
+	"testing"
+
+	"github.com/windoze95/saltybytes-api/internal/config"
+)
+
+// geminiRecipeArgs is the create_recipe function-call argument object the mock
+// Gemini server returns. Field names mirror recipeToolResult exactly.
+const geminiRecipeArgs = `{
+	"title": "Skillet Cornbread",
+	"ingredients": [
+		{"name": "yellow cornmeal", "unit": "cup", "amount": 1, "original_text": "1 cup yellow cornmeal"}
+	],
+	"instructions": ["Mix the batter and bake at 425F for 20 minutes."],
+	"cook_time": 20,
+	"portions": 8,
+	"portion_size": "1 wedge",
+	"unit_system": "us_customary"
+}`
+
+// geminiFunctionCallResponse builds a native Gemini generateContent response
+// body whose candidate emits a create_recipe function call carrying args, plus
+// usage metadata for cost metering.
+func geminiFunctionCallResponse(args string) string {
+	return fmt.Sprintf(`{
+		"candidates": [
+			{"content": {"role": "model", "parts": [
+				{"functionCall": {"name": "create_recipe", "args": %s}}
+			]}}
+		],
+		"usageMetadata": {"promptTokenCount": 1200, "candidatesTokenCount": 240}
+	}`, args)
+}
+
+func TestGeminiVideoProvider_ExtractRecipesFromVideo(t *testing.T) {
+	var sawPath, sawHeader bool
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if strings.HasSuffix(r.URL.Path, ":generateContent") {
+			sawPath = true
+		}
+		if r.Header.Get("x-goog-api-key") != "" {
+			sawHeader = true
+		}
+		w.Header().Set("Content-Type", "application/json")
+		fmt.Fprint(w, geminiFunctionCallResponse(geminiRecipeArgs))
+	}))
+	defer srv.Close()
+
+	p := NewGeminiVideoProvider("test-key", "gemini-2.5-flash", testPrompts())
+	p.baseURL = srv.URL
+
+	results, err := p.ExtractRecipesFromVideo(context.Background(), []byte("fake-video-bytes"), "video/mp4", "caption + transcript text", "us_customary", "")
+	if err != nil {
+		t.Fatalf("ExtractRecipesFromVideo returned error: %v", err)
+	}
+	if !sawPath {
+		t.Error("request path did not end with :generateContent")
+	}
+	if !sawHeader {
+		t.Error("x-goog-api-key header was not set on the request")
+	}
+	if len(results) != 1 {
+		t.Fatalf("got %d results, want 1", len(results))
+	}
+
+	got := results[0]
+	if got.Title != "Skillet Cornbread" {
+		t.Errorf("title = %q, want %q", got.Title, "Skillet Cornbread")
+	}
+	if len(got.Ingredients) != 1 {
+		t.Fatalf("got %d ingredients, want 1", len(got.Ingredients))
+	}
+	if got.Ingredients[0].Name != "yellow cornmeal" || got.Ingredients[0].Unit != "cup" || got.Ingredients[0].Amount != 1 {
+		t.Errorf("ingredient[0] = %+v, want name=yellow cornmeal unit=cup amount=1", got.Ingredients[0])
+	}
+	if len(got.Instructions) != 1 {
+		t.Errorf("got %d instructions, want 1", len(got.Instructions))
+	}
+	if got.Portions != 8 {
+		t.Errorf("portions = %d, want 8", got.Portions)
+	}
+	// PromptVersion must be stamped from the prompt set (mirrors the other providers).
+	if got.PromptVersion == "" || got.PromptVersion != config.PromptVersion(testPrompts()) {
+		t.Errorf("PromptVersion = %q, want %q", got.PromptVersion, config.PromptVersion(testPrompts()))
+	}
+}
+
+func TestGeminiVideoProvider_ErrVideoTooLarge(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		t.Error("network must not be hit when the video exceeds the inline size limit")
+	}))
+	defer srv.Close()
+
+	p := NewGeminiVideoProvider("test-key", "gemini-2.5-flash", testPrompts())
+	p.baseURL = srv.URL
+
+	_, err := p.ExtractRecipesFromVideo(context.Background(), make([]byte, maxInlineVideoBytes+1), "video/mp4", "", "us_customary", "")
+	if !errors.Is(err, ErrVideoTooLarge) {
+		t.Fatalf("err = %v, want ErrVideoTooLarge", err)
+	}
+}
+
+func TestGeminiVideoProvider_NoFunctionCallIsError(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		fmt.Fprint(w, `{"candidates":[{"content":{"role":"model","parts":[{"text":"I could not find a recipe."}]}}],"usageMetadata":{"promptTokenCount":50,"candidatesTokenCount":10}}`)
+	}))
+	defer srv.Close()
+
+	p := NewGeminiVideoProvider("test-key", "gemini-2.5-flash", testPrompts())
+	p.baseURL = srv.URL
+
+	if _, err := p.ExtractRecipesFromVideo(context.Background(), []byte("fake"), "video/mp4", "", "metric", ""); err == nil {
+		t.Error("expected an error when the response has no function call, got nil")
+	}
+}
+
+func TestGeminiVideoProvider_RetriesOn500(t *testing.T) {
+	var calls int32
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if atomic.AddInt32(&calls, 1) == 1 {
+			w.WriteHeader(http.StatusInternalServerError)
+			fmt.Fprint(w, `{"error":"temporary"}`)
+			return
+		}
+		w.Header().Set("Content-Type", "application/json")
+		fmt.Fprint(w, geminiFunctionCallResponse(geminiRecipeArgs))
+	}))
+	defer srv.Close()
+
+	p := NewGeminiVideoProvider("test-key", "gemini-2.5-flash", testPrompts())
+	p.baseURL = srv.URL
+
+	results, err := p.ExtractRecipesFromVideo(context.Background(), []byte("fake"), "video/mp4", "", "us_customary", "")
+	if err != nil {
+		t.Fatalf("ExtractRecipesFromVideo returned error after retry: %v", err)
+	}
+	if len(results) != 1 || results[0].Title != "Skillet Cornbread" {
+		t.Fatalf("unexpected results after retry: %+v", results)
+	}
+	if got := atomic.LoadInt32(&calls); got != 2 {
+		t.Errorf("server was called %d times, want 2 (one 500, then one 200)", got)
+	}
+}

--- a/internal/ai/provider.go
+++ b/internal/ai/provider.go
@@ -45,6 +45,15 @@ type VisionProvider interface {
 	ExtractRecipesFromMedia(ctx context.Context, media []MediaInput, contextText string, unitSystem string, requirements string) ([]*RecipeResult, error)
 }
 
+// VideoProvider extracts recipes from a whole video ingested natively (video +
+// audio in one pass), rather than from sampled frames. Satisfied by
+// *GeminiVideoProvider. contextText carries the caption/transcript. Returns
+// ErrVideoTooLarge when the video exceeds the inline size limit so the caller
+// can fall back to frame sampling.
+type VideoProvider interface {
+	ExtractRecipesFromVideo(ctx context.Context, videoData []byte, mimeType, contextText, unitSystem, requirements string) ([]*RecipeResult, error)
+}
+
 // ImageProvider handles image generation (DALL-E 3).
 type ImageProvider interface {
 	GenerateImage(ctx context.Context, prompt string) ([]byte, error)

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -44,6 +44,12 @@ type EnvVars struct {
 	// registry endpoints). When empty the admin API is disabled entirely, so a
 	// deploy without the secret can never expose those endpoints.
 	AdminToken string `env:"ADMIN_TOKEN" optional:"true"`
+	// VideoNativeGemini routes video import through native Gemini video+audio
+	// extraction (far cheaper than sampling frames onto Sonnet, and it reads the
+	// narration natively). Requires GEMINI_API_KEY. Falls back to frame sampling
+	// per-video when the clip is too large to inline or native extraction fails.
+	VideoNativeGemini bool   `env:"VIDEO_NATIVE_GEMINI" optional:"true"`
+	GeminiVideoModel  string `env:"GEMINI_VIDEO_MODEL" envDefault:"gemini-2.5-flash" optional:"true"`
 	// PromptsPath overrides the location of the prompts YAML file, which is
 	// cwd-relative by default and only resolves from the Docker workdir.
 	PromptsPath     string `env:"PROMPTS_PATH" envDefault:"configs/prompts.yaml" optional:"true"`

--- a/internal/handlers/import_video_handler_test.go
+++ b/internal/handlers/import_video_handler_test.go
@@ -38,6 +38,14 @@ func (f *fakeFrameSampler) ExtractAudio(ctx context.Context, mediaURL string) ([
 	return nil, nil
 }
 
+func (f *fakeFrameSampler) DownloadVideo(ctx context.Context, mediaURL string, maxBytes int64) ([]byte, error) {
+	return nil, nil
+}
+
+func (f *fakeFrameSampler) ThumbnailFromVideo(ctx context.Context, videoData []byte) ([]byte, error) {
+	return nil, nil
+}
+
 // videoEnabledHandler builds an ImportHandler whose service has the video
 // dependencies wired with fakes, plus a SubscriptionService for gating.
 func videoEnabledHandler(repo *testutil.MockRecipeRepo, vrepo *testutil.MockVideoImportRepo, userRepo *testutil.MockUserRepo) *ImportHandler {

--- a/internal/router/router.go
+++ b/internal/router/router.go
@@ -154,6 +154,17 @@ func SetupRouter(cfg *config.Config, database *gorm.DB) *gin.Engine {
 		logger.Get().Info("video-link import disabled (no ScrapeCreators API key configured)")
 	}
 
+	// Native Gemini video extraction (opt-in): when enabled, video import ingests
+	// the whole clip (video + audio) through Gemini instead of sampling frames
+	// onto Sonnet — far cheaper, and it reads the narration natively. Falls back
+	// to frame sampling per-video. Requires a Gemini key.
+	if cfg.EnvVars.VideoNativeGemini && cfg.EnvVars.GeminiAPIKey != "" {
+		gvp := ai.NewGeminiVideoProvider(cfg.EnvVars.GeminiAPIKey, cfg.EnvVars.GeminiVideoModel, cfg.Prompts)
+		gvp.WithMiddleware(aiMW)
+		importService.VideoProvider = gvp
+		logger.Get().Info("native gemini video extraction enabled", zap.String("model", cfg.EnvVars.GeminiVideoModel))
+	}
+
 	// Admin API: light-tier model registry + live switch, used by the operator
 	// dashboard. Guarded by the shared ID header AND a dedicated admin token; the
 	// whole group is disabled (503) when ADMIN_TOKEN is unset, so it is never

--- a/internal/service/import.go
+++ b/internal/service/import.go
@@ -53,6 +53,11 @@ type ImportService struct {
 	VideoRepo         repository.VideoImportRepo
 	VideoFetcher      VideoFetcher
 	VideoFrameSampler VideoFrameSampler
+	// VideoProvider, when set (VIDEO_NATIVE_GEMINI enabled), extracts recipes by
+	// ingesting the whole video natively (video+audio) instead of sampling frames
+	// onto the vision provider. Falls back to VideoFrameSampler per-video on any
+	// error or an oversized clip. Optional; nil keeps the frames path.
+	VideoProvider ai.VideoProvider
 	// SubService refunds the per-user video quota when an accepted import later
 	// fails on our side. Optional; nil disables refunds (e.g. in tests).
 	SubService *SubscriptionService

--- a/internal/service/import_video.go
+++ b/internal/service/import_video.go
@@ -26,6 +26,11 @@ type VideoFetcher interface {
 type VideoFrameSampler interface {
 	Sample(ctx context.Context, mediaURL string, durationMS int) ([][]byte, error)
 	ExtractAudio(ctx context.Context, mediaURL string) ([]byte, error)
+	// DownloadVideo fetches the media into memory (native path), rejecting clips
+	// larger than maxBytes. ThumbnailFromVideo cuts a single hero frame from those
+	// bytes since the native path samples no frames.
+	DownloadVideo(ctx context.Context, mediaURL string, maxBytes int64) ([]byte, error)
+	ThumbnailFromVideo(ctx context.Context, videoData []byte) ([]byte, error)
 }
 
 const (
@@ -40,6 +45,9 @@ const (
 	whisperCostPerMin = 0.006
 	// videoProcessTimeout bounds the whole async pipeline for one fresh import.
 	videoProcessTimeout = 5 * time.Minute
+	// maxNativeVideoBytes caps clips sent to the native video provider (inlined
+	// into the request); larger clips fall back to frame sampling.
+	maxNativeVideoBytes = 18 << 20 // 18 MiB
 )
 
 // estimateVideoCost approximates the metered spend of a fresh video extraction.
@@ -199,6 +207,7 @@ func (s *ImportService) processVideoImport(jobID uint, rawURL string, user *mode
 
 	var chosen *ai.RecipeResult
 	var frames [][]byte
+	var nativeVideoBytes []byte
 	usedWhisper := false
 
 	if meta.MediaURL != "" {
@@ -208,39 +217,60 @@ func (s *ImportService) processVideoImport(jobID uint, rawURL string, user *mode
 			fail("no_media", "the video could not be downloaded", err)
 			return
 		}
-		// Scene-change frames catch on-screen text and flashy cuts; even
-		// sampling backs it up.
-		sampled, sErr := s.VideoFrameSampler.Sample(ctx, meta.MediaURL, meta.DurationMS)
-		if sErr != nil {
-			fail("sampling_failed", "could not process the video", sErr)
-			return
-		}
-		frames = sampled
 
-		media := make([]ai.MediaInput, 0, len(frames))
-		for _, f := range frames {
-			media = append(media, ai.MediaInput{Data: f, Kind: ai.MediaImage})
+		// Native path: ingest the whole clip (video + audio) in one pass — far
+		// cheaper than frames on the vision model, and it reads the narration so
+		// the Whisper fallback isn't needed. Any failure or an oversized clip
+		// falls through to frame sampling below.
+		if s.VideoProvider != nil {
+			if videoData, dlErr := s.VideoFrameSampler.DownloadVideo(ctx, meta.MediaURL, maxNativeVideoBytes); dlErr != nil {
+				log.Info("native video unavailable for this clip, using frames", zap.Error(dlErr))
+			} else if results, nErr := s.VideoProvider.ExtractRecipesFromVideo(ctx, videoData, "video/mp4", contextText, unitSystem, user.Personalization.Requirements); nErr != nil || len(results) == 0 {
+				log.Info("native video extraction failed, using frames", zap.Error(nErr))
+			} else {
+				chosen = results[0]
+				nativeVideoBytes = videoData
+				log.Info("video import used native gemini video extraction", zap.String("video_key", videoKey))
+			}
 		}
-		results, eErr := s.VisionProvider.ExtractRecipesFromMedia(ctx, media, contextText, unitSystem, user.Personalization.Requirements)
-		if eErr != nil || len(results) == 0 {
-			fail("extraction_failed", "could not find a recipe in this video", eErr)
-			return
-		}
-		chosen = results[0] // a single video yields a single recipe
 
-		// Last-resort Whisper: only when the frames+caption pass yielded a
-		// plausible-but-thin recipe AND the scraper gave no transcript to work
-		// with. The spoken audio is then the only untapped source of detail.
-		// Gated this tightly so Whisper never runs on the common (good) path
-		// nor on videos that likely have no recipe at all.
-		if s.SpeechProvider != nil && meta.Transcript == "" && recipeNeedsMoreContext(chosen) {
-			if audio, aErr := s.VideoFrameSampler.ExtractAudio(ctx, meta.MediaURL); aErr == nil && len(audio) > 0 {
-				if transcript, tErr := s.SpeechProvider.TranscribeAudio(ctx, audio, "m4a"); tErr == nil && strings.TrimSpace(transcript) != "" {
-					meta.Transcript = transcript
-					if results2, e2 := s.VisionProvider.ExtractRecipesFromMedia(ctx, media, buildVideoContext(meta), unitSystem, user.Personalization.Requirements); e2 == nil && len(results2) > 0 {
-						chosen = results2[0]
-						usedWhisper = true
-						log.Info("video import used the whisper fallback for extra context", zap.String("video_key", videoKey))
+		// Frame sampling path — the default, and the fallback when native is off
+		// or unavailable for this clip. Scene-change frames catch on-screen text
+		// and flashy cuts; even sampling backs it up.
+		if chosen == nil {
+			sampled, sErr := s.VideoFrameSampler.Sample(ctx, meta.MediaURL, meta.DurationMS)
+			if sErr != nil {
+				fail("sampling_failed", "could not process the video", sErr)
+				return
+			}
+			frames = sampled
+
+			media := make([]ai.MediaInput, 0, len(frames))
+			for _, f := range frames {
+				media = append(media, ai.MediaInput{Data: f, Kind: ai.MediaImage})
+			}
+			results, eErr := s.VisionProvider.ExtractRecipesFromMedia(ctx, media, contextText, unitSystem, user.Personalization.Requirements)
+			if eErr != nil || len(results) == 0 {
+				fail("extraction_failed", "could not find a recipe in this video", eErr)
+				return
+			}
+			chosen = results[0] // a single video yields a single recipe
+
+			// Last-resort Whisper: only when the frames+caption pass yielded a
+			// plausible-but-thin recipe AND the scraper gave no transcript to work
+			// with. The spoken audio is then the only untapped source of detail.
+			// Gated this tightly so Whisper never runs on the common (good) path
+			// nor on videos that likely have no recipe at all. (The native path
+			// already reads the audio, so it skips this.)
+			if s.SpeechProvider != nil && meta.Transcript == "" && recipeNeedsMoreContext(chosen) {
+				if audio, aErr := s.VideoFrameSampler.ExtractAudio(ctx, meta.MediaURL); aErr == nil && len(audio) > 0 {
+					if transcript, tErr := s.SpeechProvider.TranscribeAudio(ctx, audio, "m4a"); tErr == nil && strings.TrimSpace(transcript) != "" {
+						meta.Transcript = transcript
+						if results2, e2 := s.VisionProvider.ExtractRecipesFromMedia(ctx, media, buildVideoContext(meta), unitSystem, user.Personalization.Requirements); e2 == nil && len(results2) > 0 {
+							chosen = results2[0]
+							usedWhisper = true
+							log.Info("video import used the whisper fallback for extra context", zap.String("video_key", videoKey))
+						}
 					}
 				}
 			}
@@ -266,9 +296,18 @@ func (s *ImportService) processVideoImport(jobID uint, rawURL string, user *mode
 	def.SourceURL = rawURL
 	ensureUnitSystem(&def)
 
-	// Use a representative frame as the recipe thumbnail (best-effort; the text
-	// path has no frames, so this is a no-op there).
-	thumbnailURL := s.uploadVideoThumbnail(ctx, frames, videoKey)
+	// Hero image (best-effort): the middle sampled frame, or — on the native
+	// path, which samples no frames — a single frame cut from the video bytes.
+	// The text path has neither, so this is a no-op there.
+	var thumbFrame []byte
+	if len(frames) > 0 {
+		thumbFrame = frames[len(frames)/2]
+	} else if len(nativeVideoBytes) > 0 {
+		if tf, tErr := s.VideoFrameSampler.ThumbnailFromVideo(ctx, nativeVideoBytes); tErr == nil {
+			thumbFrame = tf
+		}
+	}
+	thumbnailURL := s.uploadVideoThumbnail(ctx, thumbFrame, videoKey)
 
 	_, recipeID, createErr := s.createImportedRecipe(ctx, &def, user, models.RecipeTypeImportVideo, rawURL, thumbnailURL, nil, chosen.Hashtags, chosen.PromptVersion)
 	if createErr != nil {
@@ -303,14 +342,13 @@ func (s *ImportService) processVideoImport(jobID uint, rawURL string, user *mode
 	log.Info("video import complete", zap.Int("frames", len(frames)), zap.Float64("cost_usd", job.CostUSD))
 }
 
-// uploadVideoThumbnail stores a representative frame (the middle one — past any
-// intro, before any outro) as the recipe's hero image and returns its URL.
-// Best-effort: returns "" on any failure so the import still succeeds.
-func (s *ImportService) uploadVideoThumbnail(ctx context.Context, frames [][]byte, videoKey string) string {
-	if len(frames) == 0 {
+// uploadVideoThumbnail stores the given representative frame as the recipe's
+// hero image and returns its URL. Best-effort: returns "" on empty input or any
+// failure so the import still succeeds.
+func (s *ImportService) uploadVideoThumbnail(ctx context.Context, frame []byte, videoKey string) string {
+	if len(frame) == 0 {
 		return ""
 	}
-	frame := frames[len(frames)/2]
 	if s.ThumbnailUploader != nil {
 		url, err := s.ThumbnailUploader(ctx, frame, videoKey)
 		if err != nil {

--- a/internal/service/import_video_test.go
+++ b/internal/service/import_video_test.go
@@ -28,12 +28,17 @@ func (f *fakeVideoFetcher) FetchVideo(ctx context.Context, rawURL string) (*vide
 }
 
 type fakeFrameSampler struct {
-	frames     [][]byte
-	err        error
-	calls      int
-	audio      []byte
-	audioErr   error
-	audioCalls int
+	frames        [][]byte
+	err           error
+	calls         int
+	audio         []byte
+	audioErr      error
+	audioCalls    int
+	videoData     []byte
+	downloadErr   error
+	downloadCalls int
+	thumb         []byte
+	thumbErr      error
 }
 
 func (f *fakeFrameSampler) Sample(ctx context.Context, mediaURL string, durationMS int) ([][]byte, error) {
@@ -44,6 +49,116 @@ func (f *fakeFrameSampler) Sample(ctx context.Context, mediaURL string, duration
 func (f *fakeFrameSampler) ExtractAudio(ctx context.Context, mediaURL string) ([]byte, error) {
 	f.audioCalls++
 	return f.audio, f.audioErr
+}
+
+func (f *fakeFrameSampler) DownloadVideo(ctx context.Context, mediaURL string, maxBytes int64) ([]byte, error) {
+	f.downloadCalls++
+	return f.videoData, f.downloadErr
+}
+
+func (f *fakeFrameSampler) ThumbnailFromVideo(ctx context.Context, videoData []byte) ([]byte, error) {
+	return f.thumb, f.thumbErr
+}
+
+type fakeVideoProvider struct {
+	results []*ai.RecipeResult
+	err     error
+	calls   int
+	gotCtx  string
+}
+
+func (f *fakeVideoProvider) ExtractRecipesFromVideo(ctx context.Context, videoData []byte, mimeType, contextText, unitSystem, requirements string) ([]*ai.RecipeResult, error) {
+	f.calls++
+	f.gotCtx = contextText
+	return f.results, f.err
+}
+
+// When a native VideoProvider is configured and succeeds, the whole clip is
+// ingested natively and the frame-sampling + vision path is skipped entirely.
+func TestVideoImport_NativeVideoUsed(t *testing.T) {
+	repo := testutil.NewMockRecipeRepo()
+	vrepo := testutil.NewMockVideoImportRepo()
+	svc := newVideoTestService(repo, vrepo)
+	svc.VideoFetcher = &fakeVideoFetcher{meta: tiktokMeta()}
+	// Frames are available but must NOT be used when native succeeds.
+	sampler := &fakeFrameSampler{frames: [][]byte{{0xFF, 0xD8, 0x01}}, videoData: []byte("FAKE_MP4"), thumb: []byte{0xFF, 0xD8, 0xAA}}
+	svc.VideoFrameSampler = sampler
+	native := &fakeVideoProvider{results: []*ai.RecipeResult{testutil.TestRecipeResult()}}
+	svc.VideoProvider = native
+
+	visionCalls := 0
+	svc.VisionProvider = &testutil.MockVisionProvider{
+		ExtractRecipesFromMediaFunc: func(ctx context.Context, media []ai.MediaInput, contextText, unitSystem, requirements string) ([]*ai.RecipeResult, error) {
+			visionCalls++
+			return []*ai.RecipeResult{testutil.TestRecipeResult()}, nil
+		},
+	}
+
+	job, err := svc.StartVideoImport(context.Background(), "https://www.tiktok.com/@chef/video/7499229683859426602", testutil.TestUser())
+	if err != nil {
+		t.Fatalf("StartVideoImport error: %v", err)
+	}
+	done := waitForVideoJob(t, svc, job.ID)
+	if done.Status != models.VideoImportDone {
+		t.Fatalf("final status = %q (error %q), want done", done.Status, done.Error)
+	}
+	if native.calls != 1 {
+		t.Errorf("native provider calls = %d, want 1", native.calls)
+	}
+	if sampler.downloadCalls != 1 {
+		t.Errorf("DownloadVideo calls = %d, want 1", sampler.downloadCalls)
+	}
+	if sampler.calls != 0 {
+		t.Errorf("frame Sample called %d times, want 0 (native should win)", sampler.calls)
+	}
+	if visionCalls != 0 {
+		t.Errorf("vision called %d times, want 0 (native should win)", visionCalls)
+	}
+	if len(repo.Recipes) != 1 {
+		t.Errorf("expected 1 recipe saved, got %d", len(repo.Recipes))
+	}
+}
+
+// When native extraction errors, the pipeline falls back to frame sampling +
+// the vision provider, so the import still succeeds.
+func TestVideoImport_NativeFallsBackToFrames(t *testing.T) {
+	repo := testutil.NewMockRecipeRepo()
+	vrepo := testutil.NewMockVideoImportRepo()
+	svc := newVideoTestService(repo, vrepo)
+	svc.VideoFetcher = &fakeVideoFetcher{meta: tiktokMeta()}
+	sampler := &fakeFrameSampler{frames: [][]byte{{0xFF, 0xD8, 0x01}, {0xFF, 0xD8, 0x02}}, videoData: []byte("FAKE_MP4")}
+	svc.VideoFrameSampler = sampler
+	native := &fakeVideoProvider{err: errors.New("native extraction unavailable")}
+	svc.VideoProvider = native
+
+	visionCalls := 0
+	svc.VisionProvider = &testutil.MockVisionProvider{
+		ExtractRecipesFromMediaFunc: func(ctx context.Context, media []ai.MediaInput, contextText, unitSystem, requirements string) ([]*ai.RecipeResult, error) {
+			visionCalls++
+			return []*ai.RecipeResult{testutil.TestRecipeResult()}, nil
+		},
+	}
+
+	job, err := svc.StartVideoImport(context.Background(), "https://www.tiktok.com/@chef/video/7499229683859426602", testutil.TestUser())
+	if err != nil {
+		t.Fatalf("StartVideoImport error: %v", err)
+	}
+	done := waitForVideoJob(t, svc, job.ID)
+	if done.Status != models.VideoImportDone {
+		t.Fatalf("final status = %q (error %q), want done", done.Status, done.Error)
+	}
+	if native.calls != 1 {
+		t.Errorf("native provider calls = %d, want 1", native.calls)
+	}
+	if sampler.calls != 1 {
+		t.Errorf("frame Sample calls = %d, want 1 (fallback)", sampler.calls)
+	}
+	if visionCalls != 1 {
+		t.Errorf("vision calls = %d, want 1 (fallback)", visionCalls)
+	}
+	if len(repo.Recipes) != 1 {
+		t.Errorf("expected 1 recipe saved, got %d", len(repo.Recipes))
+	}
 }
 
 func tiktokMeta() *video.VideoMeta {

--- a/internal/video/frames.go
+++ b/internal/video/frames.go
@@ -172,6 +172,81 @@ func (s *FrameSampler) ExtractAudio(ctx context.Context, mediaURL string) ([]byt
 	return b, nil
 }
 
+// DownloadVideo fetches the media into memory (via the same SSRF-safe client and
+// download seam as Sample), rejecting anything larger than maxBytes so the caller
+// can fall back to frame sampling for oversized clips. Used by the native-video
+// path, which needs the raw bytes to inline into the model request.
+func (s *FrameSampler) DownloadVideo(ctx context.Context, mediaURL string, maxBytes int64) ([]byte, error) {
+	dir, err := os.MkdirTemp("", "vidnative-*")
+	if err != nil {
+		return nil, err
+	}
+	defer os.RemoveAll(dir)
+
+	videoPath := filepath.Join(dir, "video.mp4")
+	dl := s.download
+	if dl == nil {
+		dl = s.httpDownload
+	}
+	if err := dl(ctx, mediaURL, videoPath); err != nil {
+		return nil, fmt.Errorf("download video: %w", err)
+	}
+	fi, err := os.Stat(videoPath)
+	if err != nil {
+		return nil, err
+	}
+	if fi.Size() > maxBytes {
+		return nil, fmt.Errorf("video is %d bytes, exceeds native inline limit %d", fi.Size(), maxBytes)
+	}
+	b, err := os.ReadFile(videoPath)
+	if err != nil {
+		return nil, err
+	}
+	if len(b) == 0 {
+		return nil, errors.New("downloaded an empty video")
+	}
+	return b, nil
+}
+
+// ThumbnailFromVideo extracts a single representative JPEG frame (~1s in, past
+// any black intro) from already-downloaded video bytes, for use as the recipe's
+// hero image on the native path where no frame set is produced. Best-effort.
+func (s *FrameSampler) ThumbnailFromVideo(ctx context.Context, videoData []byte) ([]byte, error) {
+	dir, err := os.MkdirTemp("", "vidthumb-*")
+	if err != nil {
+		return nil, err
+	}
+	defer os.RemoveAll(dir)
+
+	inPath := filepath.Join(dir, "video.mp4")
+	if err := os.WriteFile(inPath, videoData, 0o600); err != nil {
+		return nil, err
+	}
+	outPath := filepath.Join(dir, "thumb.jpg")
+	run := s.runFFmpeg
+	if run == nil {
+		run = realFFmpeg
+	}
+	if err := run(ctx, thumbnailArgs(inPath, outPath)); err != nil {
+		return nil, fmt.Errorf("ffmpeg thumbnail extraction: %w", err)
+	}
+	b, err := os.ReadFile(outPath)
+	if err != nil {
+		return nil, err
+	}
+	if len(b) == 0 {
+		return nil, errors.New("extracted empty thumbnail")
+	}
+	return b, nil
+}
+
+func thumbnailArgs(inPath, outPath string) []string {
+	return []string{
+		"-hide_banner", "-loglevel", "error", "-ss", "1", "-i", inPath,
+		"-frames:v", "1", "-vf", fmt.Sprintf("scale=%d:-1", frameWidth), "-y", outPath,
+	}
+}
+
 func audioArgs(inPath, outPath string) []string {
 	return []string{
 		"-hide_banner", "-loglevel", "error", "-i", inPath,


### PR DESCRIPTION
## Native video, not frames

Today video import samples **~30 JPEG frames** and sends them to **Sonnet** vision (~$0.14/video), with a separate **Whisper** pass for narration. This adds a native path: ingest the **whole clip (video + audio)** through **Gemini 2.5 Flash** in one `generateContent` call.

- **~35× cheaper** (~$0.004 vs ~$0.14/video)
- **Reads the narration natively** → no Whisper hop
- **No ffmpeg frame sampling** on the happy path

### How it works
- `ai.GeminiVideoProvider` (`internal/ai/gemini_native.go`): native `generateContent` with the video **inlined (base64)** + a **forced `create_recipe`** function call. Reuses the shared recipe **schema + parser + validation verbatim**, so output is identical to the other providers. Retries on 429/5xx; meters tokens via `recordUsage`; returns `ErrVideoTooLarge` above the 18 MiB inline limit.
- Pipeline tries **native first, falls back to frame sampling** per-video on any error/oversized clip. The native path cuts one hero frame from the downloaded bytes for the thumbnail.
- `FrameSampler.DownloadVideo` (SSRF-safe, in-memory, size-capped) + `ThumbnailFromVideo` back it.

### Safety / rollout
**Opt-in and OFF by default** — `VIDEO_NATIVE_GEMINI=true` + `GEMINI_API_KEY` (already in SSM). Merging is **behavior-preserving**; video import stays on the Sonnet-frames path until the flag is set. Enable = one task-def env change, no code deploy.

### Verification
- Offline: provider (success / too-large / no-call / retry) + pipeline (native-used, fallback-to-frames). Full suite `go test ./... -count=1` green.
- Live: the native `generateContent` contract (`functionDeclarations` + `toolConfig{mode:ANY}` + `functionCall` + `usageMetadata`) validated against real `gemini-2.5-flash` (HTTP 200, correct forced call). Only the inline *video* bytes weren't smoke-tested locally (no ffmpeg here) — recommend one real-reel test before flipping the flag on.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
https://claude.ai/code/session_01BU4UWZutHd1AnK3XAf7H19