### PR TITLE
feat(finder): Phase 1 — paginate /recipes/find (offset + has_more, additive, ships dark)

### DIFF
--- a/internal/service/recipe_finder.go
+++ b/internal/service/recipe_finder.go
@@ -74,6 +74,10 @@ type FinderEvent struct {
 	Chips     []string           `json:"chips,omitempty"`
 	Broaden   []string           `json:"broaden,omitempty"`
 	Error     string             `json:"error,omitempty"`
+	// HasMore reports whether more pages of underlying search results are
+	// available (derived from the search result, not the shortlist length —
+	// the finder drops avoid/duplicate candidates). Carried on the shortlist event.
+	HasMore bool `json:"has_more,omitempty"`
 }
 
 // FinderFacets are the tappable facet-chip selections that steer a find. They
@@ -98,6 +102,9 @@ type FinderRequest struct {
 	Facets   FinderFacets  `json:"facets"`
 	FreeText string        `json:"free_text,omitempty"`
 	Refine   *FinderRefine `json:"refine,omitempty"`
+	// Offset pages through the underlying search results (0-based). Negative
+	// values are clamped to 0.
+	Offset int `json:"offset,omitempty"`
 }
 
 // RecipeFinderService drives the guided "recipe finder": one bounded trajectory
@@ -143,7 +150,12 @@ func (s *RecipeFinderService) FindRecipes(ctx context.Context, user *models.User
 	}
 
 	// 2. Search real recipes (reuses the exact + semantic/embedding cache).
-	searchRes, err := s.Search.SearchRecipes(ctx, query, finderSearchCount, 0)
+	// Page through results with the requested offset (negatives clamped to 0).
+	offset := req.Offset
+	if offset < 0 {
+		offset = 0
+	}
+	searchRes, err := s.Search.SearchRecipes(ctx, query, finderSearchCount, offset)
 	if err != nil {
 		logger.Get().Error("recipe finder search failed", zap.String("query", query), zap.Error(err))
 		s.emit(ctx, events, FinderEvent{Type: FinderEventError, Error: "search failed"})
@@ -176,7 +188,9 @@ func (s *RecipeFinderService) FindRecipes(ctx context.Context, user *models.User
 		s.emit(ctx, events, FinderEvent{Type: FinderEventEmpty, Broaden: broadenList(rank, req)})
 		return
 	}
-	if !s.emit(ctx, events, FinderEvent{Type: FinderEventShortlist, Items: items}) {
+	// HasMore is derived from the search page (not len(items)) so dropped
+	// avoid/duplicate candidates never under-report that more pages exist.
+	if !s.emit(ctx, events, FinderEvent{Type: FinderEventShortlist, Items: items, HasMore: searchRes.HasMore}) {
 		return
 	}
 

--- a/internal/service/recipe_finder_test.go
+++ b/internal/service/recipe_finder_test.go
@@ -2,6 +2,7 @@ package service
 
 import (
 	"context"
+	"fmt"
 	"strings"
 	"testing"
 
@@ -305,5 +306,78 @@ func TestFindRecipes_EmptyNeverInvents(t *testing.T) {
 		if len(ev.Items) != 0 {
 			t.Errorf("event %s carried %d fabricated items on the empty path", ev.Type, len(ev.Items))
 		}
+	}
+}
+
+func TestFindRecipes_Offset(t *testing.T) {
+	makeCandidates := func(n int) []ai.SearchResult {
+		out := make([]ai.SearchResult, n)
+		for i := range out {
+			out[i] = ai.SearchResult{
+				Title:       fmt.Sprintf("Recipe %d", i),
+				URL:         fmt.Sprintf("https://example.com/r%d", i),
+				Source:      "example.com",
+				Description: "desc",
+			}
+		}
+		return out
+	}
+
+	// Rank only the first two candidates, so the shortlist is deliberately
+	// shorter than the search page — HasMore must still reflect the search page,
+	// never len(items).
+	ranker := &testutil.MockTextProvider{
+		ExpandAndRankRecipesFunc: func(ctx context.Context, req ai.FinderRankRequest) (*ai.FinderRankResult, error) {
+			return &ai.FinderRankResult{
+				Ranked: []ai.FinderRanking{{Index: 0, Reason: "a"}, {Index: 1, Reason: "b"}},
+			}, nil
+		},
+	}
+
+	cases := []struct {
+		name        string
+		reqOffset   int
+		pageSize    int // results the provider returns
+		wantOffset  int
+		wantHasMore bool
+	}{
+		{name: "full page has more", reqOffset: 10, pageSize: finderSearchCount, wantOffset: 10, wantHasMore: true},
+		{name: "short page no more", reqOffset: 20, pageSize: 3, wantOffset: 20, wantHasMore: false},
+		{name: "negative offset clamped to zero", reqOffset: -5, pageSize: 3, wantOffset: 0, wantHasMore: false},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			var gotOffset int
+			searchProvider := &testutil.MockSearchProvider{
+				SearchRecipesFunc: func(ctx context.Context, query string, count, offset int) ([]ai.SearchResult, error) {
+					gotOffset = offset
+					return makeCandidates(tc.pageSize), nil
+				},
+			}
+			svc := newFinderService(searchProvider, ranker, &testutil.MockFamilyRepo{})
+			events := runFinder(svc, testutil.TestUser(), FinderRequest{
+				Facets: FinderFacets{Protein: "chicken"},
+				Offset: tc.reqOffset,
+			})
+
+			// The requested offset (clamped) reaches the search provider.
+			if gotOffset != tc.wantOffset {
+				t.Errorf("search offset = %d, want %d", gotOffset, tc.wantOffset)
+			}
+
+			// HasMore rides the shortlist event and reflects the search page.
+			shortlist, ok := firstEventOfType(events, FinderEventShortlist)
+			if !ok {
+				t.Fatalf("no shortlist event (order: %v)", eventTypes(events))
+			}
+			if shortlist.HasMore != tc.wantHasMore {
+				t.Errorf("shortlist.HasMore = %v, want %v", shortlist.HasMore, tc.wantHasMore)
+			}
+			// The shortlist stays shorter than the page (proves HasMore is not len(items)).
+			if len(shortlist.Items) != 2 {
+				t.Errorf("shortlist has %d items, want 2 (ranker returned 2)", len(shortlist.Items))
+			}
+		})
 	}
 }


