### PR TITLE
feat(ai): full Gemini main-tier TextProvider (opt-in) + voice to Flash

### DIFF
--- a/internal/ai/openai_maintier.go
+++ b/internal/ai/openai_maintier.go
@@ -1,0 +1,538 @@
+package ai
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"time"
+
+	openai "github.com/sashabaranov/go-openai"
+	"github.com/windoze95/saltybytes-api/internal/config"
+)
+
+// This file completes *OpenAICompatProvider so it satisfies the full
+// TextProvider interface (not just the cheap "light" tier). Each method mirrors
+// the matching AnthropicProvider method in anthropic.go field-for-field —
+// identical prompt templates, template-data keys, tool schemas and result
+// parsers — so the main tier can run on an OpenAI-compatible endpoint (e.g.
+// Gemini 2.5 Pro) and produce byte-for-byte faithful requests/results. Only the
+// transport differs: chat-completions function calls instead of Anthropic
+// messages tool use.
+//
+// The three inline tool schemas below are hand-copied from the corresponding
+// Anthropic tool constructors (analyzeAllergensTool, classifyVoiceIntentTool,
+// saveDietaryProfileTool). The recipe schema is the shared recipeProperties
+// helper, so it is reused directly rather than copied.
+
+// messagesToOpenAIParams converts our Message slice into OpenAI chat messages,
+// mirroring messagesToAnthropicParams: system-role turns are dropped from the
+// message list (the Anthropic callers discard the separated system prompt and
+// supply their own), and user/assistant turns are carried over in order.
+func messagesToOpenAIParams(msgs []Message) []openai.ChatCompletionMessage {
+	out := make([]openai.ChatCompletionMessage, 0, len(msgs))
+	for _, m := range msgs {
+		switch m.Role {
+		case "user":
+			out = append(out, openai.ChatCompletionMessage{Role: openai.ChatMessageRoleUser, Content: m.Content})
+		case "assistant":
+			out = append(out, openai.ChatCompletionMessage{Role: openai.ChatMessageRoleAssistant, Content: m.Content})
+		}
+	}
+	return out
+}
+
+// allergenProperties is the JSON-schema property set for the analyze_allergens
+// tool, copied verbatim from analyzeAllergensTool().OfTool.InputSchema.Properties
+// so both tiers request the identical schema.
+func allergenProperties() map[string]interface{} {
+	return map[string]interface{}{
+		"ingredient_analyses": map[string]interface{}{
+			"type":        "array",
+			"description": "Analysis of each ingredient for allergens",
+			"items": map[string]interface{}{
+				"type": "object",
+				"properties": map[string]interface{}{
+					"ingredient_name":    map[string]interface{}{"type": "string", "description": "Name of the ingredient"},
+					"common_allergens":   map[string]interface{}{"type": "array", "items": map[string]interface{}{"type": "string"}, "description": "Known common allergens in this ingredient"},
+					"possible_allergens": map[string]interface{}{"type": "array", "items": map[string]interface{}{"type": "string"}, "description": "Possible allergens that may be present"},
+					"sub_ingredients":    map[string]interface{}{"type": "array", "items": map[string]interface{}{"type": "string"}, "description": "Sub-ingredients that may contain allergens"},
+					"seed_oil_risk":      map[string]interface{}{"type": "boolean", "description": "Whether this ingredient has seed oil risk"},
+					"confidence":         map[string]interface{}{"type": "number", "description": "Confidence score from 0 to 1"},
+				},
+			},
+		},
+		"confidence": map[string]interface{}{
+			"type":        "number",
+			"description": "Overall confidence score from 0 to 1",
+		},
+		"requires_review": map[string]interface{}{
+			"type":        "boolean",
+			"description": "Whether the analysis requires human review",
+		},
+	}
+}
+
+// voiceIntentProperties is the JSON-schema property set for the
+// classify_voice_intent tool, copied verbatim from
+// classifyVoiceIntentTool().OfTool.InputSchema.Properties.
+func voiceIntentProperties() map[string]interface{} {
+	return map[string]interface{}{
+		"type": map[string]interface{}{
+			"type":        "string",
+			"description": "The classified intent type",
+			"enum":        []string{"scroll_up", "scroll_down", "navigate", "question", "ignore"},
+		},
+		"amount": map[string]interface{}{
+			"type":        "string",
+			"description": "Scroll amount",
+			"enum":        []string{"small", "large"},
+		},
+		"target": map[string]interface{}{
+			"type":        "string",
+			"description": "Navigation target section",
+		},
+		"text": map[string]interface{}{
+			"type":        "string",
+			"description": "The question text for question intents",
+		},
+	}
+}
+
+// dietaryProfileProperties is the JSON-schema property set for the
+// save_dietary_profile tool, copied verbatim from
+// saveDietaryProfileTool().OfTool.InputSchema.Properties.
+func dietaryProfileProperties() map[string]interface{} {
+	return map[string]interface{}{
+		"allergies": map[string]interface{}{
+			"type":        "array",
+			"description": "Food allergies. Empty array if none.",
+			"items": map[string]interface{}{
+				"type": "object",
+				"properties": map[string]interface{}{
+					"name":      map[string]interface{}{"type": "string", "description": "Name of the allergen (e.g. 'peanuts', 'shellfish')"},
+					"severity":  map[string]interface{}{"type": "string", "description": "Severity of the allergy", "enum": []string{"mild", "moderate", "severe", "life_threatening"}},
+					"sub_forms": map[string]interface{}{"type": "array", "items": map[string]interface{}{"type": "string"}, "description": "Specific forms or sub-ingredients that trigger the allergy (e.g. 'raw egg' but not 'baked egg'). Empty array if it applies to all forms."},
+					"notes":     map[string]interface{}{"type": "string", "description": "Additional notes about the allergy (reactions, cross-contamination concerns, etc.)"},
+				},
+			},
+		},
+		"intolerances": map[string]interface{}{
+			"type":        "array",
+			"description": "Food intolerances (e.g. 'lactose', 'gluten'). Empty array if none.",
+			"items":       map[string]interface{}{"type": "string"},
+		},
+		"restrictions": map[string]interface{}{
+			"type":        "array",
+			"description": "Dietary restrictions including lifestyle, cultural, or religious (e.g. 'vegetarian', 'halal', 'keto'). Empty array if none.",
+			"items":       map[string]interface{}{"type": "string"},
+		},
+		"preferences": map[string]interface{}{
+			"type":        "array",
+			"description": "Food preferences and dislikes (e.g. 'dislikes cilantro', 'loves spicy food'). Empty array if none.",
+			"items":       map[string]interface{}{"type": "string"},
+		},
+		"medical_notes": map[string]interface{}{
+			"type":        "string",
+			"description": "Medically relevant dietary notes (e.g. 'low sodium for hypertension'). Empty string if none.",
+		},
+	}
+}
+
+// GenerateRecipe creates a new recipe via a forced create_recipe function call.
+// Mirrors AnthropicProvider.GenerateRecipe: it sends only the rendered system
+// and user prompts (it does not use req.Messages, matching the Anthropic side).
+func (p *OpenAICompatProvider) GenerateRecipe(ctx context.Context, req RecipeRequest) (*RecipeResult, error) {
+	op := AIOperation{
+		Name:      "GenerateRecipe",
+		Provider:  p.providerName,
+		Model:     p.model,
+		StartTime: time.Now(),
+	}
+
+	return runWithMiddleware(ctx, p.middleware, op, func(ctx context.Context) (*RecipeResult, error) {
+		sysSuffix, err := config.RenderPrompt(p.prompts.Recipe.Generate.System, map[string]interface{}{
+			"UnitSystem":     req.UnitSystem,
+			"Requirements":   req.Requirements,
+			"CookingContext": req.CookingContext,
+		})
+		if err != nil {
+			return nil, fmt.Errorf("render system prompt: %w", err)
+		}
+
+		userPrompt, err := config.RenderPrompt(p.prompts.Recipe.Generate.User, map[string]interface{}{
+			"Prompt": req.UserPrompt,
+		})
+		if err != nil {
+			return nil, fmt.Errorf("render user prompt: %w", err)
+		}
+
+		summaryDesc := p.prompts.Recipe.Summarize.Recipe
+
+		chatReq := openai.ChatCompletionRequest{
+			Model:     p.model,
+			MaxTokens: 4096,
+			Messages: []openai.ChatCompletionMessage{
+				{Role: openai.ChatMessageRoleSystem, Content: combineSystemPrompt(p.prompts.Recipe.Generate.SystemPrefix, sysSuffix)},
+				{Role: openai.ChatMessageRoleUser, Content: userPrompt},
+			},
+			Tools: []openai.Tool{{
+				Type: openai.ToolTypeFunction,
+				Function: &openai.FunctionDefinition{
+					Name:        "create_recipe",
+					Description: "Create a structured recipe definition with all required fields.",
+					Parameters:  schemaObject(recipeProperties(summaryDesc)),
+				},
+			}},
+			ToolChoice: openai.ToolChoice{
+				Type:     openai.ToolTypeFunction,
+				Function: openai.ToolFunction{Name: "create_recipe"},
+			},
+		}
+
+		return p.completeRecipe(ctx, chatReq)
+	})
+}
+
+// RegenerateRecipe revises an existing recipe based on conversation history.
+// Mirrors AnthropicProvider.RegenerateRecipe.
+func (p *OpenAICompatProvider) RegenerateRecipe(ctx context.Context, req RegenerateRequest) (*RecipeResult, error) {
+	op := AIOperation{
+		Name:      "RegenerateRecipe",
+		Provider:  p.providerName,
+		Model:     p.model,
+		StartTime: time.Now(),
+	}
+
+	return runWithMiddleware(ctx, p.middleware, op, func(ctx context.Context) (*RecipeResult, error) {
+		sysSuffix, err := config.RenderPrompt(p.prompts.Recipe.Regenerate.System, map[string]interface{}{
+			"UnitSystem":     req.UnitSystem,
+			"Requirements":   req.Requirements,
+			"CookingContext": req.CookingContext,
+		})
+		if err != nil {
+			return nil, fmt.Errorf("render system prompt: %w", err)
+		}
+
+		summaryDesc := p.prompts.Recipe.Summarize.Changes
+
+		userPrompt, err := config.RenderPrompt(p.prompts.Recipe.Regenerate.User, map[string]interface{}{
+			"Prompt": req.UserPrompt,
+		})
+		if err != nil {
+			return nil, fmt.Errorf("render user prompt: %w", err)
+		}
+
+		// Build message list: system + existing history + new user prompt.
+		messages := []openai.ChatCompletionMessage{
+			{Role: openai.ChatMessageRoleSystem, Content: combineSystemPrompt(p.prompts.Recipe.Regenerate.SystemPrefix, sysSuffix)},
+		}
+		messages = append(messages, messagesToOpenAIParams(req.ExistingHistory)...)
+		messages = append(messages, openai.ChatCompletionMessage{Role: openai.ChatMessageRoleUser, Content: userPrompt})
+
+		chatReq := openai.ChatCompletionRequest{
+			Model:     p.model,
+			MaxTokens: 4096,
+			Messages:  messages,
+			Tools: []openai.Tool{{
+				Type: openai.ToolTypeFunction,
+				Function: &openai.FunctionDefinition{
+					Name:        "create_recipe",
+					Description: "Create a structured recipe definition with all required fields.",
+					Parameters:  schemaObject(recipeProperties(summaryDesc)),
+				},
+			}},
+			ToolChoice: openai.ToolChoice{
+				Type:     openai.ToolTypeFunction,
+				Function: openai.ToolFunction{Name: "create_recipe"},
+			},
+		}
+
+		return p.completeRecipe(ctx, chatReq)
+	})
+}
+
+// ForkRecipe creates a new recipe branched from an existing one.
+// Mirrors AnthropicProvider.ForkRecipe.
+func (p *OpenAICompatProvider) ForkRecipe(ctx context.Context, req ForkRequest) (*RecipeResult, error) {
+	op := AIOperation{
+		Name:      "ForkRecipe",
+		Provider:  p.providerName,
+		Model:     p.model,
+		StartTime: time.Now(),
+	}
+
+	return runWithMiddleware(ctx, p.middleware, op, func(ctx context.Context) (*RecipeResult, error) {
+		sysSuffix, err := config.RenderPrompt(p.prompts.Recipe.Fork.System, map[string]interface{}{
+			"UnitSystem":     req.UnitSystem,
+			"Requirements":   req.Requirements,
+			"CookingContext": req.CookingContext,
+		})
+		if err != nil {
+			return nil, fmt.Errorf("render system prompt: %w", err)
+		}
+
+		summaryDesc := p.prompts.Recipe.Summarize.Recipe
+
+		userPrompt, err := config.RenderPrompt(p.prompts.Recipe.Fork.User, map[string]interface{}{
+			"Prompt": req.UserPrompt,
+		})
+		if err != nil {
+			return nil, fmt.Errorf("render user prompt: %w", err)
+		}
+
+		messages := []openai.ChatCompletionMessage{
+			{Role: openai.ChatMessageRoleSystem, Content: combineSystemPrompt(p.prompts.Recipe.Fork.SystemPrefix, sysSuffix)},
+		}
+		messages = append(messages, messagesToOpenAIParams(req.ExistingHistory)...)
+		messages = append(messages, openai.ChatCompletionMessage{Role: openai.ChatMessageRoleUser, Content: userPrompt})
+
+		chatReq := openai.ChatCompletionRequest{
+			Model:     p.model,
+			MaxTokens: 4096,
+			Messages:  messages,
+			Tools: []openai.Tool{{
+				Type: openai.ToolTypeFunction,
+				Function: &openai.FunctionDefinition{
+					Name:        "create_recipe",
+					Description: "Create a structured recipe definition with all required fields.",
+					Parameters:  schemaObject(recipeProperties(summaryDesc)),
+				},
+			}},
+			ToolChoice: openai.ToolChoice{
+				Type:     openai.ToolTypeFunction,
+				Function: openai.ToolFunction{Name: "create_recipe"},
+			},
+		}
+
+		return p.completeRecipe(ctx, chatReq)
+	})
+}
+
+// completeRecipe issues a forced create_recipe chat completion and parses,
+// validates and stamps the resulting recipe. Shared by GenerateRecipe,
+// RegenerateRecipe and ForkRecipe (their only difference is prompt/history).
+func (p *OpenAICompatProvider) completeRecipe(ctx context.Context, chatReq openai.ChatCompletionRequest) (*RecipeResult, error) {
+	resp, err := p.createChatCompletion(ctx, chatReq)
+	if err != nil {
+		return nil, err
+	}
+
+	args, err := firstToolCallArguments(resp, "create_recipe")
+	if err != nil {
+		return nil, err
+	}
+
+	var tr recipeToolResult
+	if err := json.Unmarshal([]byte(args), &tr); err != nil {
+		return nil, NewAIError(FailureContentParse, fmt.Errorf("failed to unmarshal recipe: %w", err), "failed to parse recipe tool result")
+	}
+
+	result := toolResultToRecipeResult(&tr)
+	if err := validateRecipeResult(result); err != nil {
+		return nil, err
+	}
+	result.PromptVersion = config.PromptVersion(p.prompts)
+	return result, nil
+}
+
+// AnalyzeAllergens analyses ingredients for allergen risks via a forced
+// analyze_allergens function call. Mirrors AnthropicProvider.AnalyzeAllergens.
+func (p *OpenAICompatProvider) AnalyzeAllergens(ctx context.Context, req AllergenRequest) (*AllergenResult, error) {
+	op := AIOperation{
+		Name:      "AnalyzeAllergens",
+		Provider:  p.providerName,
+		Model:     p.model,
+		StartTime: time.Now(),
+	}
+
+	return runWithMiddleware(ctx, p.middleware, op, func(ctx context.Context) (*AllergenResult, error) {
+		sysPrompt, err := config.RenderPrompt(p.prompts.Allergen.Analyze.System, nil)
+		if err != nil {
+			return nil, fmt.Errorf("render system prompt: %w", err)
+		}
+
+		ingredientList, _ := json.Marshal(req.Ingredients)
+		userPrompt, err := config.RenderPrompt(p.prompts.Allergen.Analyze.User, map[string]interface{}{
+			"Ingredients": string(ingredientList),
+			"IsPremium":   req.IsPremium,
+		})
+		if err != nil {
+			return nil, fmt.Errorf("render user prompt: %w", err)
+		}
+
+		chatReq := openai.ChatCompletionRequest{
+			Model:     p.model,
+			MaxTokens: 4096,
+			Messages: []openai.ChatCompletionMessage{
+				{Role: openai.ChatMessageRoleSystem, Content: sysPrompt},
+				{Role: openai.ChatMessageRoleUser, Content: userPrompt},
+			},
+			Tools: []openai.Tool{{
+				Type: openai.ToolTypeFunction,
+				Function: &openai.FunctionDefinition{
+					Name:        "analyze_allergens",
+					Description: "Analyze ingredients for allergen risks and return structured results.",
+					Parameters:  schemaObject(allergenProperties()),
+				},
+			}},
+			ToolChoice: openai.ToolChoice{
+				Type:     openai.ToolTypeFunction,
+				Function: openai.ToolFunction{Name: "analyze_allergens"},
+			},
+		}
+
+		resp, err := p.createChatCompletion(ctx, chatReq)
+		if err != nil {
+			return nil, err
+		}
+
+		args, err := firstToolCallArguments(resp, "analyze_allergens")
+		if err != nil {
+			return nil, err
+		}
+
+		var tr allergenToolResult
+		if err := json.Unmarshal([]byte(args), &tr); err != nil {
+			return nil, NewAIError(FailureContentParse, fmt.Errorf("failed to unmarshal allergen analysis: %w", err), "failed to parse allergen tool result")
+		}
+		return toolResultToAllergenResult(&tr), nil
+	})
+}
+
+// ClassifyVoiceIntent classifies a voice transcript into an app intent via a
+// forced classify_voice_intent function call. Mirrors
+// AnthropicProvider.ClassifyVoiceIntent.
+func (p *OpenAICompatProvider) ClassifyVoiceIntent(ctx context.Context, transcript string) (*VoiceIntent, error) {
+	op := AIOperation{
+		Name:      "ClassifyVoiceIntent",
+		Provider:  p.providerName,
+		Model:     p.model,
+		StartTime: time.Now(),
+	}
+
+	return runWithMiddleware(ctx, p.middleware, op, func(ctx context.Context) (*VoiceIntent, error) {
+		sysPrompt, err := config.RenderPrompt(p.prompts.Voice.Intent.System, nil)
+		if err != nil {
+			return nil, fmt.Errorf("render system prompt: %w", err)
+		}
+
+		chatReq := openai.ChatCompletionRequest{
+			Model:     p.model,
+			MaxTokens: 256,
+			Messages: []openai.ChatCompletionMessage{
+				{Role: openai.ChatMessageRoleSystem, Content: sysPrompt},
+				{Role: openai.ChatMessageRoleUser, Content: transcript},
+			},
+			Tools: []openai.Tool{{
+				Type: openai.ToolTypeFunction,
+				Function: &openai.FunctionDefinition{
+					Name:        "classify_voice_intent",
+					Description: "Classify a voice transcript into an app intent.",
+					Parameters:  schemaObject(voiceIntentProperties()),
+				},
+			}},
+			ToolChoice: openai.ToolChoice{
+				Type:     openai.ToolTypeFunction,
+				Function: openai.ToolFunction{Name: "classify_voice_intent"},
+			},
+		}
+
+		resp, err := p.createChatCompletion(ctx, chatReq)
+		if err != nil {
+			return nil, err
+		}
+
+		args, err := firstToolCallArguments(resp, "classify_voice_intent")
+		if err != nil {
+			return nil, err
+		}
+
+		var tr voiceIntentToolResult
+		if err := json.Unmarshal([]byte(args), &tr); err != nil {
+			return nil, NewAIError(FailureContentParse, fmt.Errorf("failed to unmarshal voice intent: %w", err), "failed to parse voice intent tool result")
+		}
+		return toolResultToVoiceIntent(&tr), nil
+	})
+}
+
+// DietaryInterview conducts a multi-turn dietary interview. The model is offered
+// the save_dietary_profile tool with tool choice left on "auto": it keeps asking
+// questions (plain-text turns → Complete=false) until it has gathered enough
+// information, then calls the tool (Complete=true, Profile set, Response=wrap-up).
+// Mirrors AnthropicProvider.DietaryInterview and extractDietaryInterviewFromMessage.
+func (p *OpenAICompatProvider) DietaryInterview(ctx context.Context, messages []Message, memberName string) (*DietaryInterviewResult, error) {
+	op := AIOperation{
+		Name:      "DietaryInterview",
+		Provider:  p.providerName,
+		Model:     p.model,
+		StartTime: time.Now(),
+	}
+
+	return runWithMiddleware(ctx, p.middleware, op, func(ctx context.Context) (*DietaryInterviewResult, error) {
+		sysSuffix, err := config.RenderPrompt(p.prompts.DietaryInterview.System, map[string]interface{}{
+			"MemberName": memberName,
+		})
+		if err != nil {
+			return nil, fmt.Errorf("render system prompt: %w", err)
+		}
+
+		chatMsgs := []openai.ChatCompletionMessage{
+			{Role: openai.ChatMessageRoleSystem, Content: combineSystemPrompt(p.prompts.DietaryInterview.SystemPrefix, sysSuffix)},
+		}
+		chatMsgs = append(chatMsgs, messagesToOpenAIParams(messages)...)
+
+		// ToolChoice "auto" (not forced): let the model decide when the
+		// interview has enough information to call save_dietary_profile.
+		chatReq := openai.ChatCompletionRequest{
+			Model:     p.model,
+			MaxTokens: 1024,
+			Messages:  chatMsgs,
+			Tools: []openai.Tool{{
+				Type: openai.ToolTypeFunction,
+				Function: &openai.FunctionDefinition{
+					Name:        "save_dietary_profile",
+					Description: "Save the completed dietary profile. Call this ONLY once the interview has gathered enough information to fill out the profile (allergies, intolerances, restrictions, and preferences have all been asked about).",
+					Parameters:  schemaObject(dietaryProfileProperties()),
+				},
+			}},
+			ToolChoice: "auto",
+		}
+
+		resp, err := p.createChatCompletion(ctx, chatReq)
+		if err != nil {
+			return nil, err
+		}
+
+		if resp == nil || len(resp.Choices) == 0 {
+			return nil, NewAIError(FailureContentEmpty, errors.New("no choices in chat completion response"), "no choices in response")
+		}
+
+		msg := resp.Choices[0].Message
+		text := msg.Content
+
+		var profile *DietaryProfileResult
+		for _, call := range msg.ToolCalls {
+			if call.Function.Name != "save_dietary_profile" {
+				continue
+			}
+			var tr dietaryProfileToolResult
+			if err := json.Unmarshal([]byte(call.Function.Arguments), &tr); err != nil {
+				return nil, NewAIError(FailureContentParse, fmt.Errorf("failed to unmarshal dietary profile: %w", err), "failed to parse dietary profile tool result")
+			}
+			profile = toolResultToDietaryProfile(&tr)
+		}
+
+		if profile != nil {
+			if text == "" {
+				text = dietaryWrapUpFallback
+			}
+			return &DietaryInterviewResult{Response: text, Complete: true, Profile: profile}, nil
+		}
+
+		if text == "" {
+			return nil, NewAIError(FailureContentEmpty, errors.New("no text content in chat completion response"), "no text content in response")
+		}
+		return &DietaryInterviewResult{Response: text}, nil
+	})
+}

