### PR TITLE
feat(vision): native Gemini image/PDF extraction (opt-in) — vision off Sonnet

### DIFF
--- a/internal/ai/gemini_native.go
+++ b/internal/ai/gemini_native.go
@@ -261,16 +261,24 @@ func firstFunctionCallArgs(resp *geminiGenerateContentResponse, name string) (js
 	return nil, false
 }
 
-// generateContent POSTs the request to {baseURL}/models/{model}:generateContent
-// and returns the parsed response. It retries a bounded number of times on HTTP
-// 429 / 5xx (and transport errors) with a short, context-honoring backoff.
+// generateContent delegates to the shared geminiGenerateContent helper using
+// this provider's injected client and endpoint configuration.
 func (p *GeminiVideoProvider) generateContent(ctx context.Context, reqBody geminiGenerateContentRequest) (*geminiGenerateContentResponse, error) {
+	return geminiGenerateContent(ctx, p.httpClient(), p.baseURL, p.apiKey, p.model, reqBody)
+}
+
+// geminiGenerateContent POSTs the request to
+// {baseURL}/models/{model}:generateContent and returns the parsed response. It
+// retries a bounded number of times on HTTP 429 / 5xx (and transport errors)
+// with a short, context-honoring backoff. Shared by the native Gemini video and
+// vision providers.
+func geminiGenerateContent(ctx context.Context, httpClient *http.Client, baseURL, apiKey, model string, reqBody geminiGenerateContentRequest) (*geminiGenerateContentResponse, error) {
 	payload, err := json.Marshal(reqBody)
 	if err != nil {
 		return nil, fmt.Errorf("marshal gemini request: %w", err)
 	}
 
-	endpoint := fmt.Sprintf("%s/models/%s:generateContent", p.baseURL, p.model)
+	endpoint := fmt.Sprintf("%s/models/%s:generateContent", baseURL, model)
 
 	const maxAttempts = 3
 	var lastErr error
@@ -287,9 +295,9 @@ func (p *GeminiVideoProvider) generateContent(ctx context.Context, reqBody gemin
 			return nil, err
 		}
 		req.Header.Set("Content-Type", "application/json")
-		req.Header.Set("x-goog-api-key", p.apiKey)
+		req.Header.Set("x-goog-api-key", apiKey)
 
-		resp, err := p.httpClient().Do(req)
+		resp, err := httpClient.Do(req)
 		if err != nil {
 			lastErr = fmt.Errorf("gemini request failed: %w", err)
 			continue

--- a/internal/ai/gemini_vision.go
+++ b/internal/ai/gemini_vision.go
@@ -1,0 +1,256 @@
+package ai
+
+import (
+	"context"
+	"encoding/base64"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"net/http"
+	"time"
+
+	"github.com/windoze95/saltybytes-api/internal/config"
+	"github.com/windoze95/saltybytes-api/internal/logger"
+	"go.uber.org/zap"
+)
+
+// GeminiVisionProvider extracts structured recipes from images and PDF documents
+// using Google's native Gemini generateContent API with forced function calling.
+// It deliberately reuses the shared recipe schema (recipeProperties), parsing
+// (recipeToolResult / multiRecipeToolResult / toolResultToRecipeResult) and
+// validation (validateRecipeResult) helpers so its output is byte-for-byte
+// faithful to the Anthropic vision provider.
+type GeminiVisionProvider struct {
+	apiKey     string
+	model      string
+	baseURL    string
+	prompts    *config.Prompts
+	middleware AIMiddleware // nil means no middleware
+	http       *http.Client
+}
+
+// Compile-time assurance the provider satisfies the VisionProvider interface.
+var _ VisionProvider = (*GeminiVisionProvider)(nil)
+
+// NewGeminiVisionProvider creates a native Gemini vision-extraction provider. An
+// empty model defaults to gemini-2.5-flash.
+func NewGeminiVisionProvider(apiKey, model string, prompts *config.Prompts) *GeminiVisionProvider {
+	if model == "" {
+		model = "gemini-2.5-flash"
+	}
+	return &GeminiVisionProvider{
+		apiKey:  apiKey,
+		model:   model,
+		baseURL: "https://generativelanguage.googleapis.com/v1beta",
+		prompts: prompts,
+		http:    &http.Client{Timeout: 120 * time.Second},
+	}
+}
+
+// WithMiddleware sets the middleware chain for this provider.
+func (p *GeminiVisionProvider) WithMiddleware(mw AIMiddleware) {
+	p.middleware = mw
+}
+
+// httpClient returns the injected client or a default one.
+func (p *GeminiVisionProvider) httpClient() *http.Client {
+	if p.http != nil {
+		return p.http
+	}
+	return http.DefaultClient
+}
+
+// visionSystemPrompt renders the shared vision system prompt (prefix + dynamic
+// suffix) exactly as the Anthropic provider does.
+func (p *GeminiVisionProvider) visionSystemPrompt(unitSystem, requirements string) (string, error) {
+	sysSuffix, err := config.RenderPrompt(p.prompts.Recipe.Import.Vision.System, map[string]interface{}{
+		"UnitSystem":   unitSystem,
+		"Requirements": requirements,
+	})
+	if err != nil {
+		return "", fmt.Errorf("render system prompt: %w", err)
+	}
+	return combineSystemPrompt(p.prompts.Recipe.Import.Vision.SystemPrefix, sysSuffix), nil
+}
+
+// ExtractRecipeFromImage extracts a single structured recipe from a photo via a
+// forced create_recipe function call. Mirrors AnthropicProvider.ExtractRecipeFromImage.
+func (p *GeminiVisionProvider) ExtractRecipeFromImage(ctx context.Context, imageData []byte, unitSystem string, requirements string) (*RecipeResult, error) {
+	op := AIOperation{
+		Name:      "ExtractRecipeFromImage",
+		Provider:  "gemini",
+		Model:     p.model,
+		StartTime: time.Now(),
+	}
+
+	return runWithMiddleware(ctx, p.middleware, op, func(ctx context.Context) (*RecipeResult, error) {
+		systemPrompt, err := p.visionSystemPrompt(unitSystem, requirements)
+		if err != nil {
+			return nil, err
+		}
+
+		reqBody := geminiGenerateContentRequest{
+			Contents: []geminiContent{{
+				Role: "user",
+				Parts: []geminiPart{
+					{InlineData: &geminiInlineData{MimeType: detectImageMediaType(imageData), Data: base64.StdEncoding.EncodeToString(imageData)}},
+					{Text: "Extract the recipe from this image. If the image shows a prepared dish, infer a reasonable recipe for it."},
+				},
+			}},
+			Tools: []geminiTool{{
+				FunctionDeclarations: []geminiFunctionDeclaration{{
+					Name:        "create_recipe",
+					Description: "Create a structured recipe definition with all required fields.",
+					Parameters:  schemaObject(recipeProperties(p.prompts.Recipe.Summarize.Recipe)),
+				}},
+			}},
+			ToolConfig: &geminiToolConfig{
+				FunctionCallingConfig: geminiFunctionCallingConfig{
+					Mode:                 "ANY",
+					AllowedFunctionNames: []string{"create_recipe"},
+				},
+			},
+		}
+		if systemPrompt != "" {
+			reqBody.SystemInstruction = &geminiContent{Parts: []geminiPart{{Text: systemPrompt}}}
+		}
+
+		resp, err := geminiGenerateContent(ctx, p.httpClient(), p.baseURL, p.apiKey, p.model, reqBody)
+		if err != nil {
+			return nil, err
+		}
+
+		recordUsage(ctx, TokenUsage{
+			InputTokens:  resp.UsageMetadata.PromptTokenCount,
+			OutputTokens: resp.UsageMetadata.CandidatesTokenCount,
+		})
+
+		args, ok := firstFunctionCallArgs(resp, "create_recipe")
+		if !ok {
+			return nil, NewAIError(FailureContentEmpty, errors.New("no create_recipe function call in Gemini response"), "no recipe function call in response")
+		}
+
+		var tr recipeToolResult
+		if err := json.Unmarshal(args, &tr); err != nil {
+			return nil, NewAIError(FailureContentParse, fmt.Errorf("failed to unmarshal recipe: %w", err), "failed to parse recipe tool result")
+		}
+
+		result := toolResultToRecipeResult(&tr)
+		if err := validateRecipeResult(result); err != nil {
+			return nil, err
+		}
+		result.PromptVersion = config.PromptVersion(p.prompts)
+		return result, nil
+	})
+}
+
+// ExtractRecipesFromMedia extracts every distinct recipe found across the
+// provided images and/or PDF documents in a single native Gemini request.
+// Mirrors AnthropicProvider.ExtractRecipesFromMedia.
+func (p *GeminiVisionProvider) ExtractRecipesFromMedia(ctx context.Context, media []MediaInput, contextText string, unitSystem string, requirements string) ([]*RecipeResult, error) {
+	op := AIOperation{
+		Name:      "ExtractRecipesFromMedia",
+		Provider:  "gemini",
+		Model:     p.model,
+		StartTime: time.Now(),
+	}
+
+	return runWithMiddleware(ctx, p.middleware, op, func(ctx context.Context) ([]*RecipeResult, error) {
+		systemPrompt, err := p.visionSystemPrompt(unitSystem, requirements)
+		if err != nil {
+			return nil, err
+		}
+
+		parts := make([]geminiPart, 0, len(media)+2)
+		for _, m := range media {
+			mimeType := detectImageMediaType(m.Data)
+			if m.Kind == MediaPDF {
+				mimeType = "application/pdf"
+			}
+			parts = append(parts, geminiPart{InlineData: &geminiInlineData{MimeType: mimeType, Data: base64.StdEncoding.EncodeToString(m.Data)}})
+		}
+		if contextText != "" {
+			parts = append(parts, geminiPart{Text: "The following is the spoken transcript and caption from the source video. Treat it as a primary source of the ingredient quantities and step order; the images above are stills sampled from the same video and often show on-screen text, ingredients, and amounts not spoken aloud. Reconcile the two.\n\n" + contextText})
+		}
+		parts = append(parts, geminiPart{Text: "These images and/or documents contain one or more recipes. Extract EVERY distinct recipe you find across all of them, returning one entry per recipe. If an item shows a prepared dish with no written recipe, infer a reasonable recipe for it."})
+
+		reqBody := geminiGenerateContentRequest{
+			Contents: []geminiContent{{
+				Role:  "user",
+				Parts: parts,
+			}},
+			Tools: []geminiTool{{
+				FunctionDeclarations: []geminiFunctionDeclaration{{
+					Name:        "extract_recipes",
+					Description: "Extract every distinct recipe found across the provided images and documents. Return one entry per recipe.",
+					Parameters:  multiRecipeSchema(p.prompts.Recipe.Summarize.Recipe),
+				}},
+			}},
+			ToolConfig: &geminiToolConfig{
+				FunctionCallingConfig: geminiFunctionCallingConfig{
+					Mode:                 "ANY",
+					AllowedFunctionNames: []string{"extract_recipes"},
+				},
+			},
+			GenerationConfig: &geminiGenerationConfig{MaxOutputTokens: 16000},
+		}
+		if systemPrompt != "" {
+			reqBody.SystemInstruction = &geminiContent{Parts: []geminiPart{{Text: systemPrompt}}}
+		}
+
+		resp, err := geminiGenerateContent(ctx, p.httpClient(), p.baseURL, p.apiKey, p.model, reqBody)
+		if err != nil {
+			return nil, err
+		}
+
+		recordUsage(ctx, TokenUsage{
+			InputTokens:  resp.UsageMetadata.PromptTokenCount,
+			OutputTokens: resp.UsageMetadata.CandidatesTokenCount,
+		})
+
+		args, ok := firstFunctionCallArgs(resp, "extract_recipes")
+		if !ok {
+			return nil, NewAIError(FailureContentEmpty, errors.New("no extract_recipes function call in Gemini response"), "no recipes function call in response")
+		}
+
+		var tr multiRecipeToolResult
+		if err := json.Unmarshal(args, &tr); err != nil {
+			return nil, NewAIError(FailureContentParse, fmt.Errorf("failed to unmarshal recipes: %w", err), "failed to parse recipes tool result")
+		}
+
+		pv := config.PromptVersion(p.prompts)
+		valid := make([]*RecipeResult, 0, len(tr.Recipes))
+		for i := range tr.Recipes {
+			r := toolResultToRecipeResult(&tr.Recipes[i])
+			if err := validateRecipeResult(r); err != nil {
+				logger.Get().Warn("skipping invalid extracted recipe", zap.String("title", r.Title), zap.Error(err))
+				continue
+			}
+			r.PromptVersion = pv
+			valid = append(valid, r)
+		}
+		if len(valid) == 0 {
+			return nil, NewAIError(FailureContentQuality, errors.New("no valid recipes extracted from media"), "no recipes found in the provided files")
+		}
+		return valid, nil
+	})
+}
+
+// multiRecipeSchema builds the extract_recipes tool parameters: a JSON-schema
+// object with a "recipes" array whose items reuse the shared recipeProperties
+// schema. Mirrors createMultiRecipeTool's input schema.
+func multiRecipeSchema(summaryPrompt string) map[string]interface{} {
+	return map[string]interface{}{
+		"type": "object",
+		"properties": map[string]interface{}{
+			"recipes": map[string]interface{}{
+				"type":        "array",
+				"description": "Every distinct recipe found across all provided inputs, one entry per recipe.",
+				"items": map[string]interface{}{
+					"type":       "object",
+					"properties": recipeProperties(summaryPrompt),
+				},
+			},
+		},
+	}
+}

--- a/internal/ai/gemini_vision_test.go
+++ b/internal/ai/gemini_vision_test.go
@@ -1,0 +1,162 @@
+package ai
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/windoze95/saltybytes-api/internal/config"
+)
+
+// geminiMultiRecipeArgs is the extract_recipes function-call argument object the
+// mock Gemini server returns for the multi-media test: two distinct recipes.
+// Field names mirror recipeToolResult / multiRecipeToolResult exactly.
+const geminiMultiRecipeArgs = `{
+	"recipes": [
+		{
+			"title": "Skillet Cornbread",
+			"ingredients": [{"name": "yellow cornmeal", "unit": "cup", "amount": 1, "original_text": "1 cup yellow cornmeal"}],
+			"instructions": ["Mix the batter and bake at 425F for 20 minutes."],
+			"cook_time": 20,
+			"portions": 8,
+			"portion_size": "1 wedge",
+			"unit_system": "us_customary"
+		},
+		{
+			"title": "Honey Butter",
+			"ingredients": [{"name": "butter", "unit": "tbsp", "amount": 4, "original_text": "4 tbsp butter"}],
+			"instructions": ["Whip the butter with honey until light and fluffy."],
+			"cook_time": 5,
+			"portions": 8,
+			"portion_size": "1 tbsp",
+			"unit_system": "us_customary"
+		}
+	]
+}`
+
+// geminiExtractRecipesResponse builds a native Gemini generateContent response
+// body whose candidate emits an extract_recipes function call carrying args.
+func geminiExtractRecipesResponse(args string) string {
+	return fmt.Sprintf(`{
+		"candidates": [
+			{"content": {"role": "model", "parts": [
+				{"functionCall": {"name": "extract_recipes", "args": %s}}
+			]}}
+		],
+		"usageMetadata": {"promptTokenCount": 2400, "candidatesTokenCount": 480}
+	}`, args)
+}
+
+func TestGeminiVisionProvider_ExtractRecipeFromImage(t *testing.T) {
+	var sawPath, sawHeader bool
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if strings.HasSuffix(r.URL.Path, ":generateContent") {
+			sawPath = true
+		}
+		if r.Header.Get("x-goog-api-key") != "" {
+			sawHeader = true
+		}
+		w.Header().Set("Content-Type", "application/json")
+		// Reuse the shared single-recipe create_recipe response fixture.
+		fmt.Fprint(w, geminiFunctionCallResponse(geminiRecipeArgs))
+	}))
+	defer srv.Close()
+
+	p := NewGeminiVisionProvider("test-key", "gemini-2.5-flash", testPrompts())
+	p.baseURL = srv.URL
+
+	got, err := p.ExtractRecipeFromImage(context.Background(), []byte("fake-image-bytes"), "us_customary", "")
+	if err != nil {
+		t.Fatalf("ExtractRecipeFromImage returned error: %v", err)
+	}
+	if !sawPath {
+		t.Error("request path did not end with :generateContent")
+	}
+	if !sawHeader {
+		t.Error("x-goog-api-key header was not set on the request")
+	}
+
+	if got.Title != "Skillet Cornbread" {
+		t.Errorf("title = %q, want %q", got.Title, "Skillet Cornbread")
+	}
+	if len(got.Ingredients) != 1 || got.Ingredients[0].Name != "yellow cornmeal" || got.Ingredients[0].Unit != "cup" || got.Ingredients[0].Amount != 1 {
+		t.Fatalf("ingredients = %+v, want one {yellow cornmeal, cup, 1}", got.Ingredients)
+	}
+	if len(got.Instructions) != 1 {
+		t.Errorf("got %d instructions, want 1", len(got.Instructions))
+	}
+	if got.Portions != 8 {
+		t.Errorf("portions = %d, want 8", got.Portions)
+	}
+	if got.PromptVersion == "" || got.PromptVersion != config.PromptVersion(testPrompts()) {
+		t.Errorf("PromptVersion = %q, want %q", got.PromptVersion, config.PromptVersion(testPrompts()))
+	}
+}
+
+func TestGeminiVisionProvider_ExtractRecipesFromMedia(t *testing.T) {
+	var sawPath, sawHeader bool
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if strings.HasSuffix(r.URL.Path, ":generateContent") {
+			sawPath = true
+		}
+		if r.Header.Get("x-goog-api-key") != "" {
+			sawHeader = true
+		}
+		w.Header().Set("Content-Type", "application/json")
+		fmt.Fprint(w, geminiExtractRecipesResponse(geminiMultiRecipeArgs))
+	}))
+	defer srv.Close()
+
+	p := NewGeminiVisionProvider("test-key", "gemini-2.5-flash", testPrompts())
+	p.baseURL = srv.URL
+
+	media := []MediaInput{
+		{Data: []byte("fake-image-bytes"), Kind: MediaImage},
+		{Data: []byte("%PDF-1.4 fake"), Kind: MediaPDF},
+	}
+	results, err := p.ExtractRecipesFromMedia(context.Background(), media, "caption + transcript text", "us_customary", "")
+	if err != nil {
+		t.Fatalf("ExtractRecipesFromMedia returned error: %v", err)
+	}
+	if !sawPath {
+		t.Error("request path did not end with :generateContent")
+	}
+	if !sawHeader {
+		t.Error("x-goog-api-key header was not set on the request")
+	}
+
+	if len(results) != 2 {
+		t.Fatalf("got %d results, want 2", len(results))
+	}
+	if results[0].Title != "Skillet Cornbread" || results[1].Title != "Honey Butter" {
+		t.Errorf("titles = %q, %q; want Skillet Cornbread, Honey Butter", results[0].Title, results[1].Title)
+	}
+	if len(results[1].Ingredients) != 1 || results[1].Ingredients[0].Name != "butter" {
+		t.Errorf("results[1] ingredients = %+v, want one butter", results[1].Ingredients)
+	}
+
+	pv := config.PromptVersion(testPrompts())
+	for i, r := range results {
+		if r.PromptVersion == "" || r.PromptVersion != pv {
+			t.Errorf("results[%d].PromptVersion = %q, want %q", i, r.PromptVersion, pv)
+		}
+	}
+}
+
+func TestGeminiVisionProvider_NoFunctionCallIsError(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		fmt.Fprint(w, `{"candidates":[{"content":{"role":"model","parts":[{"text":"I could not find a recipe."}]}}],"usageMetadata":{"promptTokenCount":40,"candidatesTokenCount":8}}`)
+	}))
+	defer srv.Close()
+
+	p := NewGeminiVisionProvider("test-key", "gemini-2.5-flash", testPrompts())
+	p.baseURL = srv.URL
+
+	if _, err := p.ExtractRecipeFromImage(context.Background(), []byte("fake"), "metric", ""); err == nil {
+		t.Error("expected an error when the response has no function call, got nil")
+	}
+}

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -50,6 +50,11 @@ type EnvVars struct {
 	// per-video when the clip is too large to inline or native extraction fails.
 	VideoNativeGemini bool   `env:"VIDEO_NATIVE_GEMINI" optional:"true"`
 	GeminiVideoModel  string `env:"GEMINI_VIDEO_MODEL" envDefault:"gemini-2.5-flash" optional:"true"`
+	// VisionNativeGemini routes image/PDF recipe extraction (photo + files import,
+	// and the video frame-sampling fallback) through Gemini instead of Sonnet.
+	// Requires GEMINI_API_KEY. Falls back to the Sonnet vision provider when off.
+	VisionNativeGemini bool   `env:"VISION_NATIVE_GEMINI" optional:"true"`
+	GeminiVisionModel  string `env:"GEMINI_VISION_MODEL" envDefault:"gemini-2.5-flash" optional:"true"`
 	// PromptsPath overrides the location of the prompts YAML file, which is
 	// cwd-relative by default and only resolves from the Docker workdir.
 	PromptsPath     string `env:"PROMPTS_PATH" envDefault:"configs/prompts.yaml" optional:"true"`

--- a/internal/router/router.go
+++ b/internal/router/router.go
@@ -132,9 +132,20 @@ func SetupRouter(cfg *config.Config, database *gorm.DB) *gin.Engine {
 	modelManager.StartRefresh(context.Background(), 30*time.Second)
 	previewProvider := modelManager.Provider()
 
+	// Vision provider: Sonnet by default; native Gemini when VISION_NATIVE_GEMINI
+	// is set — routes image/PDF import (photo + files) and the video frame
+	// fallback through Gemini instead of Sonnet.
+	var visionProvider ai.VisionProvider = textProvider
+	if cfg.EnvVars.VisionNativeGemini && cfg.EnvVars.GeminiAPIKey != "" {
+		gv := ai.NewGeminiVisionProvider(cfg.EnvVars.GeminiAPIKey, cfg.EnvVars.GeminiVisionModel, cfg.Prompts)
+		gv.WithMiddleware(aiMW)
+		visionProvider = gv
+		logger.Get().Info("native gemini vision enabled", zap.String("model", cfg.EnvVars.GeminiVisionModel))
+	}
+
 	// Import-related routes setup
 	canonicalRepo := repository.NewCanonicalRecipeRepository(database)
-	importService := service.NewImportService(cfg, recipeRepo, recipeService, textProvider, textProvider, previewProvider)
+	importService := service.NewImportService(cfg, recipeRepo, recipeService, textProvider, visionProvider, previewProvider)
 	importService.CanonicalRepo = canonicalRepo
 	// Portion estimation for imports that lack a serving count (cheap Haiku task)
 	importService.Normalize = service.NewNormalizeService(cfg, previewProvider)


### PR DESCRIPTION
## Vision → Gemini

Adds a Gemini `VisionProvider` so **photo + files import** and the **video frame-sampling fallback** run on **Gemini 2.5 Flash** instead of Sonnet (~10× cheaper, top-tier vision). Together with native video (#103), this moves the **entire video path off Sonnet** — native first, and the frames fallback is now Gemini too (per request).

- `ai.GeminiVisionProvider`: full `VisionProvider` — `ExtractRecipeFromImage` (single) + `ExtractRecipesFromMedia` (multi, images **and PDFs**) — via native `generateContent` with forced `create_recipe` / `extract_recipes` calls. Reuses the shared recipe schema + parsers + validation **verbatim**, so output matches the Anthropic provider. PDFs go inline as `application/pdf`.
- Refactored the native POST/retry into a shared `geminiGenerateContent` helper (video + vision share it).
- Routed behind `VISION_NATIVE_GEMINI=true` + `GEMINI_API_KEY` (`GEMINI_VISION_MODEL` default `gemini-2.5-flash`). **Default OFF** → Sonnet vision, behavior-preserving.

### Verification
Offline tests: single-image, multi-media (2 recipes), no-call error. Full suite green; all 7 Gemini provider tests (4 video + 3 vision) pass. Shares the native `generateContent` contract already validated live against `gemini-2.5-flash`.

### Rollout
Ship OFF, then enable `VISION_NATIVE_GEMINI=true` (one task-def env change). Recommend one real photo/files import to eyeball quality before leaving it on.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
https://claude.ai/code/session_01BU4UWZutHd1AnK3XAf7H19