### PR TITLE
feat(finder): agentic multi-recipe digging + saved finder-run history (backend, ships dark)

### DIFF
--- a/internal/ai/anthropic.go
+++ b/internal/ai/anthropic.go
@@ -391,6 +391,7 @@ Select the candidates that best match the request and return them, best match fi
 For each candidate you return:
 - Give one short sentence (reason) explaining why it fits the request.
 - Give a best-effort dietary safety assessment for each family member mentioned in the dietary needs, judging ONLY from the candidate's title and description: "safe" if nothing conflicts, "caution" if it might conflict or is unclear, "avoid" if it clearly conflicts with an allergy or restriction. Keep the note short. Omit members you cannot assess.
+- If the candidate is a collection/listicle/roundup page indexing MANY recipes (e.g. "23 Best Weeknight Dinners") rather than a single recipe, set expand=true and expand_priority (higher = more worth digging into); otherwise set expand=false.
 
 Also suggest 2-4 broadened search queries (broaden_queries) the user could try to get more options.
 
@@ -422,6 +423,8 @@ func rankRecipesProperties() map[string]interface{} {
 							},
 						},
 					},
+					"expand":          map[string]interface{}{"type": "boolean", "description": "True if this candidate is a collection/listicle/roundup page of MANY recipes (not a single recipe) worth digging into."},
+					"expand_priority": map[string]interface{}{"type": "integer", "description": "When expand is true, how promising this collection is to dig into (higher = more promising). 0 otherwise."},
 				},
 			},
 		},
@@ -634,6 +637,8 @@ type finderRankToolResult struct {
 			Status     string `json:"status"`
 			Note       string `json:"note"`
 		} `json:"safety"`
+		Expand         bool `json:"expand"`
+		ExpandPriority int  `json:"expand_priority"`
 	} `json:"ranked"`
 	BroadenQueries []string `json:"broaden_queries"`
 }