--- a/internal/ai/openai_maintier_test.go
+++ b/internal/ai/openai_maintier_test.go
@@ -1,0 +1,281 @@
+package ai
+
+import (
+	"context"
+	"testing"
+
+	openai "github.com/sashabaranov/go-openai"
+	"github.com/windoze95/saltybytes-api/internal/config"
+)
+
+// toolCallResponse builds a canned chat-completion response carrying a single
+// forced tool call (fnName + JSON args). Mirrors the shape the real providers
+// return so the offline tests exercise the same parse path.
+func toolCallResponse(fnName, args string) openai.ChatCompletionResponse {
+	return openai.ChatCompletionResponse{
+		Choices: []openai.ChatCompletionChoice{{
+			Index: 0,
+			Message: openai.ChatCompletionMessage{
+				Role: openai.ChatMessageRoleAssistant,
+				ToolCalls: []openai.ToolCall{{
+					ID:       "call_1",
+					Type:     openai.ToolTypeFunction,
+					Function: openai.FunctionCall{Name: fnName, Arguments: args},
+				}},
+			},
+			FinishReason: openai.FinishReasonToolCalls,
+		}},
+		Usage: openai.Usage{PromptTokens: 100, CompletionTokens: 60},
+	}
+}
+
+func TestOpenAICompatProvider_GenerateRecipe(t *testing.T) {
+	// Field names match recipeToolResult's json tags.
+	recipeArgs := `{
+		"title": "Weeknight Beef Stew",
+		"ingredients": [
+			{"name": "beef chuck", "unit": "lb", "amount": 2, "original_text": "2 lb beef chuck"},
+			{"name": "carrot", "unit": "pieces", "amount": 3, "original_text": "3 carrots"}
+		],
+		"instructions": ["Brown the beef.", "Add vegetables and simmer for two hours."],
+		"cook_time": 130,
+		"recipe_summary": "A hearty braised beef stew.",
+		"portions": 4,
+		"portion_size": "1 bowl",
+		"unit_system": "us_customary"
+	}`
+
+	srv := newMockOpenAIServer(t, toolCallResponse("create_recipe", recipeArgs))
+	defer srv.Close()
+
+	p := NewOpenAICompatProvider("test-key", srv.URL, "gemini-2.5-pro", "gemini", testPrompts())
+
+	result, err := p.GenerateRecipe(context.Background(), RecipeRequest{
+		UserPrompt: "a hearty beef stew",
+		UnitSystem: "us_customary",
+	})
+	if err != nil {
+		t.Fatalf("GenerateRecipe returned error: %v", err)
+	}
+	if result.Title != "Weeknight Beef Stew" {
+		t.Errorf("title = %q, want %q", result.Title, "Weeknight Beef Stew")
+	}
+	if len(result.Ingredients) != 2 {
+		t.Fatalf("got %d ingredients, want 2", len(result.Ingredients))
+	}
+	if len(result.Instructions) != 2 {
+		t.Errorf("got %d instructions, want 2", len(result.Instructions))
+	}
+	// PromptVersion must be stamped from the prompt set (mirrors Anthropic).
+	if want := config.PromptVersion(testPrompts()); result.PromptVersion == "" || result.PromptVersion != want {
+		t.Errorf("PromptVersion = %q, want %q", result.PromptVersion, want)
+	}
+}
+
+func TestOpenAICompatProvider_GenerateRecipe_MissingTitleIsError(t *testing.T) {
+	// A recipe with no title must fail validation, not silently succeed.
+	badArgs := `{
+		"ingredients": [{"name": "flour", "unit": "cup", "amount": 1}],
+		"instructions": ["Mix."]
+	}`
+	srv := newMockOpenAIServer(t, toolCallResponse("create_recipe", badArgs))
+	defer srv.Close()
+
+	p := NewOpenAICompatProvider("test-key", srv.URL, "gemini-2.5-pro", "gemini", testPrompts())
+
+	if _, err := p.GenerateRecipe(context.Background(), RecipeRequest{UserPrompt: "x"}); err == nil {
+		t.Error("expected validation error for recipe missing title, got nil")
+	}
+}
+
+func TestOpenAICompatProvider_AnalyzeAllergens(t *testing.T) {
+	// Field names match allergenToolResult / ingredientAnalysisToolRes json tags.
+	allergenArgs := `{
+		"ingredient_analyses": [
+			{
+				"ingredient_name": "peanut butter",
+				"common_allergens": ["peanuts"],
+				"possible_allergens": ["tree nuts"],
+				"sub_ingredients": ["peanuts", "salt"],
+				"seed_oil_risk": false,
+				"confidence": 0.98
+			}
+		],
+		"confidence": 0.95,
+		"requires_review": false
+	}`
+
+	srv := newMockOpenAIServer(t, toolCallResponse("analyze_allergens", allergenArgs))
+	defer srv.Close()
+
+	p := NewOpenAICompatProvider("test-key", srv.URL, "gemini-2.5-pro", "gemini", testPrompts())
+
+	result, err := p.AnalyzeAllergens(context.Background(), AllergenRequest{
+		Ingredients: []IngredientInput{{Name: "peanut butter", Unit: "tbsp", Amount: 2}},
+		IsPremium:   true,
+	})
+	if err != nil {
+		t.Fatalf("AnalyzeAllergens returned error: %v", err)
+	}
+	if len(result.IngredientAnalyses) != 1 {
+		t.Fatalf("got %d analyses, want 1", len(result.IngredientAnalyses))
+	}
+	a := result.IngredientAnalyses[0]
+	if a.IngredientName != "peanut butter" {
+		t.Errorf("ingredient name = %q, want %q", a.IngredientName, "peanut butter")
+	}
+	if len(a.CommonAllergens) != 1 || a.CommonAllergens[0] != "peanuts" {
+		t.Errorf("common allergens = %v, want [peanuts]", a.CommonAllergens)
+	}
+	if result.Confidence != 0.95 {
+		t.Errorf("confidence = %v, want 0.95", result.Confidence)
+	}
+	if result.RequiresReview {
+		t.Error("requires_review = true, want false")
+	}
+}
+
+func TestOpenAICompatProvider_ClassifyVoiceIntent(t *testing.T) {
+	// Field names match voiceIntentToolResult json tags.
+	voiceArgs := `{"type": "scroll_down", "amount": "large", "target": "", "text": ""}`
+
+	srv := newMockOpenAIServer(t, toolCallResponse("classify_voice_intent", voiceArgs))
+	defer srv.Close()
+
+	p := NewOpenAICompatProvider("test-key", srv.URL, "gemini-2.5-pro", "gemini", testPrompts())
+
+	intent, err := p.ClassifyVoiceIntent(context.Background(), "scroll down a lot")
+	if err != nil {
+		t.Fatalf("ClassifyVoiceIntent returned error: %v", err)
+	}
+	if intent.Type != "scroll_down" {
+		t.Errorf("type = %q, want %q", intent.Type, "scroll_down")
+	}
+	if intent.Amount != "large" {
+		t.Errorf("amount = %q, want %q", intent.Amount, "large")
+	}
+}
+
+// DietaryInterview: a plain-text turn (no tool call) is the model asking its
+// next question. Complete must be false, Profile nil, Response set.
+func TestOpenAICompatProvider_DietaryInterview_TextTurn(t *testing.T) {
+	const question = "Do you have any food allergies I should know about?"
+	canned := openai.ChatCompletionResponse{
+		Choices: []openai.ChatCompletionChoice{{
+			Index: 0,
+			Message: openai.ChatCompletionMessage{
+				Role:    openai.ChatMessageRoleAssistant,
+				Content: question,
+			},
+			FinishReason: openai.FinishReasonStop,
+		}},
+		Usage: openai.Usage{PromptTokens: 50, CompletionTokens: 15},
+	}
+
+	srv := newMockOpenAIServer(t, canned)
+	defer srv.Close()
+
+	p := NewOpenAICompatProvider("test-key", srv.URL, "gemini-2.5-pro", "gemini", testPrompts())
+
+	result, err := p.DietaryInterview(context.Background(), []Message{
+		{Role: "assistant", Content: "Hi! Let's set up your dietary profile."},
+		{Role: "user", Content: "Sounds good."},
+	}, "Alex")
+	if err != nil {
+		t.Fatalf("DietaryInterview returned error: %v", err)
+	}
+	if result.Complete {
+		t.Error("Complete = true, want false for a plain-text interview turn")
+	}
+	if result.Profile != nil {
+		t.Error("Profile should be nil for a plain-text interview turn")
+	}
+	if result.Response != question {
+		t.Errorf("Response = %q, want %q", result.Response, question)
+	}
+}
+
+// DietaryInterview: when the model calls save_dietary_profile the interview is
+// complete, Profile is populated and Response carries the wrap-up text.
+func TestOpenAICompatProvider_DietaryInterview_SaveProfile(t *testing.T) {
+	// Field names match dietaryProfileToolResult / dietaryAllergyToolRes json tags.
+	profileArgs := `{
+		"allergies": [
+			{"name": "peanuts", "severity": "severe", "sub_forms": ["raw"], "notes": "carries an epipen"}
+		],
+		"intolerances": ["lactose"],
+		"restrictions": ["vegetarian"],
+		"preferences": ["loves spicy food"],
+		"medical_notes": "low sodium for hypertension"
+	}`
+	const wrapUp = "Great, I've saved your dietary profile!"
+
+	canned := openai.ChatCompletionResponse{
+		Choices: []openai.ChatCompletionChoice{{
+			Index: 0,
+			Message: openai.ChatCompletionMessage{
+				Role:    openai.ChatMessageRoleAssistant,
+				Content: wrapUp,
+				ToolCalls: []openai.ToolCall{{
+					ID:       "call_1",
+					Type:     openai.ToolTypeFunction,
+					Function: openai.FunctionCall{Name: "save_dietary_profile", Arguments: profileArgs},
+				}},
+			},
+			FinishReason: openai.FinishReasonToolCalls,
+		}},
+		Usage: openai.Usage{PromptTokens: 200, CompletionTokens: 80},
+	}
+
+	srv := newMockOpenAIServer(t, canned)
+	defer srv.Close()
+
+	p := NewOpenAICompatProvider("test-key", srv.URL, "gemini-2.5-pro", "gemini", testPrompts())
+
+	result, err := p.DietaryInterview(context.Background(), []Message{
+		{Role: "user", Content: "I'm allergic to peanuts and I'm vegetarian."},
+	}, "Alex")
+	if err != nil {
+		t.Fatalf("DietaryInterview returned error: %v", err)
+	}
+	if !result.Complete {
+		t.Error("Complete = false, want true when save_dietary_profile is called")
+	}
+	if result.Profile == nil {
+		t.Fatal("Profile is nil, want non-nil when save_dietary_profile is called")
+	}
+	if result.Response != wrapUp {
+		t.Errorf("Response = %q, want %q", result.Response, wrapUp)
+	}
+	if len(result.Profile.Allergies) != 1 || result.Profile.Allergies[0].Name != "peanuts" {
+		t.Errorf("allergies = %+v, want one entry named peanuts", result.Profile.Allergies)
+	}
+	if result.Profile.Allergies[0].Severity != "severe" {
+		t.Errorf("severity = %q, want %q", result.Profile.Allergies[0].Severity, "severe")
+	}
+	if len(result.Profile.Restrictions) != 1 || result.Profile.Restrictions[0] != "vegetarian" {
+		t.Errorf("restrictions = %v, want [vegetarian]", result.Profile.Restrictions)
+	}
+}
+
+// DietaryInterview: when the model calls save_dietary_profile with no wrap-up
+// text, the fallback wrap-up message is substituted.
+func TestOpenAICompatProvider_DietaryInterview_SaveProfileNoText(t *testing.T) {
+	profileArgs := `{"allergies": [], "intolerances": [], "restrictions": [], "preferences": [], "medical_notes": ""}`
+
+	srv := newMockOpenAIServer(t, toolCallResponse("save_dietary_profile", profileArgs))
+	defer srv.Close()
+
+	p := NewOpenAICompatProvider("test-key", srv.URL, "gemini-2.5-pro", "gemini", testPrompts())
+
+	result, err := p.DietaryInterview(context.Background(), []Message{{Role: "user", Content: "No restrictions."}}, "Alex")
+	if err != nil {
+		t.Fatalf("DietaryInterview returned error: %v", err)
+	}
+	if !result.Complete || result.Profile == nil {
+		t.Fatalf("want Complete + Profile, got Complete=%v Profile=%v", result.Complete, result.Profile)
+	}
+	if result.Response != dietaryWrapUpFallback {
+		t.Errorf("Response = %q, want fallback %q", result.Response, dietaryWrapUpFallback)
+	}
+}

