### PR TITLE
Finder rank: survive Gemini MALFORMED_FUNCTION_CALL + fail closed on known collections

### DIFF
--- a/internal/ai/anthropic.go
+++ b/internal/ai/anthropic.go
@@ -384,7 +384,7 @@ func estimatePortionsTool() anthropic.ToolUnionParam {
 // an inline prompt (like EstimatePortions') rather than a config template, so
 // the finder is self-contained. The hard rule — reference candidates only by
 // index, never invent — is enforced structurally by the tool schema too.
-const finderRankSystemPrompt = `You are a recipe-finding assistant. You are given a list of REAL recipe search results (candidates), each with an index, a URL, a title, a source and a description, plus a description of what the user wants (facets, free text, and their family's dietary needs).
+const finderRankSystemPromptCore = `You are a recipe-finding assistant. You are given a list of REAL recipe search results (candidates), each with an index, a URL, a title, a source and a description, plus a description of what the user wants (facets, free text, and their family's dietary needs).
 
 Select the candidates that best match the request and return them, best match first, using ONLY their given index. Never invent a recipe and never return an index that is not in the candidate list. It is fine to return fewer candidates than you were given; drop ones that clearly do not fit.
 
@@ -400,7 +400,14 @@ For each candidate you return also:
 - Give one short sentence (reason) explaining why it fits — for a collection, say what it collects.
 - Give a best-effort dietary safety assessment for each family member mentioned in the dietary needs, judging ONLY from the candidate's title and description: "safe" if nothing conflicts, "caution" if it might conflict or is unclear, "avoid" if it clearly conflicts with an allergy or restriction. Keep the note short. Omit members you cannot assess.
 
-Also suggest 2-4 broadened search queries (broaden_queries) the user could try to get more options.
+Also suggest 2-4 broadened search queries (broaden_queries) the user could try to get more options.`
+
+// finderRankSystemPrompt is the tool-calling variant used by the Anthropic
+// implementation. The OpenAI-compatible light tier appends a JSON-output
+// instruction instead (see openai_maintier.go): Gemini's function-call parser
+// intermittently rejects large rank_recipes calls outright
+// (MALFORMED_FUNCTION_CALL), so that path uses schema-constrained JSON.
+const finderRankSystemPrompt = finderRankSystemPromptCore + `
 
 Return everything via the rank_recipes tool.`
 
@@ -1567,13 +1574,14 @@ func (p *AnthropicProvider) ExpandAndRankRecipes(ctx context.Context, req Finder
 
 		params := anthropic.MessageNewParams{
 			Model: p.model,
-			// 2048 (not 512): the rank_recipes tool JSON for ~10 candidates with
-			// per-item reason + per-member safety[] + expand/expand_priority +
-			// broaden_queries runs ~1000-1500 output tokens with any family
+			// Generous (not 512): the rank_recipes tool JSON for ~10 candidates
+			// with per-item reason + per-member safety[] + expand/expand_priority
+			// + broaden_queries runs ~1000-1500 output tokens with any family
 			// profile. 512 truncated it → parse error → unranked, flag-less,
-			// reason-less fallback (the "feels like plain search" bug). The parse
-			// is also truncation-tolerant now as a backstop.
-			MaxTokens: 2048,
+			// reason-less fallback (the "feels like plain search" bug). Billed by
+			// actual tokens, so headroom is free; the parse is also
+			// truncation-tolerant as a backstop.
+			MaxTokens: 4096,
 			System:    buildCachedSystemPrompt(finderRankSystemPrompt, ""),
 			Messages: []anthropic.MessageParam{
 				newUserMessage(anthropic.NewTextBlock(string(payload))),

--- a/internal/ai/errors_test.go
+++ b/internal/ai/errors_test.go
@@ -193,6 +193,15 @@ func TestClassifyOpenAIError(t *testing.T) {
 		{"401 does not retry", &openai.APIError{HTTPStatusCode: 401}, false, 0},
 		{"plain error does not retry", errors.New("dial tcp: timeout"), false, 0},
 		{"wrapped API error still classified", fmt.Errorf("outer: %w", &openai.APIError{HTTPStatusCode: 429}), true, 2 * time.Second},
+		// Gemini's OpenAI-compat endpoint wraps error bodies in a JSON ARRAY,
+		// which go-openai can't unmarshal into ErrorResponse — those surface as
+		// *openai.RequestError, not *openai.APIError. They must retry by HTTP
+		// status too (a prod Gemini 429 on 2026-07-01 was returned terminal
+		// because only APIError was recognized).
+		{"RequestError 429 (Gemini array body) retries", &openai.RequestError{HTTPStatusCode: 429, Err: errors.New("json: cannot unmarshal array into Go value of type openai.ErrorResponse")}, true, 2 * time.Second},
+		{"RequestError 500 retries", &openai.RequestError{HTTPStatusCode: 500, Err: errors.New("boom")}, true, 2 * time.Second},
+		{"RequestError 401 does not retry", &openai.RequestError{HTTPStatusCode: 401, Err: errors.New("bad key")}, false, 0},
+		{"wrapped RequestError 429 still classified", fmt.Errorf("gemini chat completion error: %w", &openai.RequestError{HTTPStatusCode: 429, Err: errors.New("quota")}), true, 2 * time.Second},
 	}
 
 	for _, tc := range tests {

--- a/internal/ai/finder_rank_stress_live_test.go
+++ b/internal/ai/finder_rank_stress_live_test.go
@@ -1,0 +1,113 @@
+package ai
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"testing"
+)
+
+// prodShapedRankRequest mirrors what a real prod finder run sends the ranker:
+// a full 10-candidate search page (with several roundup/collection hits), a
+// multi-member family diet summary, and personalization context. The original
+// live test used 2 candidates and no family — it passed while prod failed,
+// because Gemini 2.5 Flash spends completion budget on thinking and a
+// prod-sized payload thinks well past a small MaxTokens before emitting the
+// forced tool call.
+func prodShapedRankRequest() FinderRankRequest {
+	return FinderRankRequest{
+		Facets:      "occasion: quick weeknight; time: under 30 minutes; protein: chicken",
+		FreeText:    "something cozy the kids will actually eat",
+		DietSummary: "Junior: allergic to peanuts, intolerant to lactose; Sam: vegetarian on weekdays, no cilantro; Alex: allergic to shellfish, low sodium",
+		UnitSystem:  "US customary",
+		CookingContext: "Cooks for a family of five on weeknights; prefers one-pan meals " +
+			"and minimal cleanup; has an instant pot and an air fryer.",
+		Requirements: "Avoid deep frying. Prefer recipes with a make-ahead component.",
+		Candidates: []FinderCandidate{
+			{Index: 0, Title: "Sheet-Pan Lemon Garlic Chicken Thighs", URL: "https://cooking.example/recipes/sheet-pan-lemon-garlic-chicken", Source: "cooking.example", Description: "Crispy chicken thighs roasted with baby potatoes and green beans in one pan — a 35-minute weeknight staple."},
+			{Index: 1, Title: "40 Easy Weeknight Dinner Recipes", URL: "https://mealsite.example/gallery/40-easy-weeknight-dinners", Source: "mealsite.example", Description: "Our 40 favorite quick dinners for busy nights, from pastas to stir-fries."},
+			{Index: 2, Title: "Creamy Tuscan Chicken Pasta", URL: "https://pastalove.example/creamy-tuscan-chicken-pasta", Source: "pastalove.example", Description: "Sun-dried tomatoes, spinach and parmesan in a silky cream sauce over penne, ready in 30 minutes."},
+			{Index: 3, Title: "25 Best Chicken Dinner Ideas for Busy Families", URL: "https://familyeats.example/roundups/25-best-chicken-dinners", Source: "familyeats.example", Description: "From casseroles to skillet meals, twenty-five reader-favorite chicken dinners."},
+			{Index: 4, Title: "One-Pot Chicken and Rice", URL: "https://simplesuppers.example/one-pot-chicken-and-rice", Source: "simplesuppers.example", Description: "A comforting one-pot classic with turmeric rice and juicy chicken, minimal cleanup."},
+			{Index: 5, Title: "Air Fryer Chicken Tenders (Kid Favorite!)", URL: "https://airfrieddaily.example/chicken-tenders", Source: "airfrieddaily.example", Description: "Crunchy panko tenders in 15 minutes with a honey mustard dip kids love."},
+			{Index: 6, Title: "Slow Cooker Salsa Chicken Tacos", URL: "https://tacotuesday.example/slow-cooker-salsa-chicken", Source: "tacotuesday.example", Description: "Three-ingredient shredded chicken tacos that cook while you work."},
+			{Index: 7, Title: "31 Quick Dinners to Make in July", URL: "https://seasonalplates.example/collections/31-quick-july-dinners", Source: "seasonalplates.example", Description: "A month of fast summer dinner inspiration, one for every night."},
+			{Index: 8, Title: "Skillet Chicken Parmesan", URL: "https://weeknightitalian.example/skillet-chicken-parm", Source: "weeknightitalian.example", Description: "Lightly breaded cutlets under bubbling mozzarella and marinara, no oven needed."},
+			{Index: 9, Title: "Instant Pot Chicken Noodle Soup", URL: "https://pressureluck.example/instant-pot-chicken-noodle", Source: "pressureluck.example", Description: "Classic comfort in 25 minutes, with shredded rotisserie-style chicken and egg noodles."},
+		},
+	}
+}
+
+// TestExpandAndRankRecipes_Live_ProdShapedStress runs the REAL light tier with
+// a prod-shaped payload several times in a row and requires every attempt to
+// succeed AND to flag the three collection candidates. This is the regression
+// bar for the "no rank_recipes tool call" / thinking-budget failure seen in
+// prod on 2026-07-01 (a run that returns no tool call or misses the obvious
+// roundups means the harness regressed).
+//
+// Run with:
+//
+//	FINDER_LIVE_TEST=1 \
+//	LIGHT_API_KEY=<gemini key> LIGHT_BASE_URL=<gemini openai-compat base> LIGHT_MODEL=gemini-2.5-flash \
+//	go test ./internal/ai/ -run TestExpandAndRankRecipes_Live_ProdShapedStress -v
+func TestExpandAndRankRecipes_Live_ProdShapedStress(t *testing.T) {
+	if os.Getenv("FINDER_LIVE_TEST") == "" {
+		t.Skip("set FINDER_LIVE_TEST=1 + a light-tier key (LIGHT_API_KEY/GEMINI_API_KEY), optional LIGHT_BASE_URL/LIGHT_MODEL, to run the prod-shaped live stress test")
+	}
+	apiKey := firstNonEmptyEnv("LIGHT_API_KEY", "GEMINI_API_KEY", "OPENAI_API_KEY")
+	if apiKey == "" {
+		t.Skip("no light-tier API key (LIGHT_API_KEY / GEMINI_API_KEY) set")
+	}
+	model := os.Getenv("LIGHT_MODEL")
+	if model == "" {
+		model = "gemini-2.5-flash"
+	}
+
+	p := NewOpenAICompatProvider(apiKey, os.Getenv("LIGHT_BASE_URL"), model, "gemini", testPrompts())
+
+	const attempts = 5
+	collectionIdx := map[int]bool{1: true, 3: true, 7: true}
+	var failures []string
+	for i := 0; i < attempts; i++ {
+		res, err := p.ExpandAndRankRecipes(context.Background(), prodShapedRankRequest())
+		if err != nil {
+			failures = append(failures, fmt.Sprintf("attempt %d: call failed: %v", i+1, err))
+			continue
+		}
+		// The product invariant: a collection candidate must NEVER be returned
+		// with expand=false (that is what paints a roundup as a recipe card).
+		// Being dropped from the ranking entirely is fine — dropped candidates
+		// are never shown. And no single recipe may be flagged as a collection.
+		anyCollectionHandled := false
+		for _, r := range res.Ranked {
+			if collectionIdx[r.Index] {
+				if !r.Expand {
+					failures = append(failures, fmt.Sprintf("attempt %d: collection candidate %d returned with expand=false", i+1, r.Index))
+				} else {
+					anyCollectionHandled = true
+				}
+			} else if r.Expand {
+				failures = append(failures, fmt.Sprintf("attempt %d: single recipe %d wrongly flagged expand=true", i+1, r.Index))
+			}
+		}
+		// The on-topic roundups (1: weeknight dinners, 3: chicken dinners) are
+		// strong matches — at least one collection should be flagged for digging
+		// rather than all of them dropped.
+		if !anyCollectionHandled {
+			failures = append(failures, fmt.Sprintf("attempt %d: no collection flagged expand=true at all (ranked=%v)", i+1, res.Ranked))
+		}
+	}
+
+	if len(failures) > 0 {
+		t.Fatalf("prod-shaped rank stress: %d problem(s) across %d attempts:\n%s",
+			len(failures), attempts, joinLines(failures))
+	}
+}
+
+func joinLines(lines []string) string {
+	out := ""
+	for _, l := range lines {
+		out += "  - " + l + "\n"
+	}
+	return out
+}

--- a/internal/ai/openai_dalle.go
+++ b/internal/ai/openai_dalle.go
@@ -87,5 +87,16 @@ func classifyOpenAIError(err error) (shouldRetry bool, waitTime time.Duration) {
 			return false, 0
 		}
 	}
+	// Some OpenAI-compatible endpoints (Gemini) wrap error bodies in a JSON
+	// ARRAY, which go-openai cannot unmarshal into ErrorResponse — those errors
+	// surface as *openai.RequestError instead of *openai.APIError. Classify by
+	// HTTP status so a Gemini 429/5xx still retries.
+	var reqErr *openai.RequestError
+	if errors.As(err, &reqErr) {
+		switch reqErr.HTTPStatusCode {
+		case 429, 500, 502, 503:
+			return true, 2 * time.Second
+		}
+	}
 	return false, 0
 }

--- a/internal/ai/openai_maintier.go
+++ b/internal/ai/openai_maintier.go
@@ -5,10 +5,13 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"strings"
 	"time"
 
 	openai "github.com/sashabaranov/go-openai"
 	"github.com/windoze95/saltybytes-api/internal/config"
+	"github.com/windoze95/saltybytes-api/internal/logger"
+	"go.uber.org/zap"
 )
 
 // This file completes *OpenAICompatProvider so it satisfies the full
@@ -456,10 +459,24 @@ func (p *OpenAICompatProvider) ClassifyVoiceIntent(ctx context.Context, transcri
 	})
 }
 
-// ExpandAndRankRecipes runs the recipe finder's ranking call via a forced
-// rank_recipes function call. Mirrors AnthropicProvider.ExpandAndRankRecipes —
-// same inline system prompt, wire payload and tool schema — so the light Gemini
-// tier that backs the finder produces a faithful request/result.
+// jsonSchemaMap adapts a plain schema map to the json.Marshaler that the
+// go-openai response_format json_schema field expects.
+type jsonSchemaMap map[string]interface{}
+
+func (m jsonSchemaMap) MarshalJSON() ([]byte, error) {
+	return json.Marshal(map[string]interface{}(m))
+}
+
+// ExpandAndRankRecipes runs the recipe finder's ranking call. Same core system
+// prompt, wire payload and schema as AnthropicProvider.ExpandAndRankRecipes,
+// but the output channel differs deliberately: Gemini's OpenAI-compat
+// FUNCTION-CALL parser intermittently rejects large rank_recipes calls
+// wholesale (finish_reason=MALFORMED_FUNCTION_CALL, zero tokens back —
+// prod-shaped payloads failed ~100% on 2026-07-01, which silently degraded
+// every finder run to unranked raw results). Schema-constrained JSON output
+// (response_format json_schema) sidesteps that parser entirely; the tolerant
+// parseFinderRankToolArgs consumes the JSON body just like tool args. One
+// resample covers residual model-level flakes.
 func (p *OpenAICompatProvider) ExpandAndRankRecipes(ctx context.Context, req FinderRankRequest) (*FinderRankResult, error) {
 	op := AIOperation{
 		Name:      "ExpandAndRankRecipes",
@@ -482,44 +499,56 @@ func (p *OpenAICompatProvider) ExpandAndRankRecipes(ctx context.Context, req Fin
 
 		chatReq := openai.ChatCompletionRequest{
 			Model: p.model,
-			// 2048: the rank_recipes tool JSON for ~10 candidates with per-item
-			// reason + safety[] + expand + broaden_queries runs ~1000-1500 output
-			// tokens with a family profile; 512 truncated it into an unranked
-			// fallback. Parsing is also truncation-tolerant as a backstop.
-			MaxTokens: 2048,
+			// Generous: Gemini 2.5 models spend completion budget on internal
+			// thinking BEFORE the answer, and a prod-sized rank payload (10
+			// candidates + family profile) thinks well past 2k. Billed by actual
+			// tokens, so headroom is free; parsing stays truncation-tolerant.
+			MaxTokens: 8192,
 			Messages: []openai.ChatCompletionMessage{
-				{Role: openai.ChatMessageRoleSystem, Content: finderRankSystemPrompt},
+				{Role: openai.ChatMessageRoleSystem, Content: finderRankSystemPromptCore +
+					"\n\nRespond with ONLY a JSON object holding `ranked` and `broaden_queries` as specified."},
 				{Role: openai.ChatMessageRoleUser, Content: string(payload)},
 			},
-			Tools: []openai.Tool{{
-				Type: openai.ToolTypeFunction,
-				Function: &openai.FunctionDefinition{
-					Name:        "rank_recipes",
-					Description: "Return the best-matching candidates by index, with rationales, per-member dietary safety, and broadened query suggestions.",
-					Parameters:  rankSchema,
+			ResponseFormat: &openai.ChatCompletionResponseFormat{
+				Type: openai.ChatCompletionResponseFormatTypeJSONSchema,
+				JSONSchema: &openai.ChatCompletionResponseFormatJSONSchema{
+					Name:   "rank_recipes",
+					Schema: jsonSchemaMap(rankSchema),
 				},
-			}},
-			ToolChoice: openai.ToolChoice{
-				Type:     openai.ToolTypeFunction,
-				Function: openai.ToolFunction{Name: "rank_recipes"},
 			},
 		}
 
-		resp, err := p.createChatCompletion(ctx, chatReq)
-		if err != nil {
-			return nil, err
-		}
+		var lastErr error
+		for attempt := 0; attempt < 2; attempt++ {
+			resp, err := p.createChatCompletion(ctx, chatReq)
+			if err != nil {
+				return nil, err // transport errors already retried downstream
+			}
 
-		args, err := firstToolCallArguments(resp, "rank_recipes")
-		if err != nil {
-			return nil, err
-		}
+			content := ""
+			finishReason := ""
+			if len(resp.Choices) > 0 {
+				content = strings.TrimSpace(resp.Choices[0].Message.Content)
+				finishReason = string(resp.Choices[0].FinishReason)
+			}
+			if content == "" {
+				lastErr = NewAIError(FailureContentEmpty,
+					fmt.Errorf("empty rank_recipes JSON response (finish_reason=%s, completion_tokens=%d)",
+						finishReason, resp.Usage.CompletionTokens),
+					"empty response")
+			} else if tr, perr := parseFinderRankToolArgs(content); perr == nil {
+				return toolResultToFinderRankResult(tr), nil
+			} else {
+				lastErr = perr
+			}
 
-		tr, err := parseFinderRankToolArgs(args)
-		if err != nil {
-			return nil, err
+			logger.Get().Warn("light-tier rank response unusable, resampling",
+				zap.String("provider", p.providerName),
+				zap.Int("attempt", attempt+1),
+				zap.Error(lastErr),
+			)
 		}
-		return toolResultToFinderRankResult(tr), nil
+		return nil, lastErr
 	})
 }
 

--- a/internal/ai/openai_text.go
+++ b/internal/ai/openai_text.go
@@ -120,14 +120,20 @@ func (p *OpenAICompatProvider) createChatCompletion(ctx context.Context, req ope
 // firstToolCallArguments returns the JSON argument string of the first tool
 // call in the response, guarding against zero choices / zero tool calls. fnName
 // is used only for diagnostics; tool choice is forced so the first call is the
-// requested function.
+// requested function. The empty-tool-call error carries finish_reason + token
+// usage: Gemini 2.5 models spend completion budget on thinking, so
+// finish_reason=length with a large completion count means the budget was
+// consumed before the tool call was emitted (raise MaxTokens).
 func firstToolCallArguments(resp *openai.ChatCompletionResponse, fnName string) (string, error) {
 	if resp == nil || len(resp.Choices) == 0 {
 		return "", NewAIError(FailureContentEmpty, errors.New("no choices in chat completion response"), "no choices in response")
 	}
 	calls := resp.Choices[0].Message.ToolCalls
 	if len(calls) == 0 {
-		return "", NewAIError(FailureContentEmpty, fmt.Errorf("no %s tool call in chat completion response", fnName), "no tool call in response")
+		return "", NewAIError(FailureContentEmpty,
+			fmt.Errorf("no %s tool call in chat completion response (finish_reason=%s, completion_tokens=%d)",
+				fnName, resp.Choices[0].FinishReason, resp.Usage.CompletionTokens),
+			"no tool call in response")
 	}
 	return calls[0].Function.Arguments, nil
 }

--- a/internal/service/recipe_finder.go
+++ b/internal/service/recipe_finder.go
@@ -213,6 +213,13 @@ func (s *RecipeFinderService) FindRecipes(ctx context.Context, user *models.User
 	}
 	rank := s.rankCandidates(ctx, user, req, dietSummary, results)
 
+	// 4.5. Ground-truth override: force-flag candidates the canonical cache
+	// already KNOWS are multi-recipe collection pages. The model's expand flag
+	// covers unseen pages; this keeps known collections out of the shortlist
+	// (and in the dig queue) even when the ranking call failed entirely and
+	// fallbackRanking returned no flags.
+	s.applyKnownCollections(results, rank)
+
 	// 5. Curate the shown picks: INDIVIDUAL recipes only (collections excluded),
 	// in rank order, capped to a tight top-picks set.
 	shown := buildShortlist(results, rank)
@@ -537,6 +544,31 @@ func (s *RecipeFinderService) rankCandidates(ctx context.Context, user *models.U
 		return fallbackRanking(len(results))
 	}
 	return res
+}
+
+// applyKnownCollections force-flags ranked candidates whose URL the canonical
+// cache has already marked as a multi-recipe collection page (IsMultiPage —
+// e.g. the user previewed it before). This is a DB fact, not pattern matching:
+// it complements the model's expand detection for unseen pages and, crucially,
+// keeps known collections from rendering as recipe cards when the ranking call
+// failed and the fallback ranking carries no flags at all.
+func (s *RecipeFinderService) applyKnownCollections(results []ai.SearchResult, rank *ai.FinderRankResult) {
+	if rank == nil || s.Warm == nil {
+		return
+	}
+	for i := range rank.Ranked {
+		r := &rank.Ranked[i]
+		if r.Expand || r.Index < 0 || r.Index >= len(results) {
+			continue
+		}
+		if s.Warm.IsKnownMulti(results[r.Index].URL) {
+			r.Expand = true
+			if r.ExpandPriority == 0 {
+				// Certain knowledge outranks a model guess's default priority.
+				r.ExpandPriority = 4
+			}
+		}
+	}
 }
 
 // dietContext compacts the owner's family dietary needs into a model-facing

--- a/internal/service/recipe_finder_digging_test.go
+++ b/internal/service/recipe_finder_digging_test.go
@@ -3,9 +3,11 @@ package service
 import (
 	"context"
 	"fmt"
+	"strings"
 	"testing"
 
 	"github.com/windoze95/saltybytes-api/internal/ai"
+	"github.com/windoze95/saltybytes-api/internal/models"
 	"github.com/windoze95/saltybytes-api/internal/testutil"
 )
 
@@ -322,5 +324,86 @@ func TestFindRecipes_NoDigWhenNothingFlagged(t *testing.T) {
 	}
 	if len(fake.calls) != 0 {
 		t.Errorf("resolver called %v with nothing flagged, want none", fake.calls)
+	}
+}
+
+// TestFindRecipes_KnownMultiExcludedEvenWhenRankingFails locks the fail-closed
+// invariant: when the ranking call fails entirely (fallback ranking, no expand
+// flags), a candidate the canonical cache already knows is a multi-recipe
+// collection page must STILL be excluded from the shown results and dug
+// instead. This is the guard against the 2026-07-01 prod incident where every
+// ranking failure painted "40 Easy ..." roundups as recipe cards.
+func TestFindRecipes_KnownMultiExcludedEvenWhenRankingFails(t *testing.T) {
+	collectionURL := "https://example.com/gallery/40-easy-weeknight-dinners"
+	results := []ai.SearchResult{
+		{Title: "Sheet Pan Chicken Fajitas", URL: "https://example.com/fajitas", Source: "example.com", Description: "Quick weeknight fajitas."},
+		{Title: "40 Easy Weeknight Dinner Recipes", URL: collectionURL, Source: "example.com", Description: "Our favorite quick dinners."},
+		{Title: "One-Pot Chicken and Rice", URL: "https://example.com/one-pot", Source: "example.com", Description: "A comforting one-pot classic."},
+	}
+	searchProvider := &testutil.MockSearchProvider{
+		SearchRecipesFunc: func(ctx context.Context, query string, count, offset int) ([]ai.SearchResult, error) {
+			return results, nil
+		},
+	}
+	ranker := &testutil.MockTextProvider{
+		ExpandAndRankRecipesFunc: func(ctx context.Context, req ai.FinderRankRequest) (*ai.FinderRankResult, error) {
+			return nil, fmt.Errorf("model exploded")
+		},
+	}
+
+	// The canonical cache knows the gallery URL is a multi-recipe page.
+	canon := &testutil.MockCanonicalRecipeRepo{
+		GetByNormalizedURLFunc: func(norm string) (*models.CanonicalRecipe, error) {
+			if strings.Contains(norm, "40-easy-weeknight-dinners") {
+				return &models.CanonicalRecipe{NormalizedURL: norm, IsMultiPage: true}, nil
+			}
+			return nil, fmt.Errorf("miss")
+		},
+	}
+	imp := newTestImportService(testutil.NewMockRecipeRepo(), nil, nil)
+	imp.CanonicalRepo = canon
+
+	fake := &fakeMultiResolver{entries: map[string]*MultiRecipeEntry{
+		collectionURL: resolvedEntry(collectionURL,
+			doneCard("Skillet Chicken Parm", "https://example.com/gallery/40-easy-weeknight-dinners?_recipe=chicken-parm-0"),
+		),
+	}}
+
+	svc := newFinderService(searchProvider, ranker, &testutil.MockFamilyRepo{})
+	svc.Warm = NewWarmService(imp, nil, 2, 0)
+	svc.MultiResolver = fake
+
+	events := runFinder(svc, testutil.TestUser(), FinderRequest{Facets: FinderFacets{Protein: "chicken"}})
+
+	// The known collection must never be shown as a pick...
+	for _, item := range shownItems(events) {
+		if item.Result.URL == collectionURL {
+			t.Fatalf("known multi-page collection shown as a result despite ranking failure: %+v", item)
+		}
+	}
+	// ...the two real singles still are (ranking failure degrades gracefully)...
+	shown := shownItems(events)
+	titles := make([]string, 0, len(shown))
+	for _, it := range shown {
+		titles = append(titles, it.Result.Title)
+	}
+	if len(shown) < 3 { // 2 direct singles + at least 1 mined recipe
+		t.Errorf("shown = %v, want the 2 singles plus mined recipes", titles)
+	}
+	// ...and it is dug instead: digging fired and the mined recipe was folded in.
+	if len(fake.calls) != 1 || fake.calls[0] != collectionURL {
+		t.Errorf("resolver calls = %v, want exactly the known collection", fake.calls)
+	}
+	if countEventsOfType(events, FinderEventDigging) == 0 {
+		t.Errorf("no digging event for the known collection (%v)", eventTypes(events))
+	}
+	foundMined := false
+	for _, it := range shown {
+		if it.Result.Title == "Skillet Chicken Parm" {
+			foundMined = true
+		}
+	}
+	if !foundMined {
+		t.Errorf("mined recipe not folded into results: %v", titles)
 	}
 }

--- a/internal/service/warm.go
+++ b/internal/service/warm.go
@@ -56,6 +56,22 @@ func NewWarmService(imp *ImportService, resolver *MultiRecipeResolver, concurren
 	}
 }
 
+// IsKnownMulti reports whether the canonical cache already knows this URL is a
+// multi-recipe collection/listicle page (ground truth from a prior extraction).
+// Read-only: unlike WarmURLs it never kicks background extraction. Best-effort:
+// missing wiring, a bad URL or a cache miss simply report false.
+func (w *WarmService) IsKnownMulti(rawURL string) bool {
+	if w == nil || w.Import == nil || w.Import.CanonicalRepo == nil {
+		return false
+	}
+	normalizedURL, err := NormalizeURL(rawURL)
+	if err != nil {
+		return false
+	}
+	canonical, err := w.Import.CanonicalRepo.GetByNormalizedURL(normalizedURL)
+	return err == nil && canonical != nil && canonical.IsMultiPage
+}
+
 // WarmURLs returns the current warm status of each URL, kicking off background
 // extraction for any that are uncached and not already in flight. It is
 // idempotent — calling it repeatedly with the same URLs is cheap (cached and


### PR DESCRIPTION
## The real root cause (prod evidence, not a guess)

CloudWatch shows **every recent finder ranking call failing**: `no rank_recipes tool call in chat completion response` (plus one unretried Gemini 429). Every failure → `fallbackRanking` → unranked raw search results with **no expand flags** → roundup pages rendered as recipe cards. That's the "it's just giving me search results" report, exactly.

Reproduced locally **5/5** with a prod-shaped payload (10 candidates + multi-member family profile): Gemini's OpenAI-compat **function-call parser rejects the large `rank_recipes` call wholesale** — `finish_reason=function_call_filter: MALFORMED_FUNCTION_CALL, completion_tokens=0`. The previous live test used 2 candidates and no family, which is why it passed while prod failed 100%.

## Fix — three layers

1. **Sidestep the flaky parser entirely (light tier):** ranking now uses schema-constrained JSON output (`response_format: json_schema`, same schema) instead of forced function calling, parsed by the existing tolerant parser, with one resample for residual flakes and `MaxTokens 8192` for Gemini 2.5 thinking headroom (billed per actual token). **Prod-shaped live stress: 0/5 → 5/5.**
2. **Retry Gemini 429/5xx:** Gemini wraps error bodies in a JSON *array* that go-openai can't parse into `ErrorResponse`, so its 429s surfaced as `*openai.RequestError` and were returned terminal. `classifyOpenAIError` now classifies `RequestError` by HTTP status too.
3. **Fail closed on collections:** `applyKnownCollections` force-flags any ranked candidate whose URL the canonical cache has marked `IsMultiPage` (ground truth from prior extraction — a DB fact, not pattern matching). Even a total ranking failure can no longer render a known collection as a card; it gets dug instead. New read-only `WarmService.IsKnownMulti` (never kicks extraction).

Diagnostics: empty-tool-call/empty-response errors now carry `finish_reason` + `completion_tokens`, so the next incident starts from the mechanism.

## Verification

- `TestExpandAndRankRecipes_Live_ProdShapedStress` (gated live, real Gemini): 5/5, asserts no collection is ever returned unflagged and no single recipe is misflagged.
- `TestFindRecipes_KnownMultiExcludedEvenWhenRankingFails` (offline): ranking fails hard → known collection still excluded + dug + mined recipe folded in.
- Classifier table extended with `RequestError` cases. Full offline suite green (12/12 packages).
- Post-merge: I will verify against prod with a live SSE run before calling it fixed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BU4UWZutHd1AnK3XAf7H19