@@ -650,9 +655,11 @@ func toolResultToFinderRankResult(tr *finderRankToolResult) *FinderRankResult {
 			}
 		}
 		ranked[i] = FinderRanking{
-			Index:  r.Index,
-			Reason: r.Reason,
-			Safety: safety,
+			Index:          r.Index,
+			Reason:         r.Reason,
+			Safety:         safety,
+			Expand:         r.Expand,
+			ExpandPriority: r.ExpandPriority,
 		}
 	}
 	return &FinderRankResult{

--- a/internal/ai/provider.go
+++ b/internal/ai/provider.go
@@ -263,6 +263,12 @@ type FinderRanking struct {
 	Index  int
 	Reason string
 	Safety []MemberSafety
+	// Expand marks a candidate that is a collection/listicle/roundup page (many
+	// recipes) rather than a single recipe, worth digging into for its
+	// individual recipes. ExpandPriority (higher = more promising) orders which
+	// collections to dig first when several are flagged.
+	Expand         bool
+	ExpandPriority int
 }
 
 // FinderRankResult is the output of ExpandAndRankRecipes: candidates in

--- a/internal/db/db.go
+++ b/internal/db/db.go
@@ -65,6 +65,7 @@ func connectToDatabaseWithRetry(databaseURL string) (*gorm.DB, error) {
 		&models.AIUsageLog{},
 		&models.AIModelOption{},
 		&models.AIConfig{},
+		&models.FinderSession{},
 	); migrateErr != nil {
 		return nil, fmt.Errorf("database auto-migration failed: %w", migrateErr)
 	}

--- a/internal/handlers/finder_session.go
+++ b/internal/handlers/finder_session.go
@@ -1,0 +1,108 @@
+package handlers
+
+import (
+	"errors"
+	"net/http"
+	"strconv"
+
+	"github.com/gin-gonic/gin"
+	"github.com/windoze95/saltybytes-api/internal/logger"
+	"github.com/windoze95/saltybytes-api/internal/service"
+	"github.com/windoze95/saltybytes-api/internal/util"
+	"go.uber.org/zap"
+	"gorm.io/gorm"
+)
+
+// FinderSessionHandler serves the (ungated) saved recipe-finder session history.
+type FinderSessionHandler struct {
+	Service *service.FinderSessionService
+}
+
+// NewFinderSessionHandler creates a new FinderSessionHandler.
+func NewFinderSessionHandler(svc *service.FinderSessionService) *FinderSessionHandler {
+	return &FinderSessionHandler{Service: svc}
+}
+
+// ListSessions handles GET /v1/recipes/finder/sessions?page=&page_size=.
+func (h *FinderSessionHandler) ListSessions(c *gin.Context) {
+	user, err := util.GetUserFromContext(c)
+	if err != nil {
+		c.JSON(http.StatusUnauthorized, gin.H{"error": "unauthorized"})
+		return
+	}
+
+	page := 1
+	if p, err := strconv.Atoi(c.Query("page")); err == nil && p > 0 {
+		page = p
+	}
+	pageSize := 20
+	if ps, err := strconv.Atoi(c.Query("page_size")); err == nil && ps > 0 && ps <= 100 {
+		pageSize = ps
+	}
+
+	sessions, total, err := h.Service.List(c.Request.Context(), user.ID, pageSize, (page-1)*pageSize)
+	if err != nil {
+		logger.Get().Error("failed to list finder sessions", zap.Uint("user_id", user.ID), zap.Error(err))
+		c.JSON(http.StatusInternalServerError, gin.H{"error": "failed to list sessions"})
+		return
+	}
+
+	c.JSON(http.StatusOK, gin.H{"sessions": sessions, "total": total, "page": page, "page_size": pageSize})
+}
+
+// GetSession handles GET /v1/recipes/finder/sessions/:session_id.
+func (h *FinderSessionHandler) GetSession(c *gin.Context) {
+	user, err := util.GetUserFromContext(c)
+	if err != nil {
+		c.JSON(http.StatusUnauthorized, gin.H{"error": "unauthorized"})
+		return
+	}
+
+	id, err := strconv.ParseUint(c.Param("session_id"), 10, 64)
+	if err != nil {
+		c.JSON(http.StatusBadRequest, gin.H{"error": "invalid session ID"})
+		return
+	}
+
+	session, err := h.Service.Get(c.Request.Context(), user.ID, uint(id))
+	if err != nil {
+		// A not-owned session is reported as not-found so a user can't probe for
+		// the existence of other users' sessions.
+		if errors.Is(err, gorm.ErrRecordNotFound) || errors.Is(err, service.ErrFinderSessionNotOwned) {
+			c.JSON(http.StatusNotFound, gin.H{"error": "session not found"})
+			return
+		}
+		logger.Get().Error("failed to get finder session", zap.Uint("session_id", uint(id)), zap.Error(err))
+		c.JSON(http.StatusInternalServerError, gin.H{"error": "failed to get session"})
+		return
+	}
+
+	c.JSON(http.StatusOK, gin.H{"session": session})
+}
+
+// DeleteSession handles DELETE /v1/recipes/finder/sessions/:session_id.
+func (h *FinderSessionHandler) DeleteSession(c *gin.Context) {
+	user, err := util.GetUserFromContext(c)
+	if err != nil {
+		c.JSON(http.StatusUnauthorized, gin.H{"error": "unauthorized"})
+		return
+	}
+
+	id, err := strconv.ParseUint(c.Param("session_id"), 10, 64)
+	if err != nil {
+		c.JSON(http.StatusBadRequest, gin.H{"error": "invalid session ID"})
+		return
+	}
+
+	if err := h.Service.Delete(c.Request.Context(), user.ID, uint(id)); err != nil {
+		if errors.Is(err, gorm.ErrRecordNotFound) || errors.Is(err, service.ErrFinderSessionNotOwned) {
+			c.JSON(http.StatusNotFound, gin.H{"error": "session not found"})
+			return
+		}
+		logger.Get().Error("failed to delete finder session", zap.Uint("session_id", uint(id)), zap.Error(err))
+		c.JSON(http.StatusInternalServerError, gin.H{"error": "failed to delete session"})
+		return
+	}
+
+	c.JSON(http.StatusOK, gin.H{"message": "session deleted"})
+}

--- a/internal/models/finder_session.go
+++ b/internal/models/finder_session.go
@@ -1,0 +1,54 @@
+package models
+
+import (
+	"database/sql/driver"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"time"
+
+	"gorm.io/gorm"
+)
+
+// FinderSession is a saved Recipe Finder run: what the user asked for (Intent),
+// the recipes it surfaced (Results) and a short human narration of the run.
+// It is auto-saved server-side after each completed first-page find, so a user
+// can browse and resume past finds. gorm.Model fields are declared explicitly so
+// JSON serializes snake_case (mirrors Family).
+type FinderSession struct {
+	ID        uint             `gorm:"primarykey" json:"id"`
+	CreatedAt time.Time        `json:"created_at"`
+	UpdatedAt time.Time        `json:"updated_at"`
+	DeletedAt gorm.DeletedAt   `gorm:"index" json:"-"`
+	UserID    uint             `gorm:"index;not null" json:"user_id"`
+	Title     string           `gorm:"type:text" json:"title"`
+	Intent    FinderIntent     `gorm:"type:jsonb" json:"intent"`
+	Results   SearchResultList `gorm:"type:jsonb" json:"results"`
+	Narration StringList       `gorm:"type:jsonb" json:"narration"`
+}
+
+// FinderIntent captures what a user asked for in a finder run, stored as JSONB.
+// It mirrors the finder's facet + free-text wire shape so the app can re-run it.
+type FinderIntent struct {
+	Occasion     string   `json:"occasion,omitempty"`
+	TimeBudget   string   `json:"time_budget,omitempty"`
+	Protein      string   `json:"protein,omitempty"`
+	Cuisine      string   `json:"cuisine,omitempty"`
+	UseWhatIHave []string `json:"use_what_i_have,omitempty"`
+	SurpriseMe   bool     `json:"surprise_me,omitempty"`
+	FreeText     string   `json:"free_text,omitempty"`
+}
+
+// Scan is a GORM hook that scans jsonb into FinderIntent.
+func (j *FinderIntent) Scan(value interface{}) error {
+	bytes, ok := value.([]byte)
+	if !ok {
+		return errors.New(fmt.Sprint("Failed to unmarshal JSONB value:", value))
+	}
+	return json.Unmarshal(bytes, j)
+}
+
+// Value is a GORM hook that returns the json value of FinderIntent.
+func (j FinderIntent) Value() (driver.Value, error) {
+	return json.Marshal(j)
+}

--- a/internal/repository/finder_session.go
+++ b/internal/repository/finder_session.go
@@ -1,0 +1,69 @@
+package repository
+
+import (
+	"context"
+
+	"github.com/windoze95/saltybytes-api/internal/logger"
+	"github.com/windoze95/saltybytes-api/internal/models"
+	"go.uber.org/zap"
+	"gorm.io/gorm"
+)
+
+// FinderSessionRepository persists saved Recipe Finder runs.
+type FinderSessionRepository struct {
+	DB *gorm.DB
+}
+
+// NewFinderSessionRepository creates a new FinderSessionRepository.
+func NewFinderSessionRepository(db *gorm.DB) *FinderSessionRepository {
+	return &FinderSessionRepository{DB: db}
+}
+
+// Create inserts a new finder session.
+func (r *FinderSessionRepository) Create(ctx context.Context, session *models.FinderSession) error {
+	if err := r.DB.WithContext(ctx).Create(session).Error; err != nil {
+		logger.Get().Error("failed to create finder session", zap.Uint("user_id", session.UserID), zap.Error(err))
+		return err
+	}
+	return nil
+}
+
+// ListByUser returns a page of a user's sessions, newest first, plus the total count.
+func (r *FinderSessionRepository) ListByUser(ctx context.Context, userID uint, limit, offset int) ([]models.FinderSession, int64, error) {
+	var (
+		sessions []models.FinderSession
+		total    int64
+	)
+	if err := r.DB.WithContext(ctx).Model(&models.FinderSession{}).
+		Where("user_id = ?", userID).
+		Count(&total).Error; err != nil {
+		return nil, 0, err
+	}
+	if err := r.DB.WithContext(ctx).
+		Where("user_id = ?", userID).
+		Order("created_at DESC").
+		Limit(limit).
+		Offset(offset).
+		Find(&sessions).Error; err != nil {
+		return nil, 0, err
+	}
+	return sessions, total, nil
+}
+
+// GetByID returns a session by ID (ownership is enforced by the caller).
+func (r *FinderSessionRepository) GetByID(ctx context.Context, id uint) (*models.FinderSession, error) {
+	var session models.FinderSession
+	if err := r.DB.WithContext(ctx).Where("id = ?", id).First(&session).Error; err != nil {
+		return nil, err
+	}
+	return &session, nil
+}
+
+// Delete soft-deletes a session by ID.
+func (r *FinderSessionRepository) Delete(ctx context.Context, id uint) error {
+	if err := r.DB.WithContext(ctx).Delete(&models.FinderSession{}, id).Error; err != nil {
+		logger.Get().Error("failed to delete finder session", zap.Uint("session_id", id), zap.Error(err))
+		return err
+	}
+	return nil
+}

--- a/internal/repository/interfaces.go
+++ b/internal/repository/interfaces.go
@@ -1,6 +1,7 @@
 package repository
 
 import (
+	"context"
 	"time"
 
 	"github.com/windoze95/saltybytes-api/internal/models"
@@ -83,6 +84,14 @@ type FamilyRepo interface {
 	GetOrCreateDietaryProfile(memberID uint) (*models.DietaryProfile, error)
 }
 
+// FinderSessionRepo is the interface for saved recipe-finder session operations.
+type FinderSessionRepo interface {
+	Create(ctx context.Context, session *models.FinderSession) error
+	ListByUser(ctx context.Context, userID uint, limit, offset int) ([]models.FinderSession, int64, error)
+	GetByID(ctx context.Context, id uint) (*models.FinderSession, error)
+	Delete(ctx context.Context, id uint) error
+}
+
 // AllergenRepo is the interface for allergen analysis repository operations.
 type AllergenRepo interface {
 	CreateAnalysis(analysis *models.AllergenAnalysis) error
@@ -114,3 +123,4 @@ type UserRepo interface {
 var _ UserRepo = (*UserRepository)(nil)
 var _ FamilyRepo = (*FamilyRepository)(nil)
 var _ AllergenRepo = (*AllergenRepository)(nil)
+var _ FinderSessionRepo = (*FinderSessionRepository)(nil)

--- a/internal/router/router.go
+++ b/internal/router/router.go
@@ -357,9 +357,21 @@ func SetupRouter(cfg *config.Config, database *gorm.DB) *gin.Engine {
 	// Recipe finder — a guided agent that finds REAL recipes by driving search +
 	// a single cheap ranking call (light tier), streamed over SSE. Gated by the
 	// same "search" limit as the search endpoint. Ships dark (no caller yet).
+	// Saved finder-run history (ungated) — also the finder's server-side auto-save sink.
+	finderSessionRepo := repository.NewFinderSessionRepository(database)
+	finderSessionService := service.NewFinderSessionService(finderSessionRepo)
+	finderSessionHandler := handlers.NewFinderSessionHandler(finderSessionService)
+
 	finderService := service.NewRecipeFinderService(cfg, searchService, familyRepo, warmService, previewProvider)
+	// Agentic digging expands ranker-flagged collections via the multi-recipe
+	// resolver; auto-save records each completed first-page run for history.
+	finderService.MultiResolver = multiResolver
+	finderService.Sessions = finderSessionService
 	finderHandler := &handlers.FinderHandler{Service: finderService, SubService: subService}
 	apiProtected.POST("/recipes/find", middleware.AttachUserToContext(userService), finderHandler.FindRecipes)
+	apiProtected.GET("/recipes/finder/sessions", middleware.AttachUserToContext(userService), finderSessionHandler.ListSessions)
+	apiProtected.GET("/recipes/finder/sessions/:session_id", middleware.AttachUserToContext(userService), finderSessionHandler.GetSession)
+	apiProtected.DELETE("/recipes/finder/sessions/:session_id", middleware.AttachUserToContext(userService), finderSessionHandler.DeleteSession)
 
 	// Vector similarity routes
 	similarityHandler := handlers.NewSimilarityHandler(vectorRepo, embedProvider, recipeService)

--- a/internal/service/finder_session.go
+++ b/internal/service/finder_session.go
@@ -1,0 +1,58 @@
+package service
+
+import (
+	"context"
+	"errors"
+
+	"github.com/windoze95/saltybytes-api/internal/models"
+	"github.com/windoze95/saltybytes-api/internal/repository"
+)
+
+// ErrFinderSessionNotOwned is returned when a user references a finder session
+// that belongs to someone else.
+var ErrFinderSessionNotOwned = errors.New("finder session not owned by user")
+
+// FinderSessionService manages saved recipe-finder runs. History is ungated
+// (no subscription check) — it just records what the finder already did.
+type FinderSessionService struct {
+	Repo repository.FinderSessionRepo
+}
+
+// NewFinderSessionService creates a new FinderSessionService.
+func NewFinderSessionService(repo repository.FinderSessionRepo) *FinderSessionService {
+	return &FinderSessionService{Repo: repo}
+}
+
+// Save persists a completed finder run.
+func (s *FinderSessionService) Save(ctx context.Context, session *models.FinderSession) error {
+	return s.Repo.Create(ctx, session)
+}
+
+// List returns a page of the user's sessions (newest first) and the total count.
+func (s *FinderSessionService) List(ctx context.Context, userID uint, limit, offset int) ([]models.FinderSession, int64, error) {
+	return s.Repo.ListByUser(ctx, userID, limit, offset)
+}
+
+// Get returns one session, enforcing ownership.
+func (s *FinderSessionService) Get(ctx context.Context, userID, sessionID uint) (*models.FinderSession, error) {
+	session, err := s.Repo.GetByID(ctx, sessionID)
+	if err != nil {
+		return nil, err
+	}
+	if session.UserID != userID {
+		return nil, ErrFinderSessionNotOwned
+	}
+	return session, nil
+}
+
+// Delete removes one session, enforcing ownership.
+func (s *FinderSessionService) Delete(ctx context.Context, userID, sessionID uint) error {
+	session, err := s.Repo.GetByID(ctx, sessionID)
+	if err != nil {
+		return err
+	}
+	if session.UserID != userID {
+		return ErrFinderSessionNotOwned
+	}
+	return s.Repo.Delete(ctx, sessionID)
+}

--- a/internal/service/finder_session_test.go
+++ b/internal/service/finder_session_test.go
@@ -1,0 +1,122 @@
+package service
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"testing"
+
+	"github.com/windoze95/saltybytes-api/internal/ai"
+	"github.com/windoze95/saltybytes-api/internal/models"
+	"github.com/windoze95/saltybytes-api/internal/testutil"
+	"gorm.io/gorm"
+)
+
+func TestFinderSessionService_SaveListGetDelete(t *testing.T) {
+	repo := testutil.NewMockFinderSessionRepo()
+	svc := NewFinderSessionService(repo)
+	ctx := context.Background()
+
+	// Two sessions for user 1, one for user 2.
+	for i := 0; i < 2; i++ {
+		if err := svc.Save(ctx, &models.FinderSession{UserID: 1, Title: fmt.Sprintf("s%d", i)}); err != nil {
+			t.Fatalf("Save: %v", err)
+		}
+	}
+	if err := svc.Save(ctx, &models.FinderSession{UserID: 2, Title: "other"}); err != nil {
+		t.Fatalf("Save other: %v", err)
+	}
+
+	// List returns only user 1's, newest first, with the correct total.
+	list, total, err := svc.List(ctx, 1, 10, 0)
+	if err != nil {
+		t.Fatalf("List: %v", err)
+	}
+	if total != 2 || len(list) != 2 {
+		t.Fatalf("List returned %d (total %d), want 2 (total 2)", len(list), total)
+	}
+	if list[0].Title != "s1" {
+		t.Errorf("newest-first: list[0].Title = %q, want s1", list[0].Title)
+	}
+
+	// Get enforces ownership.
+	got, err := svc.Get(ctx, 1, list[0].ID)
+	if err != nil {
+		t.Fatalf("Get own: %v", err)
+	}
+	if got.ID != list[0].ID {
+		t.Errorf("Get returned id %d, want %d", got.ID, list[0].ID)
+	}
+	if _, err := svc.Get(ctx, 999, list[0].ID); !errors.Is(err, ErrFinderSessionNotOwned) {
+		t.Errorf("Get by non-owner err = %v, want ErrFinderSessionNotOwned", err)
+	}
+
+	// Delete enforces ownership, then removes.
+	if err := svc.Delete(ctx, 999, list[0].ID); !errors.Is(err, ErrFinderSessionNotOwned) {
+		t.Errorf("Delete by non-owner err = %v, want ErrFinderSessionNotOwned", err)
+	}
+	if err := svc.Delete(ctx, 1, list[0].ID); err != nil {
+		t.Fatalf("Delete own: %v", err)
+	}
+	if _, err := svc.Get(ctx, 1, list[0].ID); !errors.Is(err, gorm.ErrRecordNotFound) {
+		t.Errorf("after delete, Get err = %v, want ErrRecordNotFound", err)
+	}
+}
+
+func TestFindRecipes_AutoSavesCompletedRun(t *testing.T) {
+	results := digSearchResults(3)
+	searchProvider := &testutil.MockSearchProvider{
+		SearchRecipesFunc: func(ctx context.Context, query string, count, offset int) ([]ai.SearchResult, error) {
+			return results, nil
+		},
+	}
+	ranker := rankAllFlagging(results, nil) // rank all, flag none
+	repo := testutil.NewMockFinderSessionRepo()
+
+	svc := newFinderService(searchProvider, ranker, &testutil.MockFamilyRepo{})
+	svc.Sessions = NewFinderSessionService(repo)
+
+	_ = runFinder(svc, testutil.TestUser(), FinderRequest{Facets: FinderFacets{Protein: "chicken", Occasion: "dinner"}})
+
+	created := repo.Created()
+	if len(created) != 1 {
+		t.Fatalf("auto-save created %d sessions, want exactly 1", len(created))
+	}
+	sess := created[0]
+	if sess.UserID != testutil.TestUser().ID {
+		t.Errorf("session UserID = %d, want %d", sess.UserID, testutil.TestUser().ID)
+	}
+	if len(sess.Results) != 3 {
+		t.Errorf("session stored %d results, want 3 (the shortlist)", len(sess.Results))
+	}
+	if sess.Title == "" {
+		t.Errorf("session has an empty title")
+	}
+	if sess.Intent.Protein != "chicken" {
+		t.Errorf("session intent protein = %q, want chicken", sess.Intent.Protein)
+	}
+	if len(sess.Narration) == 0 {
+		t.Errorf("session has no narration")
+	}
+}
+
+func TestFindRecipes_NoAutoSaveOnPagination(t *testing.T) {
+	results := digSearchResults(3)
+	searchProvider := &testutil.MockSearchProvider{
+		SearchRecipesFunc: func(ctx context.Context, query string, count, offset int) ([]ai.SearchResult, error) {
+			return results, nil
+		},
+	}
+	ranker := rankAllFlagging(results, nil)
+	repo := testutil.NewMockFinderSessionRepo()
+
+	svc := newFinderService(searchProvider, ranker, &testutil.MockFamilyRepo{})
+	svc.Sessions = NewFinderSessionService(repo)
+
+	// A paginated (offset > 0) run must NOT create a session.
+	_ = runFinder(svc, testutil.TestUser(), FinderRequest{Facets: FinderFacets{Protein: "chicken"}, Offset: 10})
+
+	if n := len(repo.Created()); n != 0 {
+		t.Errorf("paginated run created %d sessions, want 0", n)
+	}
+}

--- a/internal/service/multi_recipe.go
+++ b/internal/service/multi_recipe.go
@@ -25,6 +25,11 @@ type MultiRecipeCard struct {
 	ExtractionStatus string            `json:"extraction_status"` // "pending", "extracting", "done", "failed"
 	RecipeDef        *models.RecipeDef `json:"recipe,omitempty"`  // populated when done
 	Hashtags         []string          `json:"hashtags,omitempty"`
+	// CachedURL is the canonical-cache key under which this card's extracted
+	// recipe was stored (its own-page URL for listicles, or the distinct
+	// ?_recipe=slug URL for inline recipes). Set once ExtractionStatus is "done";
+	// a later preview/import of this URL is an instant cache hit.
+	CachedURL string `json:"cached_url,omitempty"`
 }
 
 // MultiRecipeEntry tracks the resolution state of a multi-recipe URL.
@@ -540,13 +545,34 @@ func (r *MultiRecipeResolver) DetectMultiFromHTML(ctx context.Context, sourceURL
 	return len(r.detectCards(ctx, sourceURL, html)) > 1
 }
 
+// MultiResolver is the finder's seam over the multi-recipe resolver. Digging
+// depends only on this interface so the finder's tests can inject a fake and
+// stay fully offline.
+type MultiResolver interface {
+	ResolveFromURLN(ctx context.Context, sourceURL string, maxCards int) *MultiRecipeEntry
+}
+
+var _ MultiResolver = (*MultiRecipeResolver)(nil)
+
 // ResolveFromHTML detects and begins resolving a multi-recipe page from fetched HTML.
 // Uses JSON-LD detection first, then falls back to AI-based detection.
 // Returns the entry if multi-recipe, or nil if single-recipe.
 func (r *MultiRecipeResolver) ResolveFromHTML(ctx context.Context, sourceURL string, html string) *MultiRecipeEntry {
+	return r.resolveFromHTMLN(ctx, sourceURL, html, 0)
+}
+
+// resolveFromHTMLN is ResolveFromHTML with an optional cap on the number of
+// cards resolved+extracted. maxCards <= 0 means no cap. Cards are truncated
+// before URL assignment, registration and extraction, so a capped resolve never
+// kicks off extraction for the dropped cards.
+func (r *MultiRecipeResolver) resolveFromHTMLN(ctx context.Context, sourceURL string, html string, maxCards int) *MultiRecipeEntry {
 	cards := r.detectCards(ctx, sourceURL, html)
 	if len(cards) <= 1 {
 		return nil
+	}
+
+	if maxCards > 0 && len(cards) > maxCards {
+		cards = cards[:maxCards]
 	}
 
 	// Point cards at their own recipe pages when this is a collection/listicle
@@ -572,6 +598,13 @@ func (r *MultiRecipeResolver) ResolveFromHTML(ctx context.Context, sourceURL str
 // ResolveFromURL fetches a URL and resolves if it's multi-recipe.
 // Used for late detection when a search result is clicked.
 func (r *MultiRecipeResolver) ResolveFromURL(ctx context.Context, sourceURL string) *MultiRecipeEntry {
+	return r.ResolveFromURLN(ctx, sourceURL, 0)
+}
+
+// ResolveFromURLN is ResolveFromURL with a cap on how many cards are resolved
+// and extracted (maxCards <= 0 means no cap). The finder's bounded digging uses
+// it so a huge listicle never triggers unbounded background extraction.
+func (r *MultiRecipeResolver) ResolveFromURLN(ctx context.Context, sourceURL string, maxCards int) *MultiRecipeEntry {
 	// Check if already tracked
 	if existing := r.Registry.Get(sourceURL); existing != nil {
 		return existing
@@ -585,7 +618,7 @@ func (r *MultiRecipeResolver) ResolveFromURL(ctx context.Context, sourceURL stri
 	}
 
 	// Check for multiple recipes
-	return r.ResolveFromHTML(ctx, sourceURL, html)
+	return r.resolveFromHTMLN(ctx, sourceURL, html, maxCards)
 }
 
 // extractAllRecipes runs full extraction for each card in the entry.
@@ -646,6 +679,8 @@ func (r *MultiRecipeResolver) extractSingleCard(entry *MultiRecipeEntry, idx int
 			entry.Cards[idx].ExtractionStatus = "done"
 			entry.Cards[idx].RecipeDef = def
 			entry.Cards[idx].Hashtags = hashtags
+			// The recipe lives at its own page, so that URL is its cache key.
+			entry.Cards[idx].CachedURL = sourceURL
 			entry.mu.Unlock()
 			if r.ImportService.CanonicalRepo != nil {
 				if normalizedURL, nerr := NormalizeURL(sourceURL); nerr == nil {
@@ -735,6 +770,10 @@ func (r *MultiRecipeResolver) extractSingleCard(entry *MultiRecipeEntry, idx int
 			separator = "&"
 		}
 		distinctURL := sourceURL + separator + "_recipe=" + slug
+		// This inline recipe only exists in our cache under the distinct key.
+		entry.mu.Lock()
+		entry.Cards[idx].CachedURL = distinctURL
+		entry.mu.Unlock()
 		if normalizedURL, err := NormalizeURL(distinctURL); err == nil {
 			now := time.Now()
 			canonical := &models.CanonicalRecipe{

--- a/internal/service/recipe_finder.go
+++ b/internal/service/recipe_finder.go
@@ -3,7 +3,10 @@ package service
 import (
 	"context"
 	"fmt"
+	"net/url"
+	"sort"
 	"strings"
+	"time"
 
 	"github.com/windoze95/saltybytes-api/internal/ai"
 	"github.com/windoze95/saltybytes-api/internal/config"
@@ -21,6 +24,22 @@ const (
 	// finderWarmTopN is how many top shortlisted results to proactively warm so
 	// a later tap is an instant cache hit.
 	finderWarmTopN = 4
+
+	// Agentic multi-recipe digging bounds. Digging expands a few collection /
+	// listicle candidates into their individual recipes, but stays bounded so it
+	// never turns into an open-ended crawl.
+	//
+	// finderDigMinDirect: only dig when the direct shortlist has fewer than this
+	// many items (enough direct hits → no need to dig).
+	finderDigMinDirect = 8
+	// finderDigK: max number of collections to dig into per run.
+	finderDigK = 2
+	// finderPerCollectionCardCap: max cards resolved+extracted per collection.
+	finderPerCollectionCardCap = 6
+	// finderDigMaxCards: max recipes folded in across ALL collections in a run.
+	finderDigMaxCards = 6
+	// finderDigWait: max time to wait for one collection to finish resolving.
+	finderDigWait = 4 * time.Second
 )
 
 // finderRefineChips are the bounded, tap-first refinement options offered after
@@ -41,6 +60,11 @@ const (
 	FinderEventFiltering FinderEventType = "filtering"
 	// FinderEventShortlist carries the ranked real results with rationales+safety.
 	FinderEventShortlist FinderEventType = "shortlist"
+	// FinderEventDigging announces that the finder is expanding a collection /
+	// listicle candidate into its individual recipes.
+	FinderEventDigging FinderEventType = "digging"
+	// FinderEventExpanded carries the individual recipes dug out of a collection.
+	FinderEventExpanded FinderEventType = "expanded"
 	// FinderEventWarming lists the top URLs being proactively cache-warmed.
 	FinderEventWarming FinderEventType = "warming"
 	// FinderEventRefineReady offers tap-to-refine chips + broaden suggestions.
@@ -78,6 +102,9 @@ type FinderEvent struct {
 	// available (derived from the search result, not the shortlist length —
 	// the finder drops avoid/duplicate candidates). Carried on the shortlist event.
 	HasMore bool `json:"has_more,omitempty"`
+	// CollectionTitle is the title of the collection/listicle being expanded,
+	// carried on the digging and expanded events.
+	CollectionTitle string `json:"collection_title,omitempty"`
 }
 
 // FinderFacets are the tappable facet-chip selections that steer a find. They
@@ -120,6 +147,12 @@ type RecipeFinderService struct {
 	// RankProvider is the light tier (Gemini Flash) that performs the single
 	// query-expansion + ranking call.
 	RankProvider ai.TextProvider
+	// MultiResolver (nil-safe) expands collection/listicle candidates the ranker
+	// flags into their individual recipes. When nil, digging is skipped.
+	MultiResolver MultiResolver
+	// Sessions (nil-safe) persists each completed first-page run for history.
+	// When nil, auto-save is skipped.
+	Sessions *FinderSessionService
 }
 
 // NewRecipeFinderService wires the finder over the existing search, family and
@@ -194,6 +227,12 @@ func (s *RecipeFinderService) FindRecipes(ctx context.Context, user *models.User
 		return
 	}
 
+	// 6.5. Agentic digging (bounded): when the direct shortlist is thin, expand
+	// a few collection/listicle candidates the ranker flagged into their
+	// individual recipes, folding them into the run. Never invents — every folded
+	// recipe is a real extraction from the collection.
+	folded := s.digCollections(ctx, events, results, rank, len(items))
+
 	// 7. Proactively warm the top results (best-effort) so a later tap is an
 	// instant cache hit.
 	if warmURLs := topURLs(items, finderWarmTopN); len(warmURLs) > 0 {
@@ -210,6 +249,13 @@ func (s *RecipeFinderService) FindRecipes(ctx context.Context, user *models.User
 		return
 	}
 	s.emit(ctx, events, FinderEvent{Type: FinderEventDone})
+
+	// 9. Auto-save the completed first-page run for history (ungated, best-effort).
+	// assembled = the direct shortlist plus everything dug out of collections.
+	assembled := make([]FinderResultItem, 0, len(items)+len(folded))
+	assembled = append(assembled, items...)
+	assembled = append(assembled, folded...)
+	s.autoSaveSession(user, req, query, len(results), len(folded), assembled)
 }
 
 // emit sends one event, returning false if the context is cancelled (e.g. the
@@ -221,6 +267,206 @@ func (s *RecipeFinderService) emit(ctx context.Context, events chan<- FinderEven
 	case <-ctx.Done():
 		return false
 	}
+}
+
+// digCollections agentically expands up to finderDigK collection/listicle
+// candidates the ranker flagged, folding their individual recipes into the run
+// as expanded events. It is bounded on every axis (collections dug, cards per
+// collection, total folded cards, and wait per collection) and only runs when
+// the direct shortlist is thin. It never invents — every folded recipe is a real
+// extraction from the collection. Returns the folded items so the caller can
+// include them when saving the session.
+func (s *RecipeFinderService) digCollections(ctx context.Context, events chan<- FinderEvent, results []ai.SearchResult, rank *ai.FinderRankResult, directCount int) []FinderResultItem {
+	if s.MultiResolver == nil || rank == nil {
+		return nil
+	}
+	// Enough direct hits already — don't bother digging.
+	if directCount >= finderDigMinDirect {
+		return nil
+	}
+
+	// Gather the flagged collection candidates, most promising first.
+	type collection struct {
+		url   string
+		title string
+		prio  int
+	}
+	var collections []collection
+	for _, r := range rank.Ranked {
+		if !r.Expand || r.Index < 0 || r.Index >= len(results) {
+			continue
+		}
+		u := strings.TrimSpace(results[r.Index].URL)
+		if u == "" {
+			continue
+		}
+		collections = append(collections, collection{url: u, title: results[r.Index].Title, prio: r.ExpandPriority})
+	}
+	if len(collections) == 0 {
+		return nil
+	}
+	sort.SliceStable(collections, func(i, j int) bool { return collections[i].prio > collections[j].prio })
+	if len(collections) > finderDigK {
+		collections = collections[:finderDigK]
+	}
+
+	var folded []FinderResultItem
+	for _, c := range collections {
+		if len(folded) >= finderDigMaxCards {
+			break
+		}
+		if !s.emit(ctx, events, FinderEvent{Type: FinderEventDigging, CollectionTitle: c.title}) {
+			return folded
+		}
+
+		entry := s.MultiResolver.ResolveFromURLN(ctx, c.url, finderPerCollectionCardCap)
+		if entry == nil {
+			continue
+		}
+
+		var batch []FinderResultItem
+		for _, card := range s.waitForCollection(ctx, entry) {
+			if len(folded)+len(batch) >= finderDigMaxCards {
+				break
+			}
+			// Only fold recipes that finished extracting and have a cache key —
+			// the folded URL must be an instant cache hit on tap.
+			if card.ExtractionStatus != "done" {
+				continue
+			}
+			cached := strings.TrimSpace(card.CachedURL)
+			if cached == "" {
+				continue
+			}
+			batch = append(batch, FinderResultItem{
+				Result: ai.SearchResult{
+					Title:       card.Title,
+					URL:         cached,
+					Source:      hostOf(cached),
+					ImageURL:    card.ImageURL,
+					Description: card.Description,
+				},
+				Reason: fmt.Sprintf("from '%s'", c.title),
+			})
+		}
+		if len(batch) == 0 {
+			continue
+		}
+		folded = append(folded, batch...)
+		if !s.emit(ctx, events, FinderEvent{Type: FinderEventExpanded, Items: batch, CollectionTitle: c.title}) {
+			return folded
+		}
+	}
+	return folded
+}
+
+// waitForCollection polls a resolving collection until it is terminal (resolved
+// or failed) or finderDigWait elapses, returning whatever cards exist then.
+func (s *RecipeFinderService) waitForCollection(ctx context.Context, entry *MultiRecipeEntry) []MultiRecipeCard {
+	deadline := time.After(finderDigWait)
+	ticker := time.NewTicker(300 * time.Millisecond)
+	defer ticker.Stop()
+	for {
+		if status := entry.GetStatus(); status == "resolved" || status == "failed" {
+			return entry.GetCards()
+		}
+		select {
+		case <-ctx.Done():
+			return entry.GetCards()
+		case <-deadline:
+			return entry.GetCards()
+		case <-ticker.C:
+		}
+	}
+}
+
+// autoSaveSession persists a completed first-page finder run for history. It is
+// ungated and best-effort: only first-page runs with at least one result are
+// saved, on a context detached from the request (so a client disconnect after
+// "done" doesn't cancel the write), and any error is logged, never surfaced.
+func (s *RecipeFinderService) autoSaveSession(user *models.User, req FinderRequest, query string, foundCount, foldedCount int, assembled []FinderResultItem) {
+	if s.Sessions == nil || user == nil || req.Offset != 0 || len(assembled) == 0 {
+		return
+	}
+
+	results := make(models.SearchResultList, 0, len(assembled))
+	for _, it := range assembled {
+		results = append(results, models.SearchResultItem{
+			Title:       it.Result.Title,
+			URL:         it.Result.URL,
+			Source:      it.Result.Source,
+			Rating:      it.Result.Rating,
+			ImageURL:    it.Result.ImageURL,
+			Description: it.Result.Description,
+		})
+	}
+
+	narration := models.StringList{
+		fmt.Sprintf("Searched for %q", query),
+		fmt.Sprintf("Found %d recipes", foundCount),
+	}
+	if foldedCount > 0 {
+		narration = append(narration, fmt.Sprintf("Dug %d more from collections", foldedCount))
+	}
+	narration = append(narration, fmt.Sprintf("Shortlisted %d", len(assembled)))
+
+	session := &models.FinderSession{
+		UserID:    user.ID,
+		Title:     finderSessionTitle(req),
+		Intent:    finderIntent(req),
+		Results:   results,
+		Narration: narration,
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	if err := s.Sessions.Save(ctx, session); err != nil {
+		logger.Get().Warn("failed to auto-save finder session", zap.Uint("user_id", user.ID), zap.Error(err))
+	}
+}
+
+// finderIntent maps a finder request to its persisted intent shape.
+func finderIntent(req FinderRequest) models.FinderIntent {
+	f := effectiveFacets(req)
+	return models.FinderIntent{
+		Occasion:     f.Occasion,
+		TimeBudget:   f.TimeBudget,
+		Protein:      f.Protein,
+		Cuisine:      f.Cuisine,
+		UseWhatIHave: f.UseWhatIHave,
+		SurpriseMe:   f.SurpriseMe,
+		FreeText:     strings.TrimSpace(req.FreeText),
+	}
+}
+
+// finderSessionTitle derives a short, human title for a saved run from its facets.
+func finderSessionTitle(req FinderRequest) string {
+	f := effectiveFacets(req)
+	parts := appendNonEmpty(nil, f.Protein, f.Cuisine, f.Occasion, f.TimeBudget)
+	if ft := strings.TrimSpace(req.FreeText); ft != "" {
+		parts = append(parts, ft)
+	}
+	title := strings.TrimSpace(strings.Join(parts, " "))
+	if title == "" {
+		if f.SurpriseMe {
+			return "Surprise me"
+		}
+		return "Recipe finder"
+	}
+	const maxTitle = 80
+	if len(title) > maxTitle {
+		title = strings.TrimSpace(title[:maxTitle])
+	}
+	return title
+}
+
+// hostOf returns the host of a URL, or "" if it cannot be parsed.
+func hostOf(rawURL string) string {
+	u, err := url.Parse(rawURL)
+	if err != nil {
+		return ""
+	}
+	return u.Host
 }
 
 // rankCandidates runs the single ranking model call. On any error it degrades

--- a/internal/service/recipe_finder_digging_test.go
+++ b/internal/service/recipe_finder_digging_test.go
@@ -1,0 +1,258 @@
+package service
+
+import (
+	"context"
+	"fmt"
+	"testing"
+
+	"github.com/windoze95/saltybytes-api/internal/ai"
+	"github.com/windoze95/saltybytes-api/internal/testutil"
+)
+
+// fakeMultiResolver is an offline MultiResolver: it records which URLs were
+// resolved and returns pre-built entries, so digging can be tested without any
+// network or background extraction.
+type fakeMultiResolver struct {
+	entries map[string]*MultiRecipeEntry
+	calls   []string
+}
+
+func (f *fakeMultiResolver) ResolveFromURLN(ctx context.Context, sourceURL string, maxCards int) *MultiRecipeEntry {
+	f.calls = append(f.calls, sourceURL)
+	return f.entries[sourceURL]
+}
+
+// resolvedEntry builds a *MultiRecipeEntry already in the "resolved" state so
+// waitForCollection returns its cards immediately.
+func resolvedEntry(sourceURL string, cards ...MultiRecipeCard) *MultiRecipeEntry {
+	return &MultiRecipeEntry{
+		ID:        "multi_test_" + sourceURL,
+		SourceURL: sourceURL,
+		Status:    "resolved",
+		Cards:     cards,
+	}
+}
+
+func doneCard(title, cachedURL string) MultiRecipeCard {
+	return MultiRecipeCard{Title: title, ExtractionStatus: "done", CachedURL: cachedURL, Description: title + " desc"}
+}
+
+func indexOfType(events []FinderEvent, t FinderEventType) int {
+	for i, ev := range events {
+		if ev.Type == t {
+			return i
+		}
+	}
+	return -1
+}
+
+// digSearchResults builds n distinct real search candidates.
+func digSearchResults(n int) []ai.SearchResult {
+	out := make([]ai.SearchResult, n)
+	for i := range out {
+		out[i] = ai.SearchResult{
+			Title:       fmt.Sprintf("Candidate %d", i),
+			URL:         fmt.Sprintf("https://example.com/c%d", i),
+			Source:      "example.com",
+			Description: "desc",
+		}
+	}
+	return out
+}
+
+// rankAllFlagging ranks every candidate in order, flagging the given indices as
+// expandable collections with the supplied priorities.
+func rankAllFlagging(results []ai.SearchResult, flags map[int]int) *testutil.MockTextProvider {
+	return &testutil.MockTextProvider{
+		ExpandAndRankRecipesFunc: func(ctx context.Context, req ai.FinderRankRequest) (*ai.FinderRankResult, error) {
+			ranked := make([]ai.FinderRanking, len(results))
+			for i := range results {
+				r := ai.FinderRanking{Index: i, Reason: "fits"}
+				if prio, ok := flags[i]; ok {
+					r.Expand = true
+					r.ExpandPriority = prio
+				}
+				ranked[i] = r
+			}
+			return &ai.FinderRankResult{Ranked: ranked}, nil
+		},
+	}
+}
+
+func TestFindRecipes_DigsFlaggedCollection(t *testing.T) {
+	results := digSearchResults(3)
+	searchProvider := &testutil.MockSearchProvider{
+		SearchRecipesFunc: func(ctx context.Context, query string, count, offset int) ([]ai.SearchResult, error) {
+			return results, nil
+		},
+	}
+	// Flag candidate 1 as a collection.
+	ranker := rankAllFlagging(results, map[int]int{1: 5})
+
+	fake := &fakeMultiResolver{entries: map[string]*MultiRecipeEntry{
+		results[1].URL: resolvedEntry(results[1].URL,
+			doneCard("Child A", "https://example.com/child-a?_recipe=child-a-0"),
+			doneCard("Child B", "https://example.com/child-b"),
+			MultiRecipeCard{Title: "Still Pending", ExtractionStatus: "pending"}, // must be skipped
+		),
+	}}
+
+	svc := newFinderService(searchProvider, ranker, &testutil.MockFamilyRepo{})
+	svc.MultiResolver = fake
+
+	events := runFinder(svc, testutil.TestUser(), FinderRequest{Facets: FinderFacets{Protein: "chicken"}})
+
+	// digging then expanded appear, after the shortlist and before done.
+	di := indexOfType(events, FinderEventDigging)
+	ei := indexOfType(events, FinderEventExpanded)
+	si := indexOfType(events, FinderEventShortlist)
+	done := indexOfType(events, FinderEventDone)
+	if si < 0 || di < 0 || ei < 0 || done < 0 {
+		t.Fatalf("missing events (order: %v)", eventTypes(events))
+	}
+	if !(si < di && di < ei && ei < done) {
+		t.Errorf("event order wrong: shortlist=%d digging=%d expanded=%d done=%d (%v)", si, di, ei, done, eventTypes(events))
+	}
+
+	// digging names the collection.
+	dig, _ := firstEventOfType(events, FinderEventDigging)
+	if dig.CollectionTitle != results[1].Title {
+		t.Errorf("digging collection_title = %q, want %q", dig.CollectionTitle, results[1].Title)
+	}
+
+	// expanded folds the two DONE cards (pending dropped), by CachedURL, with the
+	// "from '<collection>'" reason.
+	exp, _ := firstEventOfType(events, FinderEventExpanded)
+	if len(exp.Items) != 2 {
+		t.Fatalf("expanded has %d items, want 2 (pending card must be dropped)", len(exp.Items))
+	}
+	wantReason := fmt.Sprintf("from '%s'", results[1].Title)
+	wantURLs := map[string]bool{"https://example.com/child-a?_recipe=child-a-0": true, "https://example.com/child-b": true}
+	for _, it := range exp.Items {
+		if it.Reason != wantReason {
+			t.Errorf("folded reason = %q, want %q", it.Reason, wantReason)
+		}
+		if !wantURLs[it.Result.URL] {
+			t.Errorf("folded URL = %q, want one of the cards' CachedURL", it.Result.URL)
+		}
+	}
+
+	// Only the flagged collection was resolved, exactly once.
+	if len(fake.calls) != 1 || fake.calls[0] != results[1].URL {
+		t.Errorf("resolver calls = %v, want exactly [%s]", fake.calls, results[1].URL)
+	}
+}
+
+func TestFindRecipes_DigCapsAndPrioritizes(t *testing.T) {
+	results := digSearchResults(4)
+	searchProvider := &testutil.MockSearchProvider{
+		SearchRecipesFunc: func(ctx context.Context, query string, count, offset int) ([]ai.SearchResult, error) {
+			return results, nil
+		},
+	}
+	// Flag three collections with distinct priorities: 2 (low), 1 (high), 3 (mid).
+	ranker := rankAllFlagging(results, map[int]int{2: 1, 1: 9, 3: 5})
+
+	entries := map[string]*MultiRecipeEntry{}
+	for _, idx := range []int{1, 2, 3} {
+		entries[results[idx].URL] = resolvedEntry(results[idx].URL, doneCard("Child", "https://example.com/child"+fmt.Sprint(idx)))
+	}
+	fake := &fakeMultiResolver{entries: entries}
+
+	svc := newFinderService(searchProvider, ranker, &testutil.MockFamilyRepo{})
+	svc.MultiResolver = fake
+
+	_ = runFinder(svc, testutil.TestUser(), FinderRequest{Facets: FinderFacets{Protein: "chicken"}})
+
+	// Only finderDigK collections are dug, highest ExpandPriority first.
+	if len(fake.calls) != finderDigK {
+		t.Fatalf("resolver called %d times, want finderDigK=%d (%v)", len(fake.calls), finderDigK, fake.calls)
+	}
+	if fake.calls[0] != results[1].URL || fake.calls[1] != results[3].URL {
+		t.Errorf("dug %v, want highest-priority [%s %s]", fake.calls, results[1].URL, results[3].URL)
+	}
+}
+
+func TestFindRecipes_DigCapsTotalFolded(t *testing.T) {
+	results := digSearchResults(2)
+	searchProvider := &testutil.MockSearchProvider{
+		SearchRecipesFunc: func(ctx context.Context, query string, count, offset int) ([]ai.SearchResult, error) {
+			return results, nil
+		},
+	}
+	ranker := rankAllFlagging(results, map[int]int{1: 5})
+
+	// A single collection with more DONE cards than finderDigMaxCards.
+	var cards []MultiRecipeCard
+	for i := 0; i < finderDigMaxCards+4; i++ {
+		cards = append(cards, doneCard(fmt.Sprintf("Child %d", i), fmt.Sprintf("https://example.com/child-%d", i)))
+	}
+	fake := &fakeMultiResolver{entries: map[string]*MultiRecipeEntry{
+		results[1].URL: resolvedEntry(results[1].URL, cards...),
+	}}
+
+	svc := newFinderService(searchProvider, ranker, &testutil.MockFamilyRepo{})
+	svc.MultiResolver = fake
+
+	events := runFinder(svc, testutil.TestUser(), FinderRequest{Facets: FinderFacets{Protein: "chicken"}})
+
+	totalFolded := 0
+	for _, ev := range events {
+		if ev.Type == FinderEventExpanded {
+			totalFolded += len(ev.Items)
+		}
+	}
+	if totalFolded > finderDigMaxCards {
+		t.Errorf("folded %d recipes, want <= finderDigMaxCards=%d", totalFolded, finderDigMaxCards)
+	}
+}
+
+func TestFindRecipes_NoDigWhenNothingFlagged(t *testing.T) {
+	results := digSearchResults(3)
+	searchProvider := &testutil.MockSearchProvider{
+		SearchRecipesFunc: func(ctx context.Context, query string, count, offset int) ([]ai.SearchResult, error) {
+			return results, nil
+		},
+	}
+	ranker := rankAllFlagging(results, nil) // nothing flagged
+
+	fake := &fakeMultiResolver{entries: map[string]*MultiRecipeEntry{}}
+	svc := newFinderService(searchProvider, ranker, &testutil.MockFamilyRepo{})
+	svc.MultiResolver = fake
+
+	events := runFinder(svc, testutil.TestUser(), FinderRequest{Facets: FinderFacets{Protein: "chicken"}})
+
+	if n := countEventsOfType(events, FinderEventDigging) + countEventsOfType(events, FinderEventExpanded); n != 0 {
+		t.Errorf("emitted %d dig events with nothing flagged, want 0 (%v)", n, eventTypes(events))
+	}
+	if len(fake.calls) != 0 {
+		t.Errorf("resolver called %v with nothing flagged, want none", fake.calls)
+	}
+}
+
+func TestFindRecipes_NoDigWhenShortlistFull(t *testing.T) {
+	// A full direct shortlist (>= finderDigMinDirect) means no need to dig, even
+	// though a collection is flagged.
+	results := digSearchResults(finderDigMinDirect)
+	searchProvider := &testutil.MockSearchProvider{
+		SearchRecipesFunc: func(ctx context.Context, query string, count, offset int) ([]ai.SearchResult, error) {
+			return results, nil
+		},
+	}
+	ranker := rankAllFlagging(results, map[int]int{0: 5})
+
+	fake := &fakeMultiResolver{entries: map[string]*MultiRecipeEntry{
+		results[0].URL: resolvedEntry(results[0].URL, doneCard("Child", "https://example.com/child")),
+	}}
+	svc := newFinderService(searchProvider, ranker, &testutil.MockFamilyRepo{})
+	svc.MultiResolver = fake
+
+	events := runFinder(svc, testutil.TestUser(), FinderRequest{Facets: FinderFacets{Protein: "chicken"}})
+
+	if n := countEventsOfType(events, FinderEventDigging); n != 0 {
+		t.Errorf("dug despite a full shortlist (%d direct), want no digging", len(results))
+	}
+	if len(fake.calls) != 0 {
+		t.Errorf("resolver called %v despite a full shortlist, want none", fake.calls)
+	}
+}

--- a/internal/testutil/mocks.go
+++ b/internal/testutil/mocks.go
@@ -3,6 +3,7 @@ package testutil
 import (
 	"context"
 	"fmt"
+	"sort"
 	"sync"
 	"time"
 
@@ -990,6 +991,90 @@ func (m *MockFamilyRepo) GetOrCreateDietaryProfile(memberID uint) (*models.Dieta
 	return &models.DietaryProfile{MemberID: memberID}, nil
 }
 
+// --- MockFinderSessionRepo ---
+
+// MockFinderSessionRepo is an in-memory mock of repository.FinderSessionRepo.
+// Created sessions are recorded (survive deletion) so tests can assert on
+// auto-save behaviour; ListByUser returns a user's sessions newest-first.
+type MockFinderSessionRepo struct {
+	mu       sync.Mutex
+	sessions map[uint]*models.FinderSession
+	created  []*models.FinderSession
+	nextID   uint
+
+	CreateErr error
+}
+
+// NewMockFinderSessionRepo creates an empty in-memory finder-session repo.
+func NewMockFinderSessionRepo() *MockFinderSessionRepo {
+	return &MockFinderSessionRepo{sessions: make(map[uint]*models.FinderSession)}
+}
+
+func (m *MockFinderSessionRepo) Create(ctx context.Context, session *models.FinderSession) error {
+	if m.CreateErr != nil {
+		return m.CreateErr
+	}
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	m.nextID++
+	session.ID = m.nextID
+	cp := *session
+	m.sessions[session.ID] = &cp
+	created := *session
+	m.created = append(m.created, &created)
+	return nil
+}
+
+func (m *MockFinderSessionRepo) ListByUser(ctx context.Context, userID uint, limit, offset int) ([]models.FinderSession, int64, error) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	var all []models.FinderSession
+	for _, s := range m.sessions {
+		if s.UserID == userID {
+			all = append(all, *s)
+		}
+	}
+	sort.Slice(all, func(i, j int) bool { return all[i].ID > all[j].ID }) // newest first
+	total := int64(len(all))
+	if offset >= len(all) {
+		return []models.FinderSession{}, total, nil
+	}
+	end := offset + limit
+	if end > len(all) {
+		end = len(all)
+	}
+	return all[offset:end], total, nil
+}
+
+func (m *MockFinderSessionRepo) GetByID(ctx context.Context, id uint) (*models.FinderSession, error) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	s, ok := m.sessions[id]
+	if !ok {
+		return nil, gorm.ErrRecordNotFound
+	}
+	cp := *s
+	return &cp, nil
+}
+
+func (m *MockFinderSessionRepo) Delete(ctx context.Context, id uint) error {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	delete(m.sessions, id)
+	return nil
+}
+
+// Created returns a race-safe snapshot of every created session.
+func (m *MockFinderSessionRepo) Created() []models.FinderSession {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	out := make([]models.FinderSession, len(m.created))
+	for i, s := range m.created {
+		out[i] = *s
+	}
+	return out
+}
+
 // --- MockCanonicalRecipeRepo ---
 
 // MockCanonicalRecipeRepo mocks repository.CanonicalRecipeRepo for testing.
@@ -1145,4 +1230,5 @@ var _ repository.UserRepo = (*MockUserRepo)(nil)
 var _ repository.SearchCacheRepo = (*MockSearchCacheRepo)(nil)
 var _ repository.CanonicalRecipeRepo = (*MockCanonicalRecipeRepo)(nil)
 var _ repository.FamilyRepo = (*MockFamilyRepo)(nil)
+var _ repository.FinderSessionRepo = (*MockFinderSessionRepo)(nil)
 var _ repository.VideoImportRepo = (*MockVideoImportRepo)(nil)


### PR DESCRIPTION
## Backend: agentic multi-recipe digging + saved finder-run history

Two additive Recipe Finder enhancements in one PR (they're intertwined in `recipe_finder.go`). Both **ship dark** — old apps ignore the new SSE events; the new table + endpoints don't touch existing contracts.

### Part A — Agentic multi-recipe digging (everyone, bounded)
- **Ranker flags collections, no extra model call:** additive `Expand`/`ExpandPriority` on `ai.FinderRanking` + `expand`/`expand_priority` in the shared `rank_recipes` schema, tool-result struct and parser (the Gemini light tier gets it for free) + one system-prompt line.
- **Bounded resolver:** `MultiRecipeCard` gains `CachedURL` (set in **both** cache branches of `extractSingleCard` — own-page URL for listicles, `?_recipe=slug` URL for inline). New `MultiResolver` interface with `ResolveFromURLN(ctx, url, maxCards)` that truncates cards **before** assign/register/extract; the finder depends only on this seam so its tests stay offline.
- **`digCollections`** runs between the `shortlist` and `warming` emits, only when the direct shortlist is thin (`< finderDigMinDirect=8`) and ≥1 candidate is flagged. It digs the top `finderDigK=2` collections by `ExpandPriority`, emits `digging{collection_title}`, resolves each (cap `finderPerCollectionCardCap=6`), polls the registry (300ms, cap `finderDigWait=4s`), and folds **done** cards into `expanded{items}` as `FinderResultItem{URL: CachedURL, Reason: "from '<title>'"}`, capped at `finderDigMaxCards=6` total. Never invents — every folded recipe is a real extraction. New `FinderEventDigging`/`FinderEventExpanded` + a `CollectionTitle` field.

### Part B — Session history + server-side auto-save (ungated)
- **New `FinderSession` entity** end-to-end (mirrors `Family`): model with JSONB `Intent`/`Results`/`Narration` (reusing `SearchResultList` + `StringList` for the app wire shape) + `AutoMigrate`; `FinderSessionRepository` + `FinderSessionRepo` interface (+ compile-time assert); `FinderSessionService` with ownership-checked `Get`/`Delete` and paginated newest-first `List`; `FinderSessionHandler`; routes `GET /v1/recipes/finder/sessions`, `GET`/`DELETE /:session_id` — **no** subscription gate.
- **Auto-save hook:** nil-safe `Sessions` on `RecipeFinderService`; after the terminal `done`, first-page runs with results are saved on a **detached 5s context** (best-effort, warn-on-error). Saved `Results` = the shortlist plus everything dug from collections; `Title` auto-derived from facets/free text.

Wired in `router.go`: `finderService.MultiResolver = multiResolver` (already built for search) + `finderService.Sessions = finderSessionService`.

### AS-BUILT contract for the app phase

**New SSE events** (added to the existing `/recipes/find` stream, between `shortlist` and `warming`):
```
event: digging
data:  { "type": "digging",  "collection_title": "23 Best Weeknight Dinners" }

event: expanded
data:  { "type": "expanded", "collection_title": "23 Best Weeknight Dinners",
         "items": [ { "result": <SearchResult>, "reason": "from '23 Best Weeknight Dinners'" }, ... ] }
```
- `result` is the usual `SearchResult` shape (`title`, `source_url`, `source_domain`, `image_url`, `description`); `source_url` is the folded recipe's **CachedURL** (an instant cache hit on tap). Items stream in batches, one `expanded` per dug collection. A run may emit zero, one, or two `digging`/`expanded` pairs.

**`FinderSession` JSON** (list item and detail share the shape):
```
{
  "id": 12, "user_id": 1, "created_at": "...", "updated_at": "...",
  "title": "chicken dinner",
  "intent":   { "occasion": "...", "time_budget": "...", "protein": "...", "cuisine": "...",
                "use_what_i_have": ["..."], "surprise_me": false, "free_text": "..." },
  "results":  [ { "title": "...", "source_url": "...", "source_domain": "...", "rating": 0,
                  "image_url": "...", "description": "..." }, ... ],
  "narration": [ "Searched for \"chicken dinner recipe\"", "Found 10 recipes", "Shortlisted 6" ]
}
```

**Session endpoints** (all under `apiProtected`, bearer auth, **no** gate):
- `GET /v1/recipes/finder/sessions?page=&page_size=` → `{ "sessions": [FinderSession...], "total": N, "page": P, "page_size": S }` (newest first)
- `GET /v1/recipes/finder/sessions/:session_id` → `{ "session": FinderSession }` (404 if not found / not owned)
- `DELETE /v1/recipes/finder/sessions/:session_id` → `{ "message": "session deleted" }` (404 if not found / not owned; soft delete)

### Verification
`recipe_finder_digging_test.go` (fake `MultiResolver` → digging→expanded order, folded reason + `URL==CachedURL`, resolver called ≤K only for flagged URLs highest-priority-first, folded ≤ maxCards, no dig when nothing flagged, no dig when the shortlist is full) and `finder_session_test.go` (Save/List/Get/Delete + ownership; auto-save `Create` once at `done`, none on `offset>0`). New `MockFinderSessionRepo`. `go build ./...`, `go vet ./...`, `go test ./... -count=1` all green + **offline** (new tests also pass under `-race`).

### Deviations (reasonable calls)
1. `FinderSessionRepository` methods take `ctx` (Family's don't) so the detached 5s auto-save bound is real via `WithContext`.
2. Auto-save runs **synchronously** with a detached `context.Background()`+5s (survives client disconnect; the client already sees `done` and the response is flushed, so it isn't blocked) — simpler and testable vs. a goroutine.
3. Ownership violations return **404** (not 403) so a user can't probe for others' sessions.
4. Expand-flagged collections remain in the direct shortlist (buildShortlist unchanged); digging adds their children additively.
5. Narration is derived server-side (query + counts) since its content was unspecified.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
https://claude.ai/code/session_01BU4UWZutHd1AnK3XAf7H19