--- a/internal/ai/openai_text.go
+++ b/internal/ai/openai_text.go
@@ -320,32 +320,7 @@ func (p *OpenAICompatProvider) CookingQA(ctx context.Context, question string, r
 	})
 }
 
-// --- Unsupported on the light tier ---
-//
-// These TextProvider methods are only ever called on the main (Sonnet)
-// provider. They are stubbed to satisfy the interface and fail loudly if the
-// light tier is ever wired to a path that needs them.
-
-func (p *OpenAICompatProvider) GenerateRecipe(ctx context.Context, req RecipeRequest) (*RecipeResult, error) {
-	return nil, fmt.Errorf("OpenAICompatProvider: %s not supported by the light tier", "GenerateRecipe")
-}
-
-func (p *OpenAICompatProvider) RegenerateRecipe(ctx context.Context, req RegenerateRequest) (*RecipeResult, error) {
-	return nil, fmt.Errorf("OpenAICompatProvider: %s not supported by the light tier", "RegenerateRecipe")
-}
-
-func (p *OpenAICompatProvider) ForkRecipe(ctx context.Context, req ForkRequest) (*RecipeResult, error) {
-	return nil, fmt.Errorf("OpenAICompatProvider: %s not supported by the light tier", "ForkRecipe")
-}
-
-func (p *OpenAICompatProvider) AnalyzeAllergens(ctx context.Context, req AllergenRequest) (*AllergenResult, error) {
-	return nil, fmt.Errorf("OpenAICompatProvider: %s not supported by the light tier", "AnalyzeAllergens")
-}
-
-func (p *OpenAICompatProvider) ClassifyVoiceIntent(ctx context.Context, transcript string) (*VoiceIntent, error) {
-	return nil, fmt.Errorf("OpenAICompatProvider: %s not supported by the light tier", "ClassifyVoiceIntent")
-}
-
-func (p *OpenAICompatProvider) DietaryInterview(ctx context.Context, messages []Message, memberName string) (*DietaryInterviewResult, error) {
-	return nil, fmt.Errorf("OpenAICompatProvider: %s not supported by the light tier", "DietaryInterview")
-}
+// The remaining TextProvider methods (GenerateRecipe, RegenerateRecipe,
+// ForkRecipe, AnalyzeAllergens, ClassifyVoiceIntent, DietaryInterview) are
+// implemented in openai_maintier.go, so this provider can serve the full main
+// tier (e.g. Gemini 2.5 Pro) as well as the light tier.

