### PR TITLE
feat(finder): Phase 1 — backend Recipe Finder (SSE endpoint + single-call ranking, ships dark)

### DIFF
--- a/internal/ai/anthropic.go
+++ b/internal/ai/anthropic.go
@@ -380,6 +380,74 @@ func estimatePortionsTool() anthropic.ToolUnionParam {
 	}
 }
 
+// finderRankSystemPrompt steers the recipe finder's single ranking call. It is
+// an inline prompt (like EstimatePortions') rather than a config template, so
+// the finder is self-contained. The hard rule — reference candidates only by
+// index, never invent — is enforced structurally by the tool schema too.
+const finderRankSystemPrompt = `You are a recipe-finding assistant. You are given a list of REAL recipe search results (candidates), each with an index, and a description of what the user wants (facets, free text, and their family's dietary needs).
+
+Select the candidates that best match the request and return them, best match first, using ONLY their given index. Never invent a recipe and never return an index that is not in the candidate list. It is fine to return fewer candidates than you were given; drop ones that clearly do not fit.
+
+For each candidate you return:
+- Give one short sentence (reason) explaining why it fits the request.
+- Give a best-effort dietary safety assessment for each family member mentioned in the dietary needs, judging ONLY from the candidate's title and description: "safe" if nothing conflicts, "caution" if it might conflict or is unclear, "avoid" if it clearly conflicts with an allergy or restriction. Keep the note short. Omit members you cannot assess.
+
+Also suggest 2-4 broadened search queries (broaden_queries) the user could try to get more options.
+
+Return everything via the rank_recipes tool.`
+
+// rankRecipesProperties is the JSON-schema property set for the rank_recipes
+// tool. It is shared by the Anthropic tool definition and the OpenAI-compatible
+// main/light provider (openai_maintier.go) so both tiers request the identical
+// schema.
+func rankRecipesProperties() map[string]interface{} {
+	return map[string]interface{}{
+		"ranked": map[string]interface{}{
+			"type":        "array",
+			"description": "Chosen candidates, best match first. Each references a candidate by its index.",
+			"items": map[string]interface{}{
+				"type": "object",
+				"properties": map[string]interface{}{
+					"index":  map[string]interface{}{"type": "integer", "description": "Index of the candidate from the provided list. Must be one of the given indices."},
+					"reason": map[string]interface{}{"type": "string", "description": "One short sentence on why this candidate fits the request."},
+					"safety": map[string]interface{}{
+						"type":        "array",
+						"description": "Best-effort per-family-member dietary assessment from the title/description. Empty if no dietary needs were given.",
+						"items": map[string]interface{}{
+							"type": "object",
+							"properties": map[string]interface{}{
+								"member_name": map[string]interface{}{"type": "string", "description": "Family member's name"},
+								"status":      map[string]interface{}{"type": "string", "description": "Dietary safety for this member", "enum": []string{"safe", "caution", "avoid"}},
+								"note":        map[string]interface{}{"type": "string", "description": "Short note explaining the status"},
+							},
+						},
+					},
+				},
+			},
+		},
+		"broaden_queries": map[string]interface{}{
+			"type":        "array",
+			"description": "2-4 broadened search queries the user could try for more options.",
+			"items":       map[string]interface{}{"type": "string"},
+		},
+	}
+}
+
+// rankRecipesTool builds the Claude tool definition for the recipe finder's
+// query-expansion + ranking call.
+func rankRecipesTool() anthropic.ToolUnionParam {
+	return anthropic.ToolUnionParam{
+		OfTool: &anthropic.ToolParam{
+			Name:        "rank_recipes",
+			Description: anthropic.String("Return the best-matching candidates by index, with rationales, per-member dietary safety, and broadened query suggestions."),
+			InputSchema: anthropic.ToolInputSchemaParam{
+				Type:       "object",
+				Properties: rankRecipesProperties(),
+			},
+		},
+	}
+}
+
 // saveDietaryProfileTool builds the Claude tool definition for saving a
 // completed dietary profile at the end of a dietary interview. The input
 // schema mirrors models.DietaryProfile's snake_case JSON shape.
@@ -510,6 +578,86 @@ func toolResultToPortionEstimate(tr *portionToolResult) *PortionEstimate {
 		Portions:    tr.Portions,
 		PortionSize: tr.PortionSize,
 		Confidence:  tr.Confidence,
+	}
+}
+
+// finderRankPayloadCandidate / finderRankPayload are the JSON body sent to the
+// ranker as the user turn. Keeping them in a shared builder means the Anthropic
+// and OpenAI-compatible providers send byte-identical requests.
+type finderRankPayloadCandidate struct {
+	Index       int    `json:"index"`
+	Title       string `json:"title"`
+	Source      string `json:"source,omitempty"`
+	Description string `json:"description,omitempty"`
+}
+
+type finderRankPayload struct {
+	Facets         string                       `json:"facets,omitempty"`
+	FreeText       string                       `json:"free_text,omitempty"`
+	UnitSystem     string                       `json:"unit_system,omitempty"`
+	CookingContext string                       `json:"cooking_context,omitempty"`
+	Requirements   string                       `json:"requirements,omitempty"`
+	DietSummary    string                       `json:"diet_summary,omitempty"`
+	Candidates     []finderRankPayloadCandidate `json:"candidates"`
+}
+
+// buildFinderRankPayload converts a FinderRankRequest into the wire payload sent
+// to the ranker. Shared by both providers so their requests are identical.
+func buildFinderRankPayload(req FinderRankRequest) finderRankPayload {
+	candidates := make([]finderRankPayloadCandidate, len(req.Candidates))
+	for i, c := range req.Candidates {
+		candidates[i] = finderRankPayloadCandidate{
+			Index:       c.Index,
+			Title:       c.Title,
+			Source:      c.Source,
+			Description: c.Description,
+		}
+	}
+	return finderRankPayload{
+		Facets:         req.Facets,
+		FreeText:       req.FreeText,
+		UnitSystem:     req.UnitSystem,
+		CookingContext: req.CookingContext,
+		Requirements:   req.Requirements,
+		DietSummary:    req.DietSummary,
+		Candidates:     candidates,
+	}
+}
+
+// finderRankToolResult is the JSON structure returned by the rank_recipes tool call.
+type finderRankToolResult struct {
+	Ranked []struct {
+		Index  int    `json:"index"`
+		Reason string `json:"reason"`
+		Safety []struct {
+			MemberName string `json:"member_name"`
+			Status     string `json:"status"`
+			Note       string `json:"note"`
+		} `json:"safety"`
+	} `json:"ranked"`
+	BroadenQueries []string `json:"broaden_queries"`
+}
+
+func toolResultToFinderRankResult(tr *finderRankToolResult) *FinderRankResult {
+	ranked := make([]FinderRanking, len(tr.Ranked))
+	for i, r := range tr.Ranked {
+		safety := make([]MemberSafety, len(r.Safety))
+		for j, s := range r.Safety {
+			safety[j] = MemberSafety{
+				MemberName: s.MemberName,
+				Status:     s.Status,
+				Note:       s.Note,
+			}
+		}
+		ranked[i] = FinderRanking{
+			Index:  r.Index,
+			Reason: r.Reason,
+			Safety: safety,
+		}
+	}
+	return &FinderRankResult{
+		Ranked:         ranked,
+		BroadenQueries: tr.BroadenQueries,
 	}
 }
 
@@ -746,6 +894,24 @@ func extractPortionFromToolUse(msg *anthropic.Message) (*PortionEstimate, error)
 				return nil, fmt.Errorf("failed to parse portion tool result: %w", err)
 			}
 			return toolResultToPortionEstimate(&tr), nil