### PR DESCRIPTION
## Phase 1 — Paginate `/recipes/find` (offset + has_more)

First phase of unifying the finder into search: let the finder page through the underlying search results. **Additive + `omitempty`**, so it ships dark and existing clients are unaffected.

### Changes (all in `internal/service/recipe_finder.go`)
- **`FinderRequest.Offset`** (`json:"offset,omitempty"`, 0-based) — decoded by the existing handler `BindJSON`, so `internal/handlers/finder.go` needs **no change**. Negative offsets are clamped to 0.
- **`FindRecipes`** now passes the clamped offset to `SearchService.SearchRecipes` (was hardcoded `0`). The service already supports offset and computes `HasMore`.
- **`FinderEvent.HasMore`** (`json:"has_more,omitempty"`) — emitted on the **shortlist** event as `searchRes.HasMore`, **derived from the search page, not `len(items)`**, so the finder dropping avoid/duplicate candidates never under-reports that more pages exist.

### Gating (unchanged, confirmed correct for paging)
A paginated search is non-cached, so the `found` event's `from_cache` is `false` and the handler increments the `search` quota once — matching the search handler, which also counts paginated searches. No double counting.

### Request / SSE additions as implemented
- Request: `POST /v1/recipes/find` body gains optional `"offset": <int>` (alongside `facets`/`free_text`/`refine`).
- SSE: the `shortlist` event's `data` JSON gains `"has_more": <bool>` (omitted when false).

### Verification
`TestFindRecipes_Offset` (table-driven) asserts the requested offset (clamped) reaches the search provider and that the shortlist's `HasMore` tracks the search page — `true` on a full/over-count page, `false` on a short page — while the shortlist stays shorter than the page (proving `HasMore` is not `len(items)`). `go build ./...`, `go vet ./...`, `go test ./... -count=1` all green + **offline**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
https://claude.ai/code/session_01BU4UWZutHd1AnK3XAf7H19