--- a/internal/ai/openai_text_test.go
+++ b/internal/ai/openai_text_test.go
@@ -175,27 +175,6 @@ func TestOpenAICompatProvider_EstimatePortions(t *testing.T) {
 	}
 }
 
-func TestOpenAICompatProvider_StubsReturnError(t *testing.T) {
-	p := NewOpenAICompatProvider("test-key", "", "gpt-4o-mini", "openai", testPrompts())
-	ctx := context.Background()
-
-	if _, err := p.GenerateRecipe(ctx, RecipeRequest{}); err == nil {
-		t.Error("GenerateRecipe: expected error, got nil")
-	} else if !strings.Contains(err.Error(), "not supported by the light tier") {
-		t.Errorf("GenerateRecipe error = %q, want it to mention 'not supported by the light tier'", err.Error())
-	}
-
-	if _, err := p.AnalyzeAllergens(ctx, AllergenRequest{}); err == nil {
-		t.Error("AnalyzeAllergens: expected error, got nil")
-	}
-	if _, err := p.DietaryInterview(ctx, nil, "Alex"); err == nil {
-		t.Error("DietaryInterview: expected error, got nil")
-	}
-	if _, err := p.ClassifyVoiceIntent(ctx, "scroll down"); err == nil {
-		t.Error("ClassifyVoiceIntent: expected error, got nil")
-	}
-}
-
 func TestOpenAICompatProvider_NoToolCallIsError(t *testing.T) {
 	// A response with no tool call must surface a clear error rather than panic.
 	canned := openai.ChatCompletionResponse{

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -35,9 +35,18 @@ type EnvVars struct {
 	// high-volume preview/extraction tasks. LightModel/LightBaseURL override the
 	// model ID and endpoint; empty LightBaseURL uses the provider's default.
 	// This is the startup default — the dashboard live-switch overrides it via DB.
-	LightProvider  string `env:"LIGHT_PROVIDER" envDefault:"anthropic" optional:"true"`
-	LightModel     string `env:"LIGHT_MODEL" optional:"true"`
-	LightBaseURL   string `env:"LIGHT_BASE_URL" optional:"true"`
+	LightProvider string `env:"LIGHT_PROVIDER" envDefault:"anthropic" optional:"true"`
+	LightModel    string `env:"LIGHT_MODEL" optional:"true"`
+	LightBaseURL  string `env:"LIGHT_BASE_URL" optional:"true"`
+	// Main-tier provider selection: the flagship reasoning tier (recipe
+	// generation/regen/fork, allergens, dietary). Defaults to "anthropic" (Sonnet);
+	// set to "gemini"/"openai"/"deepseek" to A/B a cheaper frontier model
+	// (e.g. gemini-2.5-pro). MainModel/MainBaseURL override the model + endpoint.
+	// Streaming generation gracefully falls back to non-streaming for non-Anthropic
+	// providers. Behavior-preserving while unset.
+	MainProvider   string `env:"MAIN_PROVIDER" envDefault:"anthropic" optional:"true"`
+	MainModel      string `env:"MAIN_MODEL" optional:"true"`
+	MainBaseURL    string `env:"MAIN_BASE_URL" optional:"true"`
 	GeminiAPIKey   string `env:"GEMINI_API_KEY" optional:"true"`
 	DeepSeekAPIKey string `env:"DEEPSEEK_API_KEY" optional:"true"`
 	// AdminToken guards the admin API (the dashboard's live model-switch +

--- a/internal/router/router.go
+++ b/internal/router/router.go
@@ -32,6 +32,33 @@ func lightKeysFromConfig(cfg *config.Config) ai.LightKeys {
 	}
 }
 
+// buildMainTextProvider selects the flagship reasoning provider. Defaults to the
+// Anthropic Sonnet provider; MAIN_PROVIDER=gemini/openai/deepseek swaps in a
+// cheaper frontier model (an OpenAI-compatible provider that implements the full
+// TextProvider). gemini defaults to gemini-2.5-pro. Falls back to Sonnet if the
+// alternative can't be built (e.g. a missing key), so the app always boots.
+func buildMainTextProvider(cfg *config.Config, sonnet ai.TextProvider, mw ai.AIMiddleware) ai.TextProvider {
+	switch cfg.EnvVars.MainProvider {
+	case "", "anthropic":
+		return sonnet
+	default:
+		model := cfg.EnvVars.MainModel
+		if model == "" && cfg.EnvVars.MainProvider == "gemini" {
+			model = "gemini-2.5-pro"
+		}
+		spec := ai.LightProviderSpec{Provider: cfg.EnvVars.MainProvider, Model: model, BaseURL: cfg.EnvVars.MainBaseURL}
+		p, err := ai.BuildLightProvider(spec, lightKeysFromConfig(cfg), cfg.Prompts, mw)
+		if err != nil {
+			logger.Get().Warn("main provider unbuildable, using anthropic sonnet",
+				zap.String("provider", cfg.EnvVars.MainProvider), zap.Error(err))
+			return sonnet
+		}
+		logger.Get().Info("main tier provider active",
+			zap.String("provider", cfg.EnvVars.MainProvider), zap.String("model", model))
+		return p
+	}
+}
+
 // SetupRouter sets up the Gin router.
 func SetupRouter(cfg *config.Config, database *gorm.DB) *gin.Engine {
 	// Create default Gin router
@@ -107,11 +134,17 @@ func SetupRouter(cfg *config.Config, database *gorm.DB) *gin.Engine {
 	aiMW := ai.NewMiddlewareChain(&ai.LoggingMiddleware{}, costMW)
 	textProvider.WithMiddleware(aiMW)
 
+	// Main (flagship reasoning) tier: Sonnet by default; a cheaper frontier model
+	// (e.g. gemini-2.5-pro) when MAIN_PROVIDER is set, driving recipe
+	// generation/regen/fork, allergens and dietary. Streaming generation falls
+	// back to non-streaming for non-Anthropic providers (no StreamingTextProvider).
+	mainTextProvider := buildMainTextProvider(cfg, textProvider, aiMW)
+
 	// Recipe-related routes setup
 	recipeRepo := repository.NewRecipeRepository(database)
 	vectorRepo := repository.NewVectorRepository(database)
 	embedProvider := ai.NewEmbeddingProvider(cfg.EnvVars.OpenAIAPIKey)
-	recipeService := service.NewRecipeService(cfg, recipeRepo, textProvider, imageProvider)
+	recipeService := service.NewRecipeService(cfg, recipeRepo, mainTextProvider, imageProvider)
 	recipeService.EmbedProvider = embedProvider
 	recipeService.VectorRepo = vectorRepo
 	recipeHandler := handlers.NewRecipeHandler(recipeService)
@@ -145,7 +178,7 @@ func SetupRouter(cfg *config.Config, database *gorm.DB) *gin.Engine {
 
 	// Import-related routes setup
 	canonicalRepo := repository.NewCanonicalRecipeRepository(database)
-	importService := service.NewImportService(cfg, recipeRepo, recipeService, textProvider, visionProvider, previewProvider)
+	importService := service.NewImportService(cfg, recipeRepo, recipeService, mainTextProvider, visionProvider, previewProvider)
 	importService.CanonicalRepo = canonicalRepo
 	// Portion estimation for imports that lack a serving count (cheap Haiku task)
 	importService.Normalize = service.NewNormalizeService(cfg, previewProvider)
@@ -271,7 +304,7 @@ func SetupRouter(cfg *config.Config, database *gorm.DB) *gin.Engine {
 
 	// Family-related routes setup
 	familyRepo := repository.NewFamilyRepository(database)
-	familyService := service.NewFamilyService(cfg, familyRepo, textProvider)
+	familyService := service.NewFamilyService(cfg, familyRepo, mainTextProvider)
 	familyHandler := handlers.NewFamilyHandler(familyService)
 
 	apiProtected.POST("/family", middleware.AttachUserToContext(userService), familyHandler.CreateFamily)
@@ -284,7 +317,7 @@ func SetupRouter(cfg *config.Config, database *gorm.DB) *gin.Engine {
 
 	// Allergen analysis routes setup
 	allergenRepo := repository.NewAllergenRepository(database)
-	allergenService := service.NewAllergenService(cfg, allergenRepo, familyRepo, recipeRepo, textProvider, subService)
+	allergenService := service.NewAllergenService(cfg, allergenRepo, familyRepo, recipeRepo, mainTextProvider, subService)
 	allergenHandler := handlers.NewAllergenHandler(allergenService)
 
 	apiProtected.POST("/recipes/:recipe_id/allergens/analyze", middleware.AttachUserToContext(userService), allergenHandler.AnalyzeRecipe)
@@ -343,7 +376,9 @@ func SetupRouter(cfg *config.Config, database *gorm.DB) *gin.Engine {
 	go hub.Run()
 	speechProvider := ai.NewWhisperProvider(cfg.EnvVars.OpenAIAPIKey)
 	importService.SpeechProvider = speechProvider
-	voiceService := service.NewVoiceService(cfg, textProvider, speechProvider)
+	// Voice cooking assistant (intent classification + cooking Q&A) runs on the
+	// cheap/fast light tier, not the flagship model.
+	voiceService := service.NewVoiceService(cfg, previewProvider, speechProvider)
 	cookingHandler := ws.NewCookingHandler(hub, cfg.EnvVars.JwtSecretKey, voiceService, recipeRepo)
 	r.GET("/v1/ws/cook/:recipe_id", cookingHandler.HandleCookingSession)
 


### PR DESCRIPTION
Completes the Gemini routing across the whole AI surface.

## 1. Main tier swappable — flag-off, behavior-preserving
Implements the **6 remaining `TextProvider` methods** on `OpenAICompatProvider` (`GenerateRecipe`, `RegenerateRecipe`, `ForkRecipe`, `AnalyzeAllergens`, `ClassifyVoiceIntent`, `DietaryInterview`) in `internal/ai/openai_maintier.go`, **mirroring the Anthropic methods field-for-field** — same prompt templates, template-data keys, tool schemas, and result parsers (`recipeToolResult`/`allergenToolResult`/… reused verbatim). So `OpenAICompatProvider` now serves the **full main tier**, not just the light tier.

- `MAIN_PROVIDER` (default `anthropic` = **Sonnet**) selects it. `MAIN_PROVIDER=gemini` → **gemini-2.5-pro** for recipe generation/regen/fork + allergens + dietary. ($1.25/$10 vs Sonnet $3/$15 — cheaper *and* frontier.)
- **Streaming** generation gracefully **falls back to non-streaming** for non-Anthropic providers (they don't implement `StreamingTextProvider` — the service already type-asserts + degrades).
- **Default keeps Sonnet → merging changes nothing** until `MAIN_PROVIDER` is set. A/B it, then commit.
- `DietaryInterview` uses **auto** tool-choice (not forced): text turns continue the interview; a `save_dietary_profile` call completes it — mirrors the Anthropic branch.

## 2. Voice → Flash (live)
The voice cooking assistant (intent classification + cooking Q&A) now runs on the cheap/fast **light tier** instead of Sonnet — a live routing change per plan.

## Verification
7 new main-tier tests (generate / allergens / voice + dietary *text-turn* AND *completion*). Removed the obsolete stub-error test. Full `go test ./... -count=1` green + offline.

## Rollout
Ship as-is: voice→Flash goes live; the main-tier swap stays dark until you set `MAIN_PROVIDER=gemini`. Recommend generating a few recipes on `gemini-2.5-pro` to compare quality before leaving it on (streaming degrades to non-streaming there — a UX consideration worth noting).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
https://claude.ai/code/session_01BU4UWZutHd1AnK3XAf7H19