+		}
+	}
+	return nil, errors.New("no tool_use block found in Claude response")
+}
+
+// extractFinderRankFromToolUse parses the tool-use content block for the recipe finder ranking.
+func extractFinderRankFromToolUse(msg *anthropic.Message) (*FinderRankResult, error) {
+	for _, block := range msg.Content {
+		if block.Type == "tool_use" {
+			raw, err := json.Marshal(block.Input)
+			if err != nil {
+				return nil, fmt.Errorf("failed to marshal tool input: %w", err)
+			}
+			var tr finderRankToolResult
+			if err := json.Unmarshal(raw, &tr); err != nil {
+				return nil, fmt.Errorf("failed to parse rank_recipes tool result: %w", err)
+			}
+			return toolResultToFinderRankResult(&tr), nil
 		}
 	}
 	return nil, errors.New("no tool_use block found in Claude response")
@@ -1297,6 +1463,50 @@ func (p *AnthropicProvider) EstimatePortions(ctx context.Context, recipeDef inte
 		}
 
 		return extractPortionFromToolUse(resp)
+	})
+}
+
+// ExpandAndRankRecipes performs the recipe finder's single ranking call via a
+// forced rank_recipes tool call. Mirrors the light-tier structured-call pattern
+// of EstimatePortions / ClassifyVoiceIntent: an inline system prompt, a modest
+// token budget, and metering through runWithMiddleware.
+func (p *AnthropicProvider) ExpandAndRankRecipes(ctx context.Context, req FinderRankRequest) (*FinderRankResult, error) {
+	op := AIOperation{
+		Name:      "ExpandAndRankRecipes",
+		Provider:  "anthropic",
+		Model:     string(p.model),
+		StartTime: time.Now(),
+	}
+
+	return runWithMiddleware(ctx, p.middleware, op, func(ctx context.Context) (*FinderRankResult, error) {
+		payload, err := json.Marshal(buildFinderRankPayload(req))
+		if err != nil {
+			return nil, fmt.Errorf("failed to marshal finder rank payload: %w", err)
+		}
+
+		tool := rankRecipesTool()
+
+		params := anthropic.MessageNewParams{
+			Model:     p.model,
+			MaxTokens: 512,
+			System:    buildCachedSystemPrompt(finderRankSystemPrompt, ""),
+			Messages: []anthropic.MessageParam{
+				newUserMessage(anthropic.NewTextBlock(string(payload))),
+			},
+			Tools: []anthropic.ToolUnionParam{tool},
+			ToolChoice: anthropic.ToolChoiceUnionParam{
+				OfToolChoiceTool: &anthropic.ToolChoiceToolParam{
+					Name: "rank_recipes",
+				},
+			},
+		}
+
+		resp, err := p.createMessageWithRetry(ctx, params)
+		if err != nil {
+			return nil, err
+		}
+
+		return extractFinderRankFromToolUse(resp)
 	})
 }
 

--- a/internal/ai/openai_maintier.go
+++ b/internal/ai/openai_maintier.go
@@ -456,6 +456,63 @@ func (p *OpenAICompatProvider) ClassifyVoiceIntent(ctx context.Context, transcri
 	})
 }
 
+// ExpandAndRankRecipes runs the recipe finder's ranking call via a forced
+// rank_recipes function call. Mirrors AnthropicProvider.ExpandAndRankRecipes —
+// same inline system prompt, wire payload and tool schema — so the light Gemini
+// tier that backs the finder produces a faithful request/result.
+func (p *OpenAICompatProvider) ExpandAndRankRecipes(ctx context.Context, req FinderRankRequest) (*FinderRankResult, error) {
+	op := AIOperation{
+		Name:      "ExpandAndRankRecipes",
+		Provider:  p.providerName,
+		Model:     p.model,
+		StartTime: time.Now(),
+	}
+
+	return runWithMiddleware(ctx, p.middleware, op, func(ctx context.Context) (*FinderRankResult, error) {
+		payload, err := json.Marshal(buildFinderRankPayload(req))
+		if err != nil {
+			return nil, fmt.Errorf("failed to marshal finder rank payload: %w", err)
+		}
+
+		chatReq := openai.ChatCompletionRequest{
+			Model:     p.model,
+			MaxTokens: 512,
+			Messages: []openai.ChatCompletionMessage{
+				{Role: openai.ChatMessageRoleSystem, Content: finderRankSystemPrompt},
+				{Role: openai.ChatMessageRoleUser, Content: string(payload)},
+			},
+			Tools: []openai.Tool{{
+				Type: openai.ToolTypeFunction,
+				Function: &openai.FunctionDefinition{
+					Name:        "rank_recipes",
+					Description: "Return the best-matching candidates by index, with rationales, per-member dietary safety, and broadened query suggestions.",
+					Parameters:  schemaObject(rankRecipesProperties()),
+				},
+			}},
+			ToolChoice: openai.ToolChoice{
+				Type:     openai.ToolTypeFunction,
+				Function: openai.ToolFunction{Name: "rank_recipes"},
+			},
+		}
+
+		resp, err := p.createChatCompletion(ctx, chatReq)
+		if err != nil {
+			return nil, err
+		}
+
+		args, err := firstToolCallArguments(resp, "rank_recipes")
+		if err != nil {
+			return nil, err
+		}
+
+		var tr finderRankToolResult
+		if err := json.Unmarshal([]byte(args), &tr); err != nil {
+			return nil, NewAIError(FailureContentParse, fmt.Errorf("failed to unmarshal rank_recipes result: %w", err), "failed to parse rank_recipes tool result")
+		}
+		return toolResultToFinderRankResult(&tr), nil
+	})
+}
+
 // DietaryInterview conducts a multi-turn dietary interview. The model is offered
 // the save_dietary_profile tool with tool choice left on "auto": it keeps asking
 // questions (plain-text turns → Complete=false) until it has gathered enough

--- a/internal/ai/provider.go
+++ b/internal/ai/provider.go
@@ -18,6 +18,14 @@ type TextProvider interface {
 	ExtractRecipeFromText(ctx context.Context, text string, unitSystem string) (*RecipeResult, error)
 	CookingQA(ctx context.Context, question string, recipeContext string) (string, error)
 	DietaryInterview(ctx context.Context, messages []Message, memberName string) (*DietaryInterviewResult, error)
+	// ExpandAndRankRecipes is the recipe finder's single model call: given the
+	// user's request and a list of REAL search-result candidates, it returns the
+	// candidates (referenced only by their index in the request) in match-ranked
+	// order with one-line rationales and best-effort per-family-member dietary
+	// safety, plus a few broadened query suggestions. Because the output is only
+	// indices into the caller's candidate list, it structurally cannot invent a
+	// recipe.
+	ExpandAndRankRecipes(ctx context.Context, req FinderRankRequest) (*FinderRankResult, error)
 }
 
 // MediaKind identifies whether a MediaInput is a raster image or a PDF document.
@@ -212,4 +220,55 @@ type SearchResult struct {
 type Message struct {
 	Role    string // "user", "assistant", "system"
 	Content string
+}
+
+// FinderCandidate is one real recipe search result offered to the finder's
+// ranker, identified by its Index in the candidate list. The ranker may only
+// refer back to candidates by Index — it is never given a way to emit a recipe
+// that is not in this list.
+type FinderCandidate struct {
+	Index       int
+	Title       string
+	Source      string
+	Description string
+}
+
+// FinderRankRequest is the input to ExpandAndRankRecipes. All of the steering
+// fields are composed server-side (never client-trusted); Candidates are the
+// real search results to rank.
+type FinderRankRequest struct {
+	Facets         string // deterministic summary of the tapped facet chips
+	FreeText       string // optional typed/spoken free text
+	UnitSystem     string
+	CookingContext string
+	Requirements   string
+	DietSummary    string // compacted family dietary needs (allergies, restrictions, preferences)
+	Candidates     []FinderCandidate
+}
+
+// MemberSafety is the model's best-effort dietary assessment of a candidate for
+// a single family member, inferred only from the candidate's title and
+// description. It is advisory (the authoritative per-ingredient allergen check
+// stays on the post-import path), and lights up the existing result-card safety
+// badges.
+type MemberSafety struct {
+	MemberName string `json:"member_name"`
+	Status     string `json:"status"` // "safe" | "caution" | "avoid"
+	Note       string `json:"note"`
+}
+
+// FinderRanking is one ranked candidate: Index into the FinderRankRequest's
+// candidate list, a one-line rationale and per-member safety badges.
+type FinderRanking struct {
+	Index  int
+	Reason string
+	Safety []MemberSafety
+}
+
+// FinderRankResult is the output of ExpandAndRankRecipes: candidates in
+// match-ranked order (by Index into the request's candidate list) plus a few
+// broadened query suggestions the user can fall back to.
+type FinderRankResult struct {
+	Ranked         []FinderRanking
+	BroadenQueries []string
 }

--- a/internal/ai/switchable.go
+++ b/internal/ai/switchable.go
@@ -76,3 +76,7 @@ func (s *SwitchableTextProvider) CookingQA(ctx context.Context, question string,
 func (s *SwitchableTextProvider) DietaryInterview(ctx context.Context, messages []Message, memberName string) (*DietaryInterviewResult, error) {
 	return s.get().DietaryInterview(ctx, messages, memberName)
 }
+
+func (s *SwitchableTextProvider) ExpandAndRankRecipes(ctx context.Context, req FinderRankRequest) (*FinderRankResult, error) {
+	return s.get().ExpandAndRankRecipes(ctx, req)
+}

--- a/internal/ai/switchable_test.go
+++ b/internal/ai/switchable_test.go
@@ -36,6 +36,9 @@ func (s switchStub) CookingQA(context.Context, string, string) (string, error) {
 func (s switchStub) DietaryInterview(context.Context, []Message, string) (*DietaryInterviewResult, error) {
 	return &DietaryInterviewResult{}, nil
 }
+func (s switchStub) ExpandAndRankRecipes(context.Context, FinderRankRequest) (*FinderRankResult, error) {
+	return &FinderRankResult{}, nil
+}
 
 func TestSwitchableTextProvider_Delegates(t *testing.T) {
 	sw := NewSwitchableTextProvider(switchStub{name: "first"})

--- a/internal/handlers/finder.go
+++ b/internal/handlers/finder.go
@@ -1,0 +1,112 @@
+package handlers
+
+import (
+	"context"
+	"encoding/json"
+	"io"
+	"net/http"
+	"time"
+
+	"github.com/gin-gonic/gin"
+	"github.com/windoze95/saltybytes-api/internal/logger"
+	"github.com/windoze95/saltybytes-api/internal/service"
+	"github.com/windoze95/saltybytes-api/internal/util"
+	"go.uber.org/zap"
+)
+
+// FinderHandler streams a guided recipe-finder run over SSE.
+type FinderHandler struct {
+	Service *service.RecipeFinderService
+	// SubService gates the finder by the SAME "search" usage limit that
+	// GET /recipes/search uses (nil skips gating, e.g. in isolated tests).
+	SubService *service.SubscriptionService
+}
+
+// FindRecipes handles POST /v1/recipes/find. It runs the bounded finder
+// trajectory and streams each step (searching → found → filtering → shortlist →
+// warming → refine_ready → done, or a terminal empty/error) as an SSE event.
+func (h *FinderHandler) FindRecipes(c *gin.Context) {
+	user, err := util.GetUserFromContext(c)
+	if err != nil {
+		c.JSON(http.StatusUnauthorized, gin.H{"error": "unauthorized"})
+		return
+	}
+
+	var req service.FinderRequest
+	if err := c.BindJSON(&req); err != nil {
+		c.JSON(http.StatusBadRequest, gin.H{"error": "Invalid request: " + err.Error()})
+		return
+	}
+
+	// Subscription gate. The finder drives search, so it is gated by the same
+	// "search" limit as the search endpoint. SearchService.SearchRecipes does
+	// NOT check or increment usage itself — all gating lives in the search
+	// handler — so we gate here exactly once and increment once for a
+	// non-cached search below, avoiding any double counting.
+	if h.SubService != nil {
+		allowed, err := h.SubService.CheckLimit(user.ID, "search")
+		if err != nil {
+			logger.Get().Error("failed to check search limit", zap.Uint("user_id", user.ID), zap.Error(err))
+			c.JSON(http.StatusInternalServerError, gin.H{"error": "Failed to check subscription limits"})
+			return
+		}
+		if !allowed {
+			c.JSON(http.StatusForbidden, gin.H{"error": "search limit reached; upgrade to premium for unlimited searches"})
+			return
+		}
+	}
+
+	// SSE headers.
+	c.Header("Content-Type", "text/event-stream")
+	c.Header("Cache-Control", "no-cache")
+	c.Header("Connection", "keep-alive")
+	c.Header("X-Accel-Buffering", "no") // disable nginx buffering
+
+	ctx, cancel := context.WithTimeout(c.Request.Context(), 2*time.Minute)
+	defer cancel()
+
+	events := make(chan service.FinderEvent, 32)
+
+	go func() {
+		defer close(events)
+		defer util.RecoverPanic("recipe finder")
+		h.Service.FindRecipes(ctx, user, req, events)
+	}()
+
+	c.Stream(func(w io.Writer) bool {
+		select {
+		case event, ok := <-events:
+			if !ok {
+				return false
+			}
+			// Count one search against the user's monthly quota only when the
+			// finder actually hit the search provider — mirroring the search
+			// handler, which increments for every non-cached search. The
+			// "found" event carries whether results came from cache, and it is
+			// emitted exactly once per run, so this counts at most once.
+			if event.Type == service.FinderEventFound && !event.FromCache {
+				h.incrementSearchUsage(user.ID)
+			}
+			data, _ := json.Marshal(event)
+			c.SSEvent(string(event.Type), string(data))
+			c.Writer.Flush()
+			// Terminal events end the stream.
+			return event.Type != service.FinderEventDone &&
+				event.Type != service.FinderEventEmpty &&
+				event.Type != service.FinderEventError
+		case <-ctx.Done():
+			return false
+		}
+	})
+}
+
+// incrementSearchUsage records one search against the user's monthly quota.
+// Failures are logged but never block the response.
+func (h *FinderHandler) incrementSearchUsage(userID uint) {
+	if h.SubService == nil {
+		return
+	}
+	if err := h.SubService.IncrementUsage(userID, "search"); err != nil {
+		logger.Get().Error("failed to increment search usage", zap.Uint("user_id", userID), zap.Error(err))
+	}
+}

--- a/internal/router/router.go
+++ b/internal/router/router.go
@@ -358,6 +358,13 @@ func SetupRouter(cfg *config.Config, database *gorm.DB) *gin.Engine {
 	apiProtected.POST("/recipes/search/check-multi", middleware.AttachUserToContext(userService), searchHandler.CheckMultiRecipe)
 	apiProtected.POST("/recipes/search/warm", middleware.AttachUserToContext(userService), searchHandler.WarmRecipes)
 
+	// Recipe finder — a guided agent that finds REAL recipes by driving search +
+	// a single cheap ranking call (light tier), streamed over SSE. Gated by the
+	// same "search" limit as the search endpoint. Ships dark (no caller yet).
+	finderService := service.NewRecipeFinderService(cfg, searchService, familyRepo, warmService, previewProvider)
+	finderHandler := &handlers.FinderHandler{Service: finderService, SubService: subService}
+	apiProtected.POST("/recipes/find", middleware.AttachUserToContext(userService), finderHandler.FindRecipes)
+
 	// Vector similarity routes
 	similarityHandler := handlers.NewSimilarityHandler(vectorRepo, embedProvider, recipeService)
 	apiProtected.GET("/recipes/similar/:recipe_id", middleware.AttachUserToContext(userService), similarityHandler.FindSimilar)

--- a/internal/service/recipe_finder.go
+++ b/internal/service/recipe_finder.go
@@ -1,0 +1,506 @@
+package service
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"github.com/windoze95/saltybytes-api/internal/ai"
+	"github.com/windoze95/saltybytes-api/internal/config"
+	"github.com/windoze95/saltybytes-api/internal/logger"
+	"github.com/windoze95/saltybytes-api/internal/models"
+	"github.com/windoze95/saltybytes-api/internal/repository"
+	"go.uber.org/zap"
+)
+
+// Recipe-finder tuning constants.
+const (
+	// finderSearchCount is how many real candidates to search for and hand to
+	// the ranker in a single find.
+	finderSearchCount = 10
+	// finderWarmTopN is how many top shortlisted results to proactively warm so
+	// a later tap is an instant cache hit.
+	finderWarmTopN = 4
+)
+
+// finderRefineChips are the bounded, tap-first refinement options offered after
+// a shortlist. They are a constant so the interaction stays guided (a bounded
+// trajectory), never an open-ended model loop.
+var finderRefineChips = []string{"quicker", "cheaper", "more veg", "swap protein"}
+
+// FinderEventType enumerates the SSE event types emitted during a recipe-finder
+// run. The string values are the wire contract with the Flutter client.
+type FinderEventType string
+
+const (
+	// FinderEventSearching announces the composed search query.
+	FinderEventSearching FinderEventType = "searching"
+	// FinderEventFound reports how many real candidates search returned.
+	FinderEventFound FinderEventType = "found"
+	// FinderEventFiltering signals the single ranking/filtering model call.
+	FinderEventFiltering FinderEventType = "filtering"
+	// FinderEventShortlist carries the ranked real results with rationales+safety.
+	FinderEventShortlist FinderEventType = "shortlist"
+	// FinderEventWarming lists the top URLs being proactively cache-warmed.
+	FinderEventWarming FinderEventType = "warming"
+	// FinderEventRefineReady offers tap-to-refine chips + broaden suggestions.
+	FinderEventRefineReady FinderEventType = "refine_ready"
+	// FinderEventDone terminates a successful run.
+	FinderEventDone FinderEventType = "done"
+	// FinderEventEmpty terminates a run that surfaced no real recipe (0 results
+	// or all dropped) — it never invents one; it only suggests broader queries.
+	FinderEventEmpty FinderEventType = "empty"
+	// FinderEventError terminates a run that failed before any shortlist.
+	FinderEventError FinderEventType = "error"
+)
+
+// FinderResultItem is one shortlisted recipe: the real search result plus the
+// finder's one-line rationale and best-effort per-member dietary safety badges.
+type FinderResultItem struct {
+	Result ai.SearchResult   `json:"result"`
+	Reason string            `json:"reason,omitempty"`
+	Safety []ai.MemberSafety `json:"safety,omitempty"`
+}
+
+// FinderEvent is a single event streamed to the client during a find. Only the
+// fields relevant to a given Type are populated (mirrors ai.StreamEvent's shape).
+type FinderEvent struct {
+	Type      FinderEventType    `json:"type"`
+	Query     string             `json:"query,omitempty"`
+	Count     int                `json:"count,omitempty"`
+	FromCache bool               `json:"from_cache,omitempty"`
+	Items     []FinderResultItem `json:"items,omitempty"`
+	URLs      []string           `json:"urls,omitempty"`
+	Chips     []string           `json:"chips,omitempty"`
+	Broaden   []string           `json:"broaden,omitempty"`
+	Error     string             `json:"error,omitempty"`
+}
+
+// FinderFacets are the tappable facet-chip selections that steer a find. They
+// are the primary (tap-first) interaction; free text and voice are secondary.
+type FinderFacets struct {
+	Occasion     string   `json:"occasion,omitempty"`
+	TimeBudget   string   `json:"time_budget,omitempty"`
+	Protein      string   `json:"protein,omitempty"`
+	Cuisine      string   `json:"cuisine,omitempty"`
+	UseWhatIHave []string `json:"use_what_i_have,omitempty"`
+	SurpriseMe   bool     `json:"surprise_me,omitempty"`
+}
+
+// FinderRefine carries a bounded, tap-first refinement of a prior find.
+type FinderRefine struct {
+	AddFacets  FinderFacets `json:"add_facets,omitempty"`
+	Constraint string       `json:"constraint,omitempty"`
+}
+
+// FinderRequest is the decoded POST /v1/recipes/find body.
+type FinderRequest struct {
+	Facets   FinderFacets  `json:"facets"`
+	FreeText string        `json:"free_text,omitempty"`
+	Refine   *FinderRefine `json:"refine,omitempty"`
+}
+
+// RecipeFinderService drives the guided "recipe finder": one bounded trajectory
+// that searches real recipes, ranks/filters them with a single cheap model call,
+// warms the top results, and streams each step as a FinderEvent. It never
+// invents a recipe — every shortlisted result is a real search hit referenced by
+// index, so fabrication is structurally impossible.
+type RecipeFinderService struct {
+	Cfg        *config.Config
+	Search     *SearchService
+	FamilyRepo repository.FamilyRepo
+	Warm       *WarmService
+	// RankProvider is the light tier (Gemini Flash) that performs the single
+	// query-expansion + ranking call.
+	RankProvider ai.TextProvider
+}
+
+// NewRecipeFinderService wires the finder over the existing search, family and
+// cache-warming machinery plus the light-tier ranking provider.
+func NewRecipeFinderService(cfg *config.Config, search *SearchService, familyRepo repository.FamilyRepo, warm *WarmService, rankProvider ai.TextProvider) *RecipeFinderService {
+	return &RecipeFinderService{
+		Cfg:          cfg,
+		Search:       search,
+		FamilyRepo:   familyRepo,
+		Warm:         warm,
+		RankProvider: rankProvider,
+	}
+}
+
+// FindRecipes runs the bounded finder trajectory, emitting FinderEvents as it
+// goes and returning when the run reaches a terminal event (done/empty/error) or
+// the context is cancelled. The caller owns the channel and closes it.
+func (s *RecipeFinderService) FindRecipes(ctx context.Context, user *models.User, req FinderRequest, events chan<- FinderEvent) {
+	// Auto-inject the family's dietary needs (server-side, never client-trusted):
+	// allergies become hard query-excludes; restrictions/preferences steer the
+	// model via the diet summary.
+	dietSummary, allergenExcludes := s.dietContext(user)
+
+	// 1. Compose the search query deterministically — no model call.
+	query := composeFinderQuery(req, allergenExcludes)
+	if !s.emit(ctx, events, FinderEvent{Type: FinderEventSearching, Query: query}) {
+		return
+	}
+
+	// 2. Search real recipes (reuses the exact + semantic/embedding cache).
+	searchRes, err := s.Search.SearchRecipes(ctx, query, finderSearchCount, 0)
+	if err != nil {
+		logger.Get().Error("recipe finder search failed", zap.String("query", query), zap.Error(err))
+		s.emit(ctx, events, FinderEvent{Type: FinderEventError, Error: "search failed"})
+		return
+	}
+	results := searchRes.Results
+	if !s.emit(ctx, events, FinderEvent{Type: FinderEventFound, Count: len(results), FromCache: searchRes.FromCache}) {
+		return
+	}
+
+	// 3. Empty search → broaden suggestions only; never invent a recipe.
+	if len(results) == 0 {
+		s.emit(ctx, events, FinderEvent{Type: FinderEventEmpty, Broaden: broadenFallback(req)})
+		return
+	}
+
+	// 4. The one and only model call: expand + rank + rationale + safety.
+	if !s.emit(ctx, events, FinderEvent{Type: FinderEventFiltering}) {
+		return
+	}
+	rank := s.rankCandidates(ctx, user, req, dietSummary, results)
+
+	// 5. Map the model's rankings back to the REAL results, dropping any
+	// out-of-range/duplicate index defensively and any candidate the model
+	// flagged allergen-"avoid".
+	items := buildShortlist(results, rank)
+
+	// 6. Everything filtered out → empty; still never invent.
+	if len(items) == 0 {
+		s.emit(ctx, events, FinderEvent{Type: FinderEventEmpty, Broaden: broadenList(rank, req)})
+		return
+	}
+	if !s.emit(ctx, events, FinderEvent{Type: FinderEventShortlist, Items: items}) {
+		return
+	}
+
+	// 7. Proactively warm the top results (best-effort) so a later tap is an
+	// instant cache hit.
+	if warmURLs := topURLs(items, finderWarmTopN); len(warmURLs) > 0 {
+		if s.Warm != nil {
+			s.Warm.WarmURLs(warmURLs)
+		}
+		if !s.emit(ctx, events, FinderEvent{Type: FinderEventWarming, URLs: warmURLs}) {
+			return
+		}
+	}
+
+	// 8. Offer bounded refinement, then finish.
+	if !s.emit(ctx, events, FinderEvent{Type: FinderEventRefineReady, Chips: finderRefineChips, Broaden: broadenList(rank, req)}) {
+		return
+	}
+	s.emit(ctx, events, FinderEvent{Type: FinderEventDone})
+}
+
+// emit sends one event, returning false if the context is cancelled (e.g. the
+// client disconnected) so the producer never blocks on an unconsumed channel.
+func (s *RecipeFinderService) emit(ctx context.Context, events chan<- FinderEvent, ev FinderEvent) bool {
+	select {
+	case events <- ev:
+		return true
+	case <-ctx.Done():
+		return false
+	}
+}
+
+// rankCandidates runs the single ranking model call. On any error it degrades
+// gracefully to the real results in search order (no reasons/safety) rather than
+// dead-ending — search already returned real recipes, so the worst case is an
+// unranked-but-real shortlist, never a fabricated one.
+func (s *RecipeFinderService) rankCandidates(ctx context.Context, user *models.User, req FinderRequest, dietSummary string, results []ai.SearchResult) *ai.FinderRankResult {
+	candidates := make([]ai.FinderCandidate, len(results))
+	for i, r := range results {
+		candidates[i] = ai.FinderCandidate{
+			Index:       i,
+			Title:       r.Title,
+			Source:      r.Source,
+			Description: r.Description,
+		}
+	}
+
+	rankReq := ai.FinderRankRequest{
+		Facets:      facetsSummary(req),
+		FreeText:    strings.TrimSpace(req.FreeText),
+		DietSummary: dietSummary,
+		Candidates:  candidates,
+	}
+	if user != nil && user.Personalization != nil {
+		rankReq.UnitSystem = user.Personalization.UnitSystemText()
+		rankReq.CookingContext = user.Personalization.CookingContextPrompt()
+		rankReq.Requirements = user.Personalization.Requirements
+	}
+
+	res, err := s.RankProvider.ExpandAndRankRecipes(ctx, rankReq)
+	if err != nil {
+		logger.Get().Warn("recipe finder ranking failed; showing unranked real results", zap.Error(err))
+		return fallbackRanking(len(results))
+	}
+	return res
+}
+
+// dietContext compacts the owner's family dietary needs into a model-facing
+// summary and a list of hard allergen excludes. It is best-effort: a missing
+// family, a repo error or absent profiles simply yield no dietary steering.
+func (s *RecipeFinderService) dietContext(user *models.User) (summary string, allergenExcludes []string) {
+	if s.FamilyRepo == nil || user == nil {
+		return "", nil
+	}
+	family, err := s.FamilyRepo.GetFamilyByOwnerID(user.ID)
+	if err != nil || family == nil {
+		return "", nil
+	}
+
+	var parts []string
+	seen := make(map[string]bool)
+	for _, member := range family.Members {
+		if member.DietaryProfile == nil {
+			continue
+		}
+		dp := member.DietaryProfile
+		var needs []string
+		for _, a := range dp.Allergies {
+			name := strings.TrimSpace(a.Name)
+			if name == "" {
+				continue
+			}
+			needs = append(needs, "allergic to "+name)
+			if key := strings.ToLower(name); !seen[key] {
+				seen[key] = true
+				allergenExcludes = append(allergenExcludes, name)
+			}
+		}
+		for _, in := range dp.Intolerances {
+			if in = strings.TrimSpace(in); in != "" {
+				needs = append(needs, "intolerant to "+in)
+			}
+		}
+		for _, r := range dp.Restrictions {
+			if r = strings.TrimSpace(r); r != "" {
+				needs = append(needs, r)
+			}
+		}
+		for _, p := range dp.Preferences {
+			if p = strings.TrimSpace(p); p != "" {
+				needs = append(needs, p)
+			}
+		}
+		if len(needs) > 0 {
+			name := strings.TrimSpace(member.Name)
+			if name == "" {
+				name = "member"
+			}
+			parts = append(parts, fmt.Sprintf("%s: %s", name, strings.Join(needs, ", ")))
+		}
+	}
+	return strings.Join(parts, "; "), allergenExcludes
+}
+
+// composeFinderQuery builds the search query string deterministically from the
+// facets, free text and constraint, appending allergen excludes as query
+// negations. No model is involved.
+func composeFinderQuery(req FinderRequest, allergenExcludes []string) string {
+	f := effectiveFacets(req)
+
+	var parts []string
+	parts = appendNonEmpty(parts, f.Cuisine, f.Protein, f.Occasion, f.TimeBudget)
+	for _, ing := range f.UseWhatIHave {
+		if ing = strings.TrimSpace(ing); ing != "" {
+			parts = append(parts, ing)
+		}
+	}
+	if ft := strings.TrimSpace(req.FreeText); ft != "" {
+		parts = append(parts, ft)
+	}
+	if req.Refine != nil {
+		if c := strings.TrimSpace(req.Refine.Constraint); c != "" {
+			parts = append(parts, c)
+		}
+	}
+
+	core := strings.TrimSpace(strings.Join(parts, " "))
+	if core == "" {
+		// Tap-first "surprise me" / no selection: a broad but real query.
+		core = "popular dinner"
+	}
+	query := core + " recipe"
+
+	for _, ex := range allergenExcludes {
+		if ex = strings.TrimSpace(ex); ex != "" {
+			query += " -" + ex
+		}
+	}
+	return query
+}
+
+// facetsSummary renders the effective facets as a compact, human-readable line
+// for the model.
+func facetsSummary(req FinderRequest) string {
+	f := effectiveFacets(req)
+	var parts []string
+	if f.Occasion != "" {
+		parts = append(parts, "occasion: "+f.Occasion)
+	}
+	if f.TimeBudget != "" {
+		parts = append(parts, "time: "+f.TimeBudget)
+	}
+	if f.Protein != "" {
+		parts = append(parts, "protein: "+f.Protein)
+	}
+	if f.Cuisine != "" {
+		parts = append(parts, "cuisine: "+f.Cuisine)
+	}
+	if len(f.UseWhatIHave) > 0 {
+		parts = append(parts, "use what I have: "+strings.Join(f.UseWhatIHave, ", "))
+	}
+	if f.SurpriseMe {
+		parts = append(parts, "surprise me")
+	}
+	if req.Refine != nil {
+		if c := strings.TrimSpace(req.Refine.Constraint); c != "" {
+			parts = append(parts, "refine: "+c)
+		}
+	}
+	return strings.Join(parts, "; ")
+}
+
+// effectiveFacets merges the base facets with any refinement facets.
+func effectiveFacets(req FinderRequest) FinderFacets {
+	f := req.Facets
+	if req.Refine != nil {
+		f = mergeFacets(f, req.Refine.AddFacets)
+	}
+	return f
+}
+
+// mergeFacets overlays add onto base: non-empty scalar fields override,
+// ingredient lists concatenate, and SurpriseMe is sticky.
+func mergeFacets(base, add FinderFacets) FinderFacets {
+	out := base
+	if add.Occasion != "" {
+		out.Occasion = add.Occasion
+	}
+	if add.TimeBudget != "" {
+		out.TimeBudget = add.TimeBudget
+	}
+	if add.Protein != "" {
+		out.Protein = add.Protein
+	}
+	if add.Cuisine != "" {
+		out.Cuisine = add.Cuisine
+	}
+	if len(add.UseWhatIHave) > 0 {
+		merged := make([]string, 0, len(out.UseWhatIHave)+len(add.UseWhatIHave))
+		merged = append(merged, out.UseWhatIHave...)
+		merged = append(merged, add.UseWhatIHave...)
+		out.UseWhatIHave = merged
+	}
+	if add.SurpriseMe {
+		out.SurpriseMe = true
+	}
+	return out
+}
+
+// buildShortlist maps the model's rankings back to the real results in rank
+// order, dropping out-of-range or duplicate indices defensively and dropping any
+// candidate flagged allergen-"avoid" for any family member.
+func buildShortlist(results []ai.SearchResult, rank *ai.FinderRankResult) []FinderResultItem {
+	if rank == nil {
+		return nil
+	}
+	items := make([]FinderResultItem, 0, len(rank.Ranked))
+	used := make(map[int]bool, len(rank.Ranked))
+	for _, r := range rank.Ranked {
+		if r.Index < 0 || r.Index >= len(results) || used[r.Index] {
+			continue
+		}
+		used[r.Index] = true
+		if hasAvoid(r.Safety) {
+			continue
+		}
+		items = append(items, FinderResultItem{
+			Result: results[r.Index],
+			Reason: r.Reason,
+			Safety: r.Safety,
+		})
+	}
+	return items
+}
+
+// hasAvoid reports whether any member's safety status is "avoid".
+func hasAvoid(safety []ai.MemberSafety) bool {
+	for _, s := range safety {
+		if strings.EqualFold(strings.TrimSpace(s.Status), "avoid") {
+			return true
+		}
+	}
+	return false
+}
+
+// topURLs returns up to n non-empty result URLs, preserving shortlist order.
+func topURLs(items []FinderResultItem, n int) []string {
+	urls := make([]string, 0, n)
+	for _, it := range items {
+		if len(urls) >= n {
+			break
+		}
+		if u := strings.TrimSpace(it.Result.URL); u != "" {
+			urls = append(urls, u)
+		}
+	}
+	return urls
+}
+
+// broadenList prefers the model's broadened queries, falling back to
+// deterministic suggestions derived from the facets.
+func broadenList(rank *ai.FinderRankResult, req FinderRequest) []string {
+	if rank != nil && len(rank.BroadenQueries) > 0 {
+		return rank.BroadenQueries
+	}
+	return broadenFallback(req)
+}
+
+// broadenFallback derives a few broadened real query strings from the facets,
+// used on the empty path (no model call happened) or when the model returned no
+// broaden suggestions.
+func broadenFallback(req FinderRequest) []string {
+	f := effectiveFacets(req)
+	seeds := appendNonEmpty(nil, f.Protein, f.Cuisine, f.Occasion, strings.TrimSpace(req.FreeText))
+
+	var out []string
+	for _, seed := range seeds {
+		out = append(out, seed+" recipes")
+		if len(out) >= 3 {
+			break
+		}
+	}
+	if len(out) == 0 {
+		return []string{"easy dinner recipes", "quick weeknight recipes", "popular recipes"}
+	}
+	return out
+}
+
+// fallbackRanking ranks all candidates in their original order with no reasons
+// or safety, used when the ranking call fails.
+func fallbackRanking(n int) *ai.FinderRankResult {
+	ranked := make([]ai.FinderRanking, n)
+	for i := range ranked {
+		ranked[i] = ai.FinderRanking{Index: i}
+	}
+	return &ai.FinderRankResult{Ranked: ranked}
+}
+
+// appendNonEmpty appends each trimmed non-empty value to dst.
+func appendNonEmpty(dst []string, values ...string) []string {
+	for _, v := range values {
+		if v = strings.TrimSpace(v); v != "" {
+			dst = append(dst, v)
+		}
+	}
+	return dst
+}

--- a/internal/service/recipe_finder_test.go
+++ b/internal/service/recipe_finder_test.go
@@ -1,0 +1,309 @@
+package service
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	"github.com/windoze95/saltybytes-api/internal/ai"
+	"github.com/windoze95/saltybytes-api/internal/config"
+	"github.com/windoze95/saltybytes-api/internal/models"
+	"github.com/windoze95/saltybytes-api/internal/repository"
+	"github.com/windoze95/saltybytes-api/internal/testutil"
+)
+
+// newFinderService builds a RecipeFinderService whose every dependency is
+// offline: a real SearchService over a mock SearchProvider with no cache repo
+// (so it always calls the provider, never the network), a WarmService with no
+// Import (so WarmURLs just reports "uncached" without extracting), and a mock
+// ranker.
+func newFinderService(searchProvider ai.SearchProvider, ranker ai.TextProvider, familyRepo repository.FamilyRepo) *RecipeFinderService {
+	cfg := &config.Config{}
+	searchService := NewSearchService(cfg, searchProvider, nil, nil)
+	warm := NewWarmService(nil, nil, 0, 0)
+	return NewRecipeFinderService(cfg, searchService, familyRepo, warm, ranker)
+}
+
+// runFinder drains a full finder run and returns the events in order.
+func runFinder(svc *RecipeFinderService, user *models.User, req FinderRequest) []FinderEvent {
+	events := make(chan FinderEvent, 32)
+	done := make(chan struct{})
+	var collected []FinderEvent
+	go func() {
+		defer close(done)
+		for ev := range events {
+			collected = append(collected, ev)
+		}
+	}()
+	svc.FindRecipes(context.Background(), user, req, events)
+	close(events)
+	<-done
+	return collected
+}
+
+func eventTypes(events []FinderEvent) []FinderEventType {
+	types := make([]FinderEventType, len(events))
+	for i, ev := range events {
+		types[i] = ev.Type
+	}
+	return types
+}
+
+func firstEventOfType(events []FinderEvent, t FinderEventType) (FinderEvent, bool) {
+	for _, ev := range events {
+		if ev.Type == t {
+			return ev, true
+		}
+	}
+	return FinderEvent{}, false
+}
+
+func countEventsOfType(events []FinderEvent, t FinderEventType) int {
+	n := 0
+	for _, ev := range events {
+		if ev.Type == t {
+			n++
+		}
+	}
+	return n
+}
+
+func sameTypes(got []FinderEventType, want ...FinderEventType) bool {
+	if len(got) != len(want) {
+		return false
+	}
+	for i := range got {
+		if got[i] != want[i] {
+			return false
+		}
+	}
+	return true
+}
+
+// finderCandidates are three real search results reused across the tests.
+func finderCandidates() []ai.SearchResult {
+	return []ai.SearchResult{
+		{Title: "Sheet Pan Chicken Fajitas", URL: "https://example.com/fajitas", Source: "example.com", Description: "Quick weeknight chicken fajitas on one pan."},
+		{Title: "Peanut Chicken Stir-Fry", URL: "https://example.com/peanut", Source: "example.com", Description: "Chicken tossed in a rich peanut sauce."},
+		{Title: "Black Bean Veggie Tacos", URL: "https://example.com/tacos", Source: "example.com", Description: "Vegetarian tacos with black beans and slaw."},
+	}
+}
+
+func TestFindRecipes_HappyPath(t *testing.T) {
+	candidates := finderCandidates()
+	searchProvider := &testutil.MockSearchProvider{
+		SearchRecipesFunc: func(ctx context.Context, query string, count, offset int) ([]ai.SearchResult, error) {
+			return candidates, nil
+		},
+	}
+
+	var gotRankReq ai.FinderRankRequest
+	ranker := &testutil.MockTextProvider{
+		ExpandAndRankRecipesFunc: func(ctx context.Context, req ai.FinderRankRequest) (*ai.FinderRankResult, error) {
+			gotRankReq = req
+			return &ai.FinderRankResult{
+				Ranked: []ai.FinderRanking{
+					{Index: 0, Reason: "Fast and family-friendly."},
+					{Index: 2, Reason: "A solid vegetarian option."},
+					{Index: 1, Reason: "Classic comfort flavor."},
+				},
+				BroadenQueries: []string{"easy chicken dinners"},
+			}, nil
+		},
+	}
+
+	svc := newFinderService(searchProvider, ranker, &testutil.MockFamilyRepo{})
+	events := runFinder(svc, testutil.TestUser(), FinderRequest{
+		Facets:   FinderFacets{Protein: "chicken", TimeBudget: "30 minutes"},
+		FreeText: "weeknight",
+	})
+
+	// Full happy-path event order.
+	if got := eventTypes(events); !sameTypes(got,
+		FinderEventSearching, FinderEventFound, FinderEventFiltering,
+		FinderEventShortlist, FinderEventWarming, FinderEventRefineReady, FinderEventDone) {
+		t.Fatalf("unexpected event order: %v", got)
+	}
+
+	// searching carries the deterministically-composed query.
+	searching, _ := firstEventOfType(events, FinderEventSearching)
+	if !strings.Contains(searching.Query, "chicken") || !strings.Contains(searching.Query, "recipe") {
+		t.Errorf("searching query %q missing composed facets", searching.Query)
+	}
+
+	// found reports the real candidate count, not from cache.
+	found, _ := firstEventOfType(events, FinderEventFound)
+	if found.Count != len(candidates) {
+		t.Errorf("found.Count = %d, want %d", found.Count, len(candidates))
+	}
+	if found.FromCache {
+		t.Errorf("found.FromCache = true, want false (mock provider is not cached)")
+	}
+
+	// The ranker was handed the REAL candidates by index.
+	if len(gotRankReq.Candidates) != len(candidates) {
+		t.Fatalf("ranker got %d candidates, want %d", len(gotRankReq.Candidates), len(candidates))
+	}
+	if gotRankReq.Candidates[0].Index != 0 || gotRankReq.Candidates[0].Title != candidates[0].Title {
+		t.Errorf("ranker candidate[0] = %+v, want index 0 title %q", gotRankReq.Candidates[0], candidates[0].Title)
+	}
+
+	// shortlist holds the real results in model rank order, each with a reason.
+	shortlist, _ := firstEventOfType(events, FinderEventShortlist)
+	if len(shortlist.Items) != 3 {
+		t.Fatalf("shortlist has %d items, want 3", len(shortlist.Items))
+	}
+	if shortlist.Items[0].Result.Title != candidates[0].Title {
+		t.Errorf("shortlist[0] title = %q, want %q", shortlist.Items[0].Result.Title, candidates[0].Title)
+	}
+	if shortlist.Items[1].Result.Title != candidates[2].Title {
+		t.Errorf("shortlist[1] title = %q, want %q (model reordered)", shortlist.Items[1].Result.Title, candidates[2].Title)
+	}
+	for i, item := range shortlist.Items {
+		if strings.TrimSpace(item.Reason) == "" {
+			t.Errorf("shortlist item %d has no reason", i)
+		}
+	}
+
+	// warming lists the top real URLs.
+	warming, _ := firstEventOfType(events, FinderEventWarming)
+	if len(warming.URLs) == 0 || warming.URLs[0] != candidates[0].URL {
+		t.Errorf("warming URLs = %v, want first = %q", warming.URLs, candidates[0].URL)
+	}
+
+	// refine_ready offers the bounded chips + broaden suggestions.
+	refine, _ := firstEventOfType(events, FinderEventRefineReady)
+	if len(refine.Chips) == 0 {
+		t.Errorf("refine_ready has no chips")
+	}
+	if len(refine.Broaden) == 0 || refine.Broaden[0] != "easy chicken dinners" {
+		t.Errorf("refine_ready broaden = %v, want model's suggestion", refine.Broaden)
+	}
+}
+
+func TestFindRecipes_DropsAllergenAvoid(t *testing.T) {
+	candidates := finderCandidates()
+	searchProvider := &testutil.MockSearchProvider{
+		SearchRecipesFunc: func(ctx context.Context, query string, count, offset int) ([]ai.SearchResult, error) {
+			return candidates, nil
+		},
+	}
+
+	var gotRankReq ai.FinderRankRequest
+	ranker := &testutil.MockTextProvider{
+		ExpandAndRankRecipesFunc: func(ctx context.Context, req ai.FinderRankRequest) (*ai.FinderRankResult, error) {
+			gotRankReq = req
+			return &ai.FinderRankResult{
+				Ranked: []ai.FinderRanking{
+					{Index: 0, Reason: "Fast and family-friendly."},
+					{Index: 1, Reason: "Peanut sauce.", Safety: []ai.MemberSafety{
+						{MemberName: "Kiddo", Status: "avoid", Note: "contains peanuts"},
+					}},
+					{Index: 2, Reason: "Vegetarian, no allergens."},
+				},
+			}, nil
+		},
+	}
+
+	// A family with a peanut allergy exercises the diet-context path.
+	familyRepo := &testutil.MockFamilyRepo{
+		GetFamilyByOwnerIDFunc: func(ownerID uint) (*models.Family, error) {
+			return &models.Family{
+				ID:      1,
+				OwnerID: ownerID,
+				Members: []models.FamilyMember{
+					{
+						Name: "Kiddo",
+						DietaryProfile: &models.DietaryProfile{
+							Allergies:    models.AllergyList{{Name: "peanuts", Severity: "severe"}},
+							Restrictions: models.StringList{"vegetarian"},
+						},
+					},
+				},
+			}, nil
+		},
+	}
+
+	svc := newFinderService(searchProvider, ranker, familyRepo)
+	events := runFinder(svc, testutil.TestUser(), FinderRequest{
+		Facets: FinderFacets{Protein: "chicken"},
+	})
+
+	// Same overall trajectory (a shortlist still forms from the survivors).
+	if got := eventTypes(events); !sameTypes(got,
+		FinderEventSearching, FinderEventFound, FinderEventFiltering,
+		FinderEventShortlist, FinderEventWarming, FinderEventRefineReady, FinderEventDone) {
+		t.Fatalf("unexpected event order: %v", got)
+	}
+
+	// The allergen-"avoid" candidate is dropped; the other two survive in order.
+	shortlist, _ := firstEventOfType(events, FinderEventShortlist)
+	if len(shortlist.Items) != 2 {
+		t.Fatalf("shortlist has %d items, want 2 (the avoid candidate dropped)", len(shortlist.Items))
+	}
+	for _, item := range shortlist.Items {
+		if item.Result.Title == candidates[1].Title {
+			t.Errorf("allergen-avoid candidate %q was not dropped", candidates[1].Title)
+		}
+	}
+	if shortlist.Items[0].Result.Title != candidates[0].Title || shortlist.Items[1].Result.Title != candidates[2].Title {
+		t.Errorf("survivors = [%q, %q], want [%q, %q]",
+			shortlist.Items[0].Result.Title, shortlist.Items[1].Result.Title, candidates[0].Title, candidates[2].Title)
+	}
+
+	// Diet context reached the model + the query, sourced server-side.
+	if !strings.Contains(strings.ToLower(gotRankReq.DietSummary), "peanuts") {
+		t.Errorf("diet summary %q missing the peanut allergy", gotRankReq.DietSummary)
+	}
+	searching, _ := firstEventOfType(events, FinderEventSearching)
+	if !strings.Contains(searching.Query, "-peanuts") {
+		t.Errorf("query %q missing the hard allergen exclude", searching.Query)
+	}
+}
+
+func TestFindRecipes_EmptyNeverInvents(t *testing.T) {
+	searchProvider := &testutil.MockSearchProvider{
+		SearchRecipesFunc: func(ctx context.Context, query string, count, offset int) ([]ai.SearchResult, error) {
+			return nil, nil // no results
+		},
+	}
+
+	rankerCalled := false
+	ranker := &testutil.MockTextProvider{
+		ExpandAndRankRecipesFunc: func(ctx context.Context, req ai.FinderRankRequest) (*ai.FinderRankResult, error) {
+			rankerCalled = true
+			return &ai.FinderRankResult{}, nil
+		},
+	}
+
+	svc := newFinderService(searchProvider, ranker, &testutil.MockFamilyRepo{})
+	events := runFinder(svc, testutil.TestUser(), FinderRequest{
+		Facets: FinderFacets{Cuisine: "thai", Protein: "tofu"},
+	})
+
+	// Exactly one empty event, and never a shortlist.
+	if n := countEventsOfType(events, FinderEventEmpty); n != 1 {
+		t.Fatalf("got %d empty events, want exactly 1 (order: %v)", n, eventTypes(events))
+	}
+	if n := countEventsOfType(events, FinderEventShortlist); n != 0 {
+		t.Errorf("got %d shortlist events on the empty path, want 0", n)
+	}
+
+	// The model is never called (nothing to rank → nothing to invent).
+	if rankerCalled {
+		t.Errorf("ranker was called on the empty path; the finder must never invent")
+	}
+
+	// The empty event carries broaden suggestions (deterministic fallback).
+	empty, _ := firstEventOfType(events, FinderEventEmpty)
+	if len(empty.Broaden) == 0 {
+		t.Errorf("empty event has no broaden suggestions")
+	}
+
+	// No event fabricated a result.
+	for _, ev := range events {
+		if len(ev.Items) != 0 {
+			t.Errorf("event %s carried %d fabricated items on the empty path", ev.Type, len(ev.Items))
+		}
+	}
+}

--- a/internal/testutil/mocks.go
+++ b/internal/testutil/mocks.go
@@ -25,6 +25,7 @@ type MockTextProvider struct {
 	ExtractRecipeFromTextFunc func(ctx context.Context, text string, unitSystem string) (*ai.RecipeResult, error)
 	CookingQAFunc             func(ctx context.Context, question string, recipeContext string) (string, error)
 	DietaryInterviewFunc      func(ctx context.Context, messages []ai.Message, memberName string) (*ai.DietaryInterviewResult, error)
+	ExpandAndRankRecipesFunc  func(ctx context.Context, req ai.FinderRankRequest) (*ai.FinderRankResult, error)
 }
 
 func (m *MockTextProvider) GenerateRecipe(ctx context.Context, req ai.RecipeRequest) (*ai.RecipeResult, error) {
@@ -88,6 +89,13 @@ func (m *MockTextProvider) DietaryInterview(ctx context.Context, messages []ai.M
 		return m.DietaryInterviewFunc(ctx, messages, memberName)
 	}
 	return nil, fmt.Errorf("DietaryInterview not configured")
+}
+
+func (m *MockTextProvider) ExpandAndRankRecipes(ctx context.Context, req ai.FinderRankRequest) (*ai.FinderRankResult, error) {
+	if m.ExpandAndRankRecipesFunc != nil {
+		return m.ExpandAndRankRecipesFunc(ctx, req)
+	}
+	return nil, fmt.Errorf("ExpandAndRankRecipes not configured")
 }
 
 // --- MockVisionProvider ---


### PR DESCRIPTION
## Phase 1 — Backend Recipe Finder (ships dark)

First phase of replacing **"Generate with AI"** (invent-from-scratch) with a guided **Recipe Finder** that surfaces only **real** recipes. This PR is backend-only and **ships dark** — there is no user-facing caller yet, and fork/regenerate + the existing invent path are **untouched** (removal lands in a later phase).

The finder is a **bounded trajectory**, not an open-ended model tool loop:
1. Compose the search query **deterministically** from facets + free text + allergen excludes — no model.
2. Run the existing search (reuses the exact + semantic/embedding cache).
3. **Exactly one** cheap **light-tier** model call expands/ranks/annotates the real candidates.
4. Drop out-of-range/duplicate indices and any candidate the model flags allergen-`avoid`.
5. Warm the top results, then stream each step over **SSE** so it feels agentic.

Because the model returns **only indices into the real search results**, it structurally cannot fabricate a recipe.

### New model method
`ai.TextProvider.ExpandAndRankRecipes(ctx, FinderRankRequest) (*FinderRankResult, error)` — the light-tier forced-tool pattern (mirrors `EstimatePortions` / `ClassifyVoiceIntent`), ~512 max tokens, metered through `runWithMiddleware`. Implemented on **both** `AnthropicProvider` and `OpenAICompatProvider` (the light Gemini-Flash tier the finder uses) via a shared `rank_recipes` schema, wire-payload builder and result parser, so both tiers send identical requests. Interface ripple covered: interface decl, both impls, `SwitchableTextProvider` passthrough, `MockTextProvider` (`ExpandAndRankRecipesFunc`) and the `switchable_test` stub (`MockStreamingTextProvider`/`stubStreamingProvider` inherit via embedding).

### New service + handler + route
- `internal/service/recipe_finder.go` — `RecipeFinderService` + `FinderEvent`. Auto-injects (server-side, never client-trusted) the user's `Personalization` and the family diet: allergies → hard query excludes, restrictions/preferences → model steer. Emits `searching → found → filtering → shortlist → warming → refine_ready → done`, or a terminal `empty` (0 results **or** all dropped) with broaden suggestions — **never** an invented recipe.
- `internal/handlers/finder.go` — `FinderHandler.FindRecipes` SSE endpoint (from the `StreamGenerateRecipe` template).
- `POST /v1/recipes/find` wired in `router.go`, reusing `searchService`, `familyRepo`, `warmService` and the light `previewProvider`.

### Subscription gating (resolved carefully)
`SearchService.SearchRecipes` does **not** gate or increment usage — all of that lives in the **search handler**. So the finder gates **once** in its handler on the same `"search"` limit and increments **once** for a non-cached search (keyed off the `found` event's `from_cache`). No double counting.

### Verification
- `go build ./...`, `go vet ./...`, `go test ./... -count=1` — all green + **offline**.
- New offline test asserts: happy-path event order with real candidates + reasons; an allergen-`avoid` candidate dropped from the shortlist (diet excludes reach the query + model); empty search yields exactly one `empty` event with broaden suggestions, **no** model call and **no** fabricated result.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
https://claude.ai/code/session_01BU4UWZutHd1AnK3XAf7H19
