### PR TITLE
Telemetry: finder_runs (agent workflow) + extraction_events (failure drill-downs)

### DIFF
--- a/internal/db/db.go
+++ b/internal/db/db.go
@@ -66,6 +66,8 @@ func connectToDatabaseWithRetry(databaseURL string) (*gorm.DB, error) {
 		&models.AIModelOption{},
 		&models.AIConfig{},
 		&models.FinderSession{},
+		&models.FinderRun{},
+		&models.ExtractionEvent{},
 	); migrateErr != nil {
 		return nil, fmt.Errorf("database auto-migration failed: %w", migrateErr)
 	}

--- a/internal/models/telemetry.go
+++ b/internal/models/telemetry.go
@@ -1,0 +1,112 @@
+package models
+
+import (
+	"database/sql/driver"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"time"
+)
+
+// FinderRun is one agent-mode search run's workflow telemetry: what each step
+// did (search → rank → dig → show) and how long it took. Written best-effort at
+// the end of every run so the dashboard can chart the agent's step funnel,
+// failure modes and latencies. Rows are facts about a finished run — no soft
+// delete, no updates.
+type FinderRun struct {
+	ID        uint      `gorm:"primarykey" json:"id"`
+	CreatedAt time.Time `gorm:"index" json:"created_at"`
+
+	UserID uint   `gorm:"index" json:"user_id"`
+	Query  string `gorm:"size:512" json:"query"`
+	Offset int    `json:"offset"`
+
+	// Search step.
+	ResultsFound int  `json:"results_found"`
+	FromCache    bool `json:"from_cache"`
+
+	// Rank step. RankOK=false means the model call failed and the run degraded
+	// to the unranked fallback (no reasons/safety; collection flags only from
+	// the canonical-cache override).
+	RankOK    bool   `gorm:"index" json:"rank_ok"`
+	RankError string `gorm:"type:text" json:"rank_error,omitempty"`
+
+	// Dig step: collections flagged (model + known-multi override), how many
+	// were actually mined, and how many individual recipes folded out.
+	CollectionsFlagged int `json:"collections_flagged"`
+	CollectionsDug     int `json:"collections_dug"`
+	CardsMined         int `json:"cards_mined"`
+
+	// What the user ended up seeing.
+	ShownDirect int `json:"shown_direct"`
+	ShownTotal  int `json:"shown_total"`
+
+	// Terminal event of the run: done | empty | error | cancelled.
+	Terminal  string `gorm:"size:16;index" json:"terminal"`
+	ErrorText string `gorm:"type:text" json:"error_text,omitempty"`
+
+	// Step latencies.
+	SearchMS int64 `json:"search_ms"`
+	RankMS   int64 `json:"rank_ms"`
+	DigMS    int64 `json:"dig_ms"`
+	TotalMS  int64 `json:"total_ms"`
+}
+
+// ExtractionEvent records one terminal recipe-extraction attempt — success or
+// failure — with enough context that a failure can be diagnosed (and handed to
+// a coding agent) without grepping CloudWatch. Append-only.
+type ExtractionEvent struct {
+	ID        uint      `gorm:"primarykey" json:"id"`
+	CreatedAt time.Time `gorm:"index" json:"created_at"`
+
+	URL    string `gorm:"size:2048" json:"url"`
+	Domain string `gorm:"size:255;index" json:"domain"`
+
+	// Origin is which product flow asked for the extraction:
+	// import | preview | warm | finder_dig | multi_expand | unknown.
+	Origin string `gorm:"size:32;index" json:"origin"`
+
+	// Method is how the recipe was (or was last attempted to be) extracted:
+	// json_ld | haiku | firecrawl_json_ld | firecrawl_haiku (ExtractionMethod
+	// values), plus multi_marked and card-specific own_page | inline_jsonld |
+	// inline_ai; "" when the attempt died before extraction (fetch failures).
+	Method string `gorm:"size:32;index" json:"method"`
+
+	Success bool `gorm:"index" json:"success"`
+
+	// ErrorCode is the stable, groupable failure class:
+	// site_blocked | not_found | fetch_failed | ai_error | no_provider | ...
+	ErrorCode string `gorm:"size:64;index" json:"error_code,omitempty"`
+	Error     string `gorm:"type:text" json:"error,omitempty"`
+
+	UsedFirecrawl bool  `json:"used_firecrawl"`
+	DurationMS    int64 `json:"duration_ms"`
+
+	// Context carries flow-specific detail for drill-downs: card title +
+	// collection URL for multi cards, retry attempts, html length, etc.
+	Context ExtractionContext `gorm:"type:jsonb" json:"context"`
+}
+
+// ExtractionContext is the free-form JSONB detail bag on an ExtractionEvent.
+type ExtractionContext map[string]interface{}
+
+// Scan is a GORM hook that scans jsonb into ExtractionContext.
+func (c *ExtractionContext) Scan(value interface{}) error {
+	if value == nil {
+		*c = nil
+		return nil
+	}
+	bytes, ok := value.([]byte)
+	if !ok {
+		return errors.New(fmt.Sprint("Failed to unmarshal JSONB value:", value))
+	}
+	return json.Unmarshal(bytes, c)
+}
+
+// Value is a GORM hook that returns the json value of ExtractionContext.
+func (c ExtractionContext) Value() (driver.Value, error) {
+	if c == nil {
+		return json.Marshal(map[string]interface{}{})
+	}
+	return json.Marshal(map[string]interface{}(c))
+}

--- a/internal/repository/interfaces.go
+++ b/internal/repository/interfaces.go
@@ -92,6 +92,17 @@ type FinderSessionRepo interface {
 	Delete(ctx context.Context, id uint) error
 }
 
+// FinderRunRepo persists agent-run workflow telemetry (dashboard analytics).
+type FinderRunRepo interface {
+	Create(run *models.FinderRun) error
+}
+
+// ExtractionEventRepo persists terminal recipe-extraction outcomes
+// (dashboard analytics + failure drill-downs).
+type ExtractionEventRepo interface {
+	Create(event *models.ExtractionEvent) error
+}
+
 // AllergenRepo is the interface for allergen analysis repository operations.
 type AllergenRepo interface {
 	CreateAnalysis(analysis *models.AllergenAnalysis) error
@@ -124,3 +135,5 @@ var _ UserRepo = (*UserRepository)(nil)
 var _ FamilyRepo = (*FamilyRepository)(nil)
 var _ AllergenRepo = (*AllergenRepository)(nil)
 var _ FinderSessionRepo = (*FinderSessionRepository)(nil)
+var _ FinderRunRepo = (*FinderRunRepository)(nil)
+var _ ExtractionEventRepo = (*ExtractionEventRepository)(nil)

--- a/internal/repository/telemetry.go
+++ b/internal/repository/telemetry.go
@@ -1,0 +1,38 @@
+package repository
+
+import (
+	"gorm.io/gorm"
+
+	"github.com/windoze95/saltybytes-api/internal/models"
+)
+
+// FinderRunRepository persists per-run agent workflow telemetry (append-only).
+type FinderRunRepository struct {
+	DB *gorm.DB
+}
+
+// NewFinderRunRepository creates a new FinderRunRepository.
+func NewFinderRunRepository(db *gorm.DB) *FinderRunRepository {
+	return &FinderRunRepository{DB: db}
+}
+
+// Create inserts one finished finder run's telemetry row.
+func (r *FinderRunRepository) Create(run *models.FinderRun) error {
+	return r.DB.Create(run).Error
+}
+
+// ExtractionEventRepository persists terminal recipe-extraction outcomes
+// (append-only).
+type ExtractionEventRepository struct {
+	DB *gorm.DB
+}
+
+// NewExtractionEventRepository creates a new ExtractionEventRepository.
+func NewExtractionEventRepository(db *gorm.DB) *ExtractionEventRepository {
+	return &ExtractionEventRepository{DB: db}
+}
+
+// Create inserts one extraction event.
+func (r *ExtractionEventRepository) Create(event *models.ExtractionEvent) error {
+	return r.DB.Create(event).Error
+}

--- a/internal/router/router.go
+++ b/internal/router/router.go
@@ -367,6 +367,8 @@ func SetupRouter(cfg *config.Config, database *gorm.DB) *gin.Engine {
 	// resolver; auto-save records each completed first-page run for history.
 	finderService.MultiResolver = multiResolver
 	finderService.Sessions = finderSessionService
+	finderService.Runs = repository.NewFinderRunRepository(database)
+	importService.Events = repository.NewExtractionEventRepository(database)
 	finderHandler := &handlers.FinderHandler{Service: finderService, SubService: subService}
 	apiProtected.POST("/recipes/find", middleware.AttachUserToContext(userService), finderHandler.FindRecipes)
 	apiProtected.GET("/recipes/finder/sessions", middleware.AttachUserToContext(userService), finderSessionHandler.ListSessions)

--- a/internal/service/import.go
+++ b/internal/service/import.go
@@ -47,6 +47,9 @@ type ImportService struct {
 	CanonicalRepo   repository.CanonicalRecipeRepo
 	Policy          *ImportPolicy
 	Normalize       *NormalizeService // optional; estimates portions when imports lack them
+	// Events (nil-safe) persists terminal extraction outcomes for the
+	// dashboard's completeness panel + failure drill-downs.
+	Events repository.ExtractionEventRepo
 
 	// Video-link import (premium). All three are nil until a ScrapeCreators key
 	// is configured at startup, which keeps the feature dark by default.
@@ -156,6 +159,7 @@ func (s *ImportService) canonicalEmbedding(ctx context.Context, recipeDef *model
 // When a CanonicalRepo is configured, it checks the canonical cache first and
 // saves extractions for future deduplication.
 func (s *ImportService) ImportFromURL(ctx context.Context, rawURL string, user *models.User) (*RecipeResponse, error) {
+	ctx = WithExtractionOrigin(ctx, ExtractionOriginImport)
 	log := logger.Get().With(zap.Uint("user_id", user.ID), zap.String("source_url", rawURL))
 
 	if err := ValidateExternalURL(rawURL); err != nil {
@@ -346,8 +350,34 @@ func (s *ImportService) fetchViaFirecrawl(ctx context.Context, rawURL string) (s
 // extractFromURL fetches a URL and extracts recipe data via JSON-LD or AI fallback.
 // Returns the recipe definition, raw hashtag strings, the page's recipe image
 // URL (when available), the extraction method used, and the prompt version.
-// Shared by PreviewFromURL, ImportFromURL, and background refresh.
+// Shared by PreviewFromURL, ImportFromURL, and background refresh. It wraps
+// the pipeline with telemetry: exactly one ExtractionEvent per attempt,
+// success or failure, with the terminal method, error class and duration.
 func (s *ImportService) extractFromURL(ctx context.Context, rawURL string) (*models.RecipeDef, []string, string, models.ExtractionMethod, string, error) {
+	start := time.Now()
+	def, hashtags, imageURL, method, promptVersion, err := s.extractFromURLInner(ctx, rawURL)
+
+	usedFirecrawl := method == models.ExtractionFirecrawlJSONLD || method == models.ExtractionFirecrawlHaiku
+	errCode := extractionErrCode(err)
+	// site_blocked means the direct fetch was blocked AND the Firecrawl
+	// escalation failed too — firecrawl was in play even though no method
+	// survived to say so.
+	if errCode == "site_blocked" {
+		usedFirecrawl = true
+	}
+	s.recordExtraction(ctx, models.ExtractionEvent{
+		URL:           rawURL,
+		Method:        string(method),
+		Success:       err == nil,
+		ErrorCode:     errCode,
+		Error:         truncateErr(err),
+		UsedFirecrawl: usedFirecrawl,
+		DurationMS:    time.Since(start).Milliseconds(),
+	})
+	return def, hashtags, imageURL, method, promptVersion, err
+}
+
+func (s *ImportService) extractFromURLInner(ctx context.Context, rawURL string) (*models.RecipeDef, []string, string, models.ExtractionMethod, string, error) {
 	log := logger.Get().With(zap.String("url", rawURL))
 
 	// Check if this domain is known to block direct fetches
@@ -817,6 +847,7 @@ type PreviewResult struct {
 // When a CanonicalRepo is configured, it checks the cache first and saves
 // extractions for future deduplication. Returns the recipe data and optional canonical ID.
 func (s *ImportService) PreviewFromURL(ctx context.Context, rawURL string) (*models.RecipeDef, *uint, error) {
+	ctx = WithExtractionOrigin(ctx, ExtractionOriginPreview)
 	log := logger.Get().With(zap.String("source_url", rawURL))
 
 	if err := ValidateExternalURL(rawURL); err != nil {
@@ -880,6 +911,7 @@ func (s *ImportService) PreviewFromURL(ctx context.Context, rawURL string) (*mod
 // structured data. The caller is expected to have already skipped cached and
 // in-flight URLs.
 func (s *ImportService) WarmURL(ctx context.Context, resolver *MultiRecipeResolver, rawURL string) error {
+	ctx = WithExtractionOrigin(ctx, ExtractionOriginWarm)
 	if err := ValidateExternalURL(rawURL); err != nil {
 		return err
 	}
@@ -892,13 +924,27 @@ func (s *ImportService) WarmURL(ctx context.Context, resolver *MultiRecipeResolv
 		return nil
 	}
 
+	start := time.Now()
 	html, err := s.fetchHTML(ctx, rawURL)
 	if err != nil {
+		s.recordExtraction(ctx, models.ExtractionEvent{
+			URL:        rawURL,
+			Success:    false,
+			ErrorCode:  extractionErrCode(err),
+			Error:      truncateErr(err),
+			DurationMS: time.Since(start).Milliseconds(),
+		})
 		return err
 	}
 
 	now := time.Now()
 	markMulti := func() error {
+		s.recordExtraction(ctx, models.ExtractionEvent{
+			URL:        rawURL,
+			Method:     "multi_marked",
+			Success:    true,
+			DurationMS: time.Since(start).Milliseconds(),
+		})
 		return s.CanonicalRepo.Upsert(&models.CanonicalRecipe{
 			NormalizedURL:    normalizedURL,
 			OriginalURL:      rawURL,
@@ -930,10 +976,26 @@ func (s *ImportService) WarmURL(ctx context.Context, resolver *MultiRecipeResolv
 			provider = s.TextProvider
 		}
 		if provider == nil {
+			s.recordExtraction(ctx, models.ExtractionEvent{
+				URL:        rawURL,
+				Success:    false,
+				ErrorCode:  "no_provider",
+				Error:      "no text provider configured for warming",
+				DurationMS: time.Since(start).Milliseconds(),
+			})
 			return fmt.Errorf("no text provider configured for warming")
 		}
 		result, aiErr := provider.ExtractRecipeFromText(ctx, html, ai.UnitSystemPreserveSource)
 		if aiErr != nil {
+			s.recordExtraction(ctx, models.ExtractionEvent{
+				URL:        rawURL,
+				Method:     string(models.ExtractionHaiku),
+				Success:    false,
+				ErrorCode:  extractionErrCode(aiErr),
+				Error:      truncateErr(aiErr),
+				DurationMS: time.Since(start).Milliseconds(),
+				Context:    models.ExtractionContext{"html_len": len(html)},
+			})
 			return aiErr
 		}
 		def := recipeResultToRecipeDef(result)
@@ -943,6 +1005,12 @@ func (s *ImportService) WarmURL(ctx context.Context, resolver *MultiRecipeResolv
 		method = models.ExtractionHaiku
 	}
 
+	s.recordExtraction(ctx, models.ExtractionEvent{
+		URL:        rawURL,
+		Method:     string(method),
+		Success:    true,
+		DurationMS: time.Since(start).Milliseconds(),
+	})
 	return s.CanonicalRepo.Upsert(&models.CanonicalRecipe{
 		NormalizedURL:    normalizedURL,
 		OriginalURL:      rawURL,
@@ -960,6 +1028,8 @@ func (s *ImportService) WarmURL(ctx context.Context, resolver *MultiRecipeResolv
 // extracting only the first recipe. The resolver handles background
 // extraction of each individual recipe.
 func (s *ImportService) PreviewFromURLWithMultiCheck(ctx context.Context, rawURL string, resolver *MultiRecipeResolver) (*PreviewResult, error) {
+	ctx = WithExtractionOrigin(ctx, ExtractionOriginPreview)
+	start := time.Now()
 	log := logger.Get().With(zap.String("source_url", rawURL))
 
 	if err := ValidateExternalURL(rawURL); err != nil {
@@ -1000,6 +1070,13 @@ func (s *ImportService) PreviewFromURLWithMultiCheck(ctx context.Context, rawURL
 	html, err := s.fetchHTML(ctx, rawURL)
 	if err != nil {
 		log.Error("failed to fetch page", zap.Error(err))
+		s.recordExtraction(ctx, models.ExtractionEvent{
+			URL:        rawURL,
+			Success:    false,
+			ErrorCode:  extractionErrCode(err),
+			Error:      truncateErr(err),
+			DurationMS: time.Since(start).Milliseconds(),
+		})
 		return nil, err // pass through ExtractionError (not_found, site_blocked, etc.)
 	}
 
@@ -1026,6 +1103,13 @@ func (s *ImportService) PreviewFromURLWithMultiCheck(ctx context.Context, rawURL
 					}
 				}
 			}
+			s.recordExtraction(ctx, models.ExtractionEvent{
+				URL:        rawURL,
+				Method:     "multi_marked",
+				Success:    true,
+				DurationMS: time.Since(start).Milliseconds(),
+				Context:    models.ExtractionContext{"cards": len(entry.GetCards())},
+			})
 			return &PreviewResult{
 				IsMulti:    true,
 				MultiID:    entry.ID,
@@ -1043,10 +1127,26 @@ func (s *ImportService) PreviewFromURLWithMultiCheck(ctx context.Context, rawURL
 			provider = s.TextProvider
 		}
 		if provider == nil {
+			s.recordExtraction(ctx, models.ExtractionEvent{
+				URL:        rawURL,
+				Success:    false,
+				ErrorCode:  "no_provider",
+				Error:      "no AI text provider configured for fallback extraction",
+				DurationMS: time.Since(start).Milliseconds(),
+			})
 			return nil, fmt.Errorf("no AI text provider configured for fallback extraction")
 		}
 		result, aiErr := provider.ExtractRecipeFromText(ctx, html, ai.UnitSystemPreserveSource)
 		if aiErr != nil {
+			s.recordExtraction(ctx, models.ExtractionEvent{
+				URL:        rawURL,
+				Method:     string(models.ExtractionHaiku),
+				Success:    false,
+				ErrorCode:  extractionErrCode(aiErr),
+				Error:      truncateErr(aiErr),
+				DurationMS: time.Since(start).Milliseconds(),
+				Context:    models.ExtractionContext{"html_len": len(html)},
+			})
 			return nil, fmt.Errorf("failed to extract recipe from URL: %w", aiErr)
 		}
 		def := recipeResultToRecipeDef(result)
@@ -1055,6 +1155,12 @@ func (s *ImportService) PreviewFromURLWithMultiCheck(ctx context.Context, rawURL
 		recipeDef = &def
 		method = models.ExtractionHaiku
 	}
+	s.recordExtraction(ctx, models.ExtractionEvent{
+		URL:        rawURL,
+		Method:     string(method),
+		Success:    true,
+		DurationMS: time.Since(start).Milliseconds(),
+	})
 
 	// Save to canonical cache
 	var canonicalID *uint

--- a/internal/service/multi_recipe.go
+++ b/internal/service/multi_recipe.go
@@ -43,6 +43,10 @@ type MultiRecipeEntry struct {
 	DetectedAt time.Time         `json:"detected_at"`
 	ResolvedAt *time.Time        `json:"resolved_at,omitempty"`
 	pageHTML   string            // stored for extraction, not serialized
+	// Origin is the product flow that triggered this resolve (preview /
+	// finder_dig / multi_expand ...). Card extraction runs on a detached
+	// context, so telemetry reads the flow from here instead of ctx.
+	Origin string `json:"-"`
 }
 
 func (e *MultiRecipeEntry) GetCards() []MultiRecipeCard {
@@ -588,6 +592,7 @@ func (r *MultiRecipeResolver) resolveFromHTMLN(ctx context.Context, sourceURL st
 	entry.mu.Lock()
 	entry.Cards = cards
 	entry.pageHTML = html
+	entry.Origin = extractionOrigin(ctx)
 	entry.mu.Unlock()
 
 	// Start background extraction for each card
@@ -625,6 +630,10 @@ func (r *MultiRecipeResolver) ResolveFromURLWithReason(ctx context.Context, sour
 // resolveFromURLCore fetches a URL and resolves it, returning the entry (or nil)
 // plus a stable reason code when no entry results.
 func (r *MultiRecipeResolver) resolveFromURLCore(ctx context.Context, sourceURL string, maxCards int) (*MultiRecipeEntry, string) {
+	// Late-detection resolves come from a tapped search result unless a more
+	// specific flow (finder_dig) already tagged the context.
+	ctx = WithExtractionOrigin(ctx, ExtractionOriginMultiExpand)
+
 	// Check if already tracked
 	if existing := r.Registry.Get(sourceURL); existing != nil {
 		return existing, ""
@@ -632,9 +641,19 @@ func (r *MultiRecipeResolver) resolveFromURLCore(ctx context.Context, sourceURL 
 
 	// Fetch only the HTML (fetchHTML escalates to Firecrawl on bot-block) — we
 	// only need the page content for JSON-LD multi-recipe card detection.
+	start := time.Now()
 	html, err := r.ImportService.fetchHTML(ctx, sourceURL)
 	if err != nil || html == "" {
-		return nil, fetchFailureReason(err)
+		reason := fetchFailureReason(err)
+		r.ImportService.recordExtraction(ctx, models.ExtractionEvent{
+			URL:        sourceURL,
+			Success:    false,
+			ErrorCode:  reason,
+			Error:      truncateErr(err),
+			DurationMS: time.Since(start).Milliseconds(),
+			Context:    models.ExtractionContext{"stage": "multi_resolve"},
+		})
+		return nil, reason
 	}
 
 	// Check for multiple recipes
@@ -843,12 +862,41 @@ func (r *MultiRecipeResolver) extractSingleCard(entry *MultiRecipeEntry, idx int
 	title := card.Title
 	sourceURL := card.SourceURL
 	pageHTML := entry.pageHTML
+	origin := entry.Origin
 	entry.mu.Unlock()
 
 	log := logger.Get().With(zap.String("title", title), zap.String("source_url", sourceURL))
 
 	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Minute)
 	defer cancel()
+
+	// One telemetry event per card, at whichever path is terminal. The card
+	// extraction runs detached, so the flow origin comes from the entry.
+	start := time.Now()
+	record := func(method string, success bool, errCode, errText string, extra models.ExtractionContext) {
+		eventURL := sourceURL
+		if eventURL == "" {
+			eventURL = entry.SourceURL
+		}
+		evCtx := models.ExtractionContext{
+			"stage":          "multi_card",
+			"collection_url": entry.SourceURL,
+			"card_title":     title,
+		}
+		for k, v := range extra {
+			evCtx[k] = v
+		}
+		r.ImportService.recordExtraction(ctx, models.ExtractionEvent{
+			URL:        eventURL,
+			Origin:     origin,
+			Method:     method,
+			Success:    success,
+			ErrorCode:  errCode,
+			Error:      errText,
+			DurationMS: time.Since(start).Milliseconds(),
+			Context:    evCtx,
+		})
+	}
 
 	// Preferred path: when this card resolved to its own recipe page (a
 	// collection/listicle of links, not inline recipes), fetch and extract that
@@ -880,6 +928,7 @@ func (r *MultiRecipeResolver) extractSingleCard(entry *MultiRecipeEntry, idx int
 				}
 			}
 			log.Info("extracted recipe from its own page", zap.Int("ingredients", len(def.Ingredients)))
+			record("own_page", true, "", "", nil)
 			return
 		}
 		log.Info("individual recipe page unavailable; falling back to collection text")
@@ -893,6 +942,7 @@ func (r *MultiRecipeResolver) extractSingleCard(entry *MultiRecipeEntry, idx int
 		ensureUnitSystem(def)
 		r.finishInlineCard(entry, idx, title, sourceURL, *def, hashtags, models.ExtractionJSONLD, log)
 		log.Info("inline recipe extracted from page JSON-LD", zap.Int("ingredients", len(def.Ingredients)))
+		record("inline_jsonld", true, "", "", nil)
 		return
 	}
 
@@ -905,6 +955,7 @@ func (r *MultiRecipeResolver) extractSingleCard(entry *MultiRecipeEntry, idx int
 		entry.mu.Lock()
 		entry.Cards[idx].ExtractionStatus = "failed"
 		entry.mu.Unlock()
+		record("inline_ai", false, "no_provider", "no AI provider available for multi-recipe extraction", nil)
 		return
 	}
 
@@ -943,6 +994,8 @@ func (r *MultiRecipeResolver) extractSingleCard(entry *MultiRecipeEntry, idx int
 		entry.mu.Lock()
 		entry.Cards[idx].ExtractionStatus = "failed"
 		entry.mu.Unlock()
+		record("inline_ai", false, extractionErrCode(err), truncateErr(err),
+			models.ExtractionContext{"attempts": cardExtractAttempts, "page_text_len": len(pageText)})
 		return
 	}
 
@@ -950,6 +1003,7 @@ func (r *MultiRecipeResolver) extractSingleCard(entry *MultiRecipeEntry, idx int
 	def.SourceURL = sourceURL
 	ensureUnitSystem(&def)
 	r.finishInlineCard(entry, idx, title, sourceURL, def, result.Hashtags, models.ExtractionHaiku, log)
+	record("inline_ai", true, "", "", models.ExtractionContext{"attempts": cardExtractAttempts})
 
 	log.Info("individual recipe extracted from page text via AI")
 }

--- a/internal/service/recipe_finder.go
+++ b/internal/service/recipe_finder.go
@@ -155,6 +155,9 @@ type RecipeFinderService struct {
 	// Sessions (nil-safe) persists each completed first-page run for history.
 	// When nil, auto-save is skipped.
 	Sessions *FinderSessionService
+	// Runs (nil-safe) persists per-run workflow telemetry (step funnel,
+	// latencies, failure modes) for the dashboard. When nil, nothing is saved.
+	Runs repository.FinderRunRepo
 }
 
 // NewRecipeFinderService wires the finder over the existing search, family and
@@ -173,6 +176,19 @@ func NewRecipeFinderService(cfg *config.Config, search *SearchService, familyRep
 // goes and returning when the run reaches a terminal event (done/empty/error) or
 // the context is cancelled. The caller owns the channel and closes it.
 func (s *RecipeFinderService) FindRecipes(ctx context.Context, user *models.User, req FinderRequest, events chan<- FinderEvent) {
+	// Workflow telemetry: one row per run, whatever way it ends. Terminal
+	// stays "cancelled" unless a real terminal event overwrites it, so client
+	// disconnects are visible too.
+	runStart := time.Now()
+	run := &models.FinderRun{Terminal: "cancelled"}
+	if user != nil {
+		run.UserID = user.ID
+	}
+	defer func() {
+		run.TotalMS = time.Since(runStart).Milliseconds()
+		s.saveRun(run)
+	}()
+
 	// Auto-inject the family's dietary needs (server-side, never client-trusted):
 	// allergies become hard query-excludes; restrictions/preferences steer the
 	// model via the diet summary.
@@ -180,6 +196,7 @@ func (s *RecipeFinderService) FindRecipes(ctx context.Context, user *models.User
 
 	// 1. Compose the search query deterministically — no model call.
 	query := composeFinderQuery(req, allergenExcludes)
+	run.Query = query
 	if !s.emit(ctx, events, FinderEvent{Type: FinderEventSearching, Query: query}) {
 		return
 	}
@@ -190,19 +207,28 @@ func (s *RecipeFinderService) FindRecipes(ctx context.Context, user *models.User
 	if offset < 0 {
 		offset = 0
 	}
+	run.Offset = offset
+	searchStart := time.Now()
 	searchRes, err := s.Search.SearchRecipes(ctx, query, finderSearchCount, offset)
+	run.SearchMS = time.Since(searchStart).Milliseconds()
 	if err != nil {
 		logger.Get().Error("recipe finder search failed", zap.String("query", query), zap.Error(err))
+		run.Terminal = "error"
+		run.ErrorText = truncateErr(err)
 		s.emit(ctx, events, FinderEvent{Type: FinderEventError, Error: "search failed"})
 		return
 	}
 	results := searchRes.Results
+	run.ResultsFound = len(results)
+	run.FromCache = searchRes.FromCache
 	if !s.emit(ctx, events, FinderEvent{Type: FinderEventFound, Count: len(results), FromCache: searchRes.FromCache}) {
 		return
 	}
 
 	// 3. Empty search → broaden suggestions only; never invent a recipe.
 	if len(results) == 0 {
+		run.Terminal = "empty"
+		run.RankOK = true // no rank attempted; don't count as a rank failure
 		s.emit(ctx, events, FinderEvent{Type: FinderEventEmpty, Broaden: broadenFallback(req)})
 		return
 	}
@@ -211,7 +237,11 @@ func (s *RecipeFinderService) FindRecipes(ctx context.Context, user *models.User
 	if !s.emit(ctx, events, FinderEvent{Type: FinderEventFiltering}) {
 		return
 	}
-	rank := s.rankCandidates(ctx, user, req, dietSummary, results)
+	rankStart := time.Now()
+	rank, rankErr := s.rankCandidates(ctx, user, req, dietSummary, results)
+	run.RankMS = time.Since(rankStart).Milliseconds()
+	run.RankOK = rankErr == ""
+	run.RankError = rankErr
 
 	// 4.5. Ground-truth override: force-flag candidates the canonical cache
 	// already KNOWS are multi-recipe collection pages. The model's expand flag
@@ -219,6 +249,7 @@ func (s *RecipeFinderService) FindRecipes(ctx context.Context, user *models.User
 	// (and in the dig queue) even when the ranking call failed entirely and
 	// fallbackRanking returned no flags.
 	s.applyKnownCollections(results, rank)
+	run.CollectionsFlagged = countExpandFlags(rank)
 
 	// 5. Curate the shown picks: INDIVIDUAL recipes only (collections excluded),
 	// in rank order, capped to a tight top-picks set.
@@ -226,6 +257,7 @@ func (s *RecipeFinderService) FindRecipes(ctx context.Context, user *models.User
 	if len(shown) > finderCuratedCap {
 		shown = shown[:finderCuratedCap]
 	}
+	run.ShownDirect = len(shown)
 
 	// 6. Emit the curated shortlist — but only if we have direct individual picks.
 	// If the search was all collections, the first batch mined below seeds the
@@ -249,11 +281,17 @@ func (s *RecipeFinderService) FindRecipes(ctx context.Context, user *models.User
 	if room > finderDigMaxCards {
 		room = finderDigMaxCards
 	}
-	folded := s.digCollections(ctx, events, results, rank, room, &shortlistEmitted, searchRes.HasMore)
+	digStart := time.Now()
+	folded, dug := s.digCollections(ctx, events, results, rank, room, &shortlistEmitted, searchRes.HasMore)
+	run.DigMS = time.Since(digStart).Milliseconds()
+	run.CollectionsDug = dug
+	run.CardsMined = len(folded)
+	run.ShownTotal = len(shown) + len(folded)
 
 	// 7. Truly nothing individual to show (search was all collections and none
 	// extracted in time) → broaden suggestions. Never fall back to collection cards.
 	if !shortlistEmitted {
+		run.Terminal = "empty"
 		s.emit(ctx, events, FinderEvent{Type: FinderEventEmpty, Broaden: broadenList(rank, req)})
 		return
 	}
@@ -273,6 +311,7 @@ func (s *RecipeFinderService) FindRecipes(ctx context.Context, user *models.User
 	if !s.emit(ctx, events, FinderEvent{Type: FinderEventRefineReady, Chips: finderRefineChips, Broaden: broadenList(rank, req)}) {
 		return
 	}
+	run.Terminal = "done"
 	s.emit(ctx, events, FinderEvent{Type: FinderEventDone})
 
 	// 10. Auto-save the completed first-page run for history (ungated, best-effort).
@@ -294,6 +333,31 @@ func (s *RecipeFinderService) emit(ctx context.Context, events chan<- FinderEven
 	}
 }
 
+// saveRun persists one run's workflow telemetry (best-effort; telemetry must
+// never fail a run).
+func (s *RecipeFinderService) saveRun(run *models.FinderRun) {
+	if s.Runs == nil {
+		return
+	}
+	if err := s.Runs.Create(run); err != nil {
+		logger.Get().Warn("failed to save finder run telemetry", zap.Error(err))
+	}
+}
+
+// countExpandFlags counts the ranked candidates flagged as collections.
+func countExpandFlags(rank *ai.FinderRankResult) int {
+	if rank == nil {
+		return 0
+	}
+	n := 0
+	for _, r := range rank.Ranked {
+		if r.Expand {
+			n++
+		}
+	}
+	return n
+}
+
 // digCollections agentically mines the collection/listicle candidates the ranker
 // flagged (Expand) into their individual recipes, up to `room` recipes. It digs
 // reliably whenever a collection is flagged — collections are never shown as
@@ -303,11 +367,14 @@ func (s *RecipeFinderService) emit(ctx context.Context, events chan<- FinderEven
 // most finderDigWait per collection. It never invents — every folded recipe is a
 // real extraction. Folded recipes append via expanded events; when no direct pick
 // was shown (shortlistEmitted false), the first mined batch seeds the shortlist
-// instead so build-89 gets a proper base list. Returns every folded recipe.
-func (s *RecipeFinderService) digCollections(ctx context.Context, events chan<- FinderEvent, results []ai.SearchResult, rank *ai.FinderRankResult, room int, shortlistEmitted *bool, hasMore bool) []FinderResultItem {
+// instead so build-89 gets a proper base list. Returns every folded recipe plus
+// how many collections were actually dug (for run telemetry).
+func (s *RecipeFinderService) digCollections(ctx context.Context, events chan<- FinderEvent, results []ai.SearchResult, rank *ai.FinderRankResult, room int, shortlistEmitted *bool, hasMore bool) ([]FinderResultItem, int) {
 	if s.MultiResolver == nil || rank == nil || room <= 0 {
-		return nil
+		return nil, 0
 	}
+	// Card extractions kicked off below are the finder's own digging.
+	ctx = WithExtractionOrigin(ctx, ExtractionOriginFinderDig)
 
 	// Gather the flagged collection candidates, most promising first.
 	type collection struct {
@@ -327,7 +394,7 @@ func (s *RecipeFinderService) digCollections(ctx context.Context, events chan<- 
 		collections = append(collections, collection{url: u, title: results[r.Index].Title, prio: r.ExpandPriority})
 	}
 	if len(collections) == 0 {
-		return nil
+		return nil, 0
 	}
 	sort.SliceStable(collections, func(i, j int) bool { return collections[i].prio > collections[j].prio })
 	if len(collections) > finderDigK {
@@ -335,13 +402,15 @@ func (s *RecipeFinderService) digCollections(ctx context.Context, events chan<- 
 	}
 
 	var folded []FinderResultItem
+	dug := 0
 	for _, c := range collections {
 		if room <= 0 {
 			break
 		}
 		if !s.emit(ctx, events, FinderEvent{Type: FinderEventDigging, CollectionTitle: c.title}) {
-			return folded
+			return folded, dug
 		}
+		dug++
 
 		// Cap per-collection extraction to what we can still show.
 		maxCards := finderPerCollectionCardCap
@@ -395,10 +464,10 @@ func (s *RecipeFinderService) digCollections(ctx context.Context, events chan<- 
 			*shortlistEmitted = true
 		}
 		if !s.emit(ctx, events, ev) {
-			return folded
+			return folded, dug
 		}
 	}
-	return folded
+	return folded, dug
 }
 
 // waitForCollection polls a resolving collection until it is terminal (resolved
@@ -514,7 +583,10 @@ func hostOf(rawURL string) string {
 // gracefully to the real results in search order (no reasons/safety) rather than
 // dead-ending — search already returned real recipes, so the worst case is an
 // unranked-but-real shortlist, never a fabricated one.
-func (s *RecipeFinderService) rankCandidates(ctx context.Context, user *models.User, req FinderRequest, dietSummary string, results []ai.SearchResult) *ai.FinderRankResult {
+// rankCandidates runs the single ranking call. The second return is the rank
+// failure text ("" on success) — a failure degrades to fallbackRanking, and
+// the caller records it on the run telemetry.
+func (s *RecipeFinderService) rankCandidates(ctx context.Context, user *models.User, req FinderRequest, dietSummary string, results []ai.SearchResult) (*ai.FinderRankResult, string) {
 	candidates := make([]ai.FinderCandidate, len(results))
 	for i, r := range results {
 		candidates[i] = ai.FinderCandidate{
@@ -541,9 +613,9 @@ func (s *RecipeFinderService) rankCandidates(ctx context.Context, user *models.U
 	res, err := s.RankProvider.ExpandAndRankRecipes(ctx, rankReq)
 	if err != nil {
 		logger.Get().Warn("recipe finder ranking failed; showing unranked real results", zap.Error(err))
-		return fallbackRanking(len(results))
+		return fallbackRanking(len(results)), truncateErr(err)
 	}
-	return res
+	return res, ""
 }
 
 // applyKnownCollections force-flags ranked candidates whose URL the canonical

--- a/internal/service/telemetry_record.go
+++ b/internal/service/telemetry_record.go
@@ -1,0 +1,98 @@
+package service
+
+import (
+	"context"
+	"errors"
+	"time"
+
+	"github.com/windoze95/saltybytes-api/internal/ai"
+	"github.com/windoze95/saltybytes-api/internal/logger"
+	"github.com/windoze95/saltybytes-api/internal/models"
+	"go.uber.org/zap"
+)
+
+// Extraction origins: which product flow asked for an extraction. Stored on
+// ExtractionEvent.Origin so the dashboard can slice completeness per flow.
+const (
+	ExtractionOriginImport      = "import"
+	ExtractionOriginPreview     = "preview"
+	ExtractionOriginWarm        = "warm"
+	ExtractionOriginFinderDig   = "finder_dig"
+	ExtractionOriginMultiExpand = "multi_expand"
+	ExtractionOriginUnknown     = "unknown"
+)
+
+type extractionOriginKey struct{}
+
+// WithExtractionOrigin tags ctx with the product flow driving any extractions
+// beneath it. An origin already present wins (the outermost flow is the one
+// the user experienced).
+func WithExtractionOrigin(ctx context.Context, origin string) context.Context {
+	if _, ok := ctx.Value(extractionOriginKey{}).(string); ok {
+		return ctx
+	}
+	return context.WithValue(ctx, extractionOriginKey{}, origin)
+}
+
+// extractionOrigin reads the flow tag off ctx.
+func extractionOrigin(ctx context.Context) string {
+	if v, ok := ctx.Value(extractionOriginKey{}).(string); ok && v != "" {
+		return v
+	}
+	return ExtractionOriginUnknown
+}
+
+// recordExtraction persists one terminal extraction outcome. Best-effort and
+// synchronous (a single indexed insert): a telemetry failure only warns, never
+// fails the extraction itself. Callers fill URL/Method/Success/Error*; Origin
+// falls back to the ctx flow tag and Domain is derived from the URL.
+func (s *ImportService) recordExtraction(ctx context.Context, ev models.ExtractionEvent) {
+	if s == nil || s.Events == nil {
+		return
+	}
+	if ev.Origin == "" {
+		ev.Origin = extractionOrigin(ctx)
+	}
+	if ev.Domain == "" {
+		ev.Domain = domainFromURL(ev.URL)
+	}
+	if ev.CreatedAt.IsZero() {
+		ev.CreatedAt = time.Now()
+	}
+	if err := s.Events.Create(&ev); err != nil {
+		logger.Get().Warn("failed to record extraction event",
+			zap.String("url", ev.URL), zap.Error(err))
+	}
+}
+
+// extractionErrCode maps an extraction failure to a stable, groupable class
+// for the dashboard: ExtractionError codes pass through (site_blocked,
+// not_found, fetch_failed, ...), AI-layer failures become ai_error, anything
+// else extract_failed.
+func extractionErrCode(err error) string {
+	if err == nil {
+		return ""
+	}
+	var exErr *ExtractionError
+	if errors.As(err, &exErr) && exErr.Code != "" {
+		return exErr.Code
+	}
+	var aiErr *ai.AIError
+	if errors.As(err, &aiErr) {
+		return "ai_error"
+	}
+	return "extract_failed"
+}
+
+// truncateErr caps an error string for storage (full stacks stay in logs).
+func truncateErr(err error) string {
+	if err == nil {
+		return ""
+	}
+	msg := err.Error()
+	const maxLen = 2000
+	if len(msg) > maxLen {
+		return msg[:maxLen] + "…"
+	}
+	return msg
+}

--- a/internal/service/telemetry_test.go
+++ b/internal/service/telemetry_test.go
@@ -1,0 +1,213 @@
+package service
+
+import (
+	"context"
+	"fmt"
+	"testing"
+
+	"github.com/windoze95/saltybytes-api/internal/ai"
+	"github.com/windoze95/saltybytes-api/internal/models"
+	"github.com/windoze95/saltybytes-api/internal/testutil"
+)
+
+// --- FinderRun telemetry -----------------------------------------------------
+
+func TestFindRecipes_TelemetryHappyPath(t *testing.T) {
+	results := digSearchResults(3)
+	searchProvider := &testutil.MockSearchProvider{
+		SearchRecipesFunc: func(ctx context.Context, query string, count, offset int) ([]ai.SearchResult, error) {
+			return results, nil
+		},
+	}
+	ranker := rankAllFlagging(results, nil) // all ranked, nothing flagged
+
+	svc := newFinderService(searchProvider, ranker, &testutil.MockFamilyRepo{})
+	runs := testutil.NewMockFinderRunRepo()
+	svc.Runs = runs
+
+	runFinder(svc, testutil.TestUser(), FinderRequest{Facets: FinderFacets{Protein: "chicken"}})
+
+	all := runs.Runs()
+	if len(all) != 1 {
+		t.Fatalf("recorded %d runs, want 1", len(all))
+	}
+	run := all[0]
+	if run.Terminal != "done" {
+		t.Errorf("Terminal = %q, want done", run.Terminal)
+	}
+	if !run.RankOK || run.RankError != "" {
+		t.Errorf("RankOK = %v / RankError = %q, want ok", run.RankOK, run.RankError)
+	}
+	if run.ResultsFound != 3 {
+		t.Errorf("ResultsFound = %d, want 3", run.ResultsFound)
+	}
+	if run.ShownDirect != 3 || run.ShownTotal != 3 {
+		t.Errorf("Shown = %d/%d, want 3/3", run.ShownDirect, run.ShownTotal)
+	}
+	if run.CollectionsFlagged != 0 || run.CollectionsDug != 0 || run.CardsMined != 0 {
+		t.Errorf("dig counters = %d/%d/%d, want zeros",
+			run.CollectionsFlagged, run.CollectionsDug, run.CardsMined)
+	}
+	if run.Query == "" {
+		t.Error("Query not recorded")
+	}
+	if run.UserID == 0 {
+		t.Error("UserID not recorded")
+	}
+}
+
+func TestFindRecipes_TelemetryRankFailure(t *testing.T) {
+	results := digSearchResults(2)
+	searchProvider := &testutil.MockSearchProvider{
+		SearchRecipesFunc: func(ctx context.Context, query string, count, offset int) ([]ai.SearchResult, error) {
+			return results, nil
+		},
+	}
+	ranker := &testutil.MockTextProvider{
+		ExpandAndRankRecipesFunc: func(ctx context.Context, req ai.FinderRankRequest) (*ai.FinderRankResult, error) {
+			return nil, fmt.Errorf("model exploded")
+		},
+	}
+
+	svc := newFinderService(searchProvider, ranker, &testutil.MockFamilyRepo{})
+	runs := testutil.NewMockFinderRunRepo()
+	svc.Runs = runs
+
+	runFinder(svc, testutil.TestUser(), FinderRequest{Facets: FinderFacets{Protein: "chicken"}})
+
+	all := runs.Runs()
+	if len(all) != 1 {
+		t.Fatalf("recorded %d runs, want 1", len(all))
+	}
+	run := all[0]
+	// The run still completes (graceful degradation) but the rank failure is
+	// visible for the dashboard's failure-rate chart.
+	if run.Terminal != "done" {
+		t.Errorf("Terminal = %q, want done (degraded run still completes)", run.Terminal)
+	}
+	if run.RankOK {
+		t.Error("RankOK = true, want false on a ranking failure")
+	}
+	if run.RankError == "" {
+		t.Error("RankError empty, want the failure text")
+	}
+}
+
+func TestFindRecipes_TelemetryDigCounters(t *testing.T) {
+	results := digSearchResults(3)
+	searchProvider := &testutil.MockSearchProvider{
+		SearchRecipesFunc: func(ctx context.Context, query string, count, offset int) ([]ai.SearchResult, error) {
+			return results, nil
+		},
+	}
+	// Candidate 1 is a flagged collection; the fake resolver mines 2 recipes.
+	ranker := rankAllFlagging(results, map[int]int{1: 5})
+	fake := &fakeMultiResolver{entries: map[string]*MultiRecipeEntry{
+		results[1].URL: resolvedEntry(results[1].URL,
+			doneCard("Mined One", results[1].URL+"?_recipe=mined-one-0"),
+			doneCard("Mined Two", results[1].URL+"?_recipe=mined-two-1"),
+		),
+	}}
+
+	svc := newFinderService(searchProvider, ranker, &testutil.MockFamilyRepo{})
+	svc.MultiResolver = fake
+	runs := testutil.NewMockFinderRunRepo()
+	svc.Runs = runs
+
+	runFinder(svc, testutil.TestUser(), FinderRequest{Facets: FinderFacets{Protein: "chicken"}})
+
+	all := runs.Runs()
+	if len(all) != 1 {
+		t.Fatalf("recorded %d runs, want 1", len(all))
+	}
+	run := all[0]
+	if run.CollectionsFlagged != 1 {
+		t.Errorf("CollectionsFlagged = %d, want 1", run.CollectionsFlagged)
+	}
+	if run.CollectionsDug != 1 {
+		t.Errorf("CollectionsDug = %d, want 1", run.CollectionsDug)
+	}
+	if run.CardsMined != 2 {
+		t.Errorf("CardsMined = %d, want 2", run.CardsMined)
+	}
+	if run.ShownTotal != run.ShownDirect+2 {
+		t.Errorf("ShownTotal = %d, want direct(%d)+2", run.ShownTotal, run.ShownDirect)
+	}
+}
+
+// --- ExtractionEvent telemetry ----------------------------------------------
+
+func TestPreviewFromURL_RecordsFailureEvent(t *testing.T) {
+	imp := newTestImportService(testutil.NewMockRecipeRepo(), nil, nil)
+	events := testutil.NewMockExtractionEventRepo()
+	imp.Events = events
+	imp.HTTPFetchOverride = func(context.Context, string) ([]byte, int, error) {
+		return nil, 404, nil
+	}
+
+	_, _, err := imp.PreviewFromURL(context.Background(), "https://example.com/recipes/lost-cake")
+	if err == nil {
+		t.Fatal("expected a not_found error")
+	}
+
+	evs := events.Events()
+	if len(evs) != 1 {
+		t.Fatalf("recorded %d events, want 1", len(evs))
+	}
+	ev := evs[0]
+	if ev.Success {
+		t.Error("Success = true, want false")
+	}
+	if ev.ErrorCode != "not_found" {
+		t.Errorf("ErrorCode = %q, want not_found", ev.ErrorCode)
+	}
+	if ev.Origin != ExtractionOriginPreview {
+		t.Errorf("Origin = %q, want preview", ev.Origin)
+	}
+	if ev.Domain != "example.com" {
+		t.Errorf("Domain = %q, want example.com", ev.Domain)
+	}
+	if ev.Error == "" {
+		t.Error("Error text empty, want the failure message")
+	}
+}
+
+func TestPreviewFromURL_RecordsSuccessEvent(t *testing.T) {
+	imp := newTestImportService(testutil.NewMockRecipeRepo(), nil, nil)
+	events := testutil.NewMockExtractionEventRepo()
+	imp.Events = events
+	imp.HTTPFetchOverride = func(context.Context, string) ([]byte, int, error) {
+		return []byte(jsonLDHTML()), 200, nil
+	}
+
+	if _, _, err := imp.PreviewFromURL(context.Background(), "https://example.com/recipes/great-cake"); err != nil {
+		t.Fatalf("preview failed: %v", err)
+	}
+
+	evs := events.Events()
+	if len(evs) != 1 {
+		t.Fatalf("recorded %d events, want 1", len(evs))
+	}
+	ev := evs[0]
+	if !ev.Success {
+		t.Errorf("Success = false (err_code=%q err=%q), want true", ev.ErrorCode, ev.Error)
+	}
+	if ev.Method != string(models.ExtractionJSONLD) {
+		t.Errorf("Method = %q, want %q", ev.Method, models.ExtractionJSONLD)
+	}
+	if ev.UsedFirecrawl {
+		t.Error("UsedFirecrawl = true, want false for a direct fetch")
+	}
+}
+
+func TestExtractionEventsNilRepoIsSafe(t *testing.T) {
+	imp := newTestImportService(testutil.NewMockRecipeRepo(), nil, nil)
+	imp.Events = nil // default: telemetry off
+	imp.HTTPFetchOverride = func(context.Context, string) ([]byte, int, error) {
+		return nil, 404, nil
+	}
+	// Must not panic.
+	if _, _, err := imp.PreviewFromURL(context.Background(), "https://example.com/x"); err == nil {
+		t.Fatal("expected error")
+	}
+}

--- a/internal/testutil/mocks.go
+++ b/internal/testutil/mocks.go
@@ -1232,3 +1232,75 @@ var _ repository.CanonicalRecipeRepo = (*MockCanonicalRecipeRepo)(nil)
 var _ repository.FamilyRepo = (*MockFamilyRepo)(nil)
 var _ repository.FinderSessionRepo = (*MockFinderSessionRepo)(nil)
 var _ repository.VideoImportRepo = (*MockVideoImportRepo)(nil)
+
+// --- MockFinderRunRepo ---
+
+// MockFinderRunRepo is an in-memory mock of repository.FinderRunRepo. Runs are
+// recorded thread-safely so tests can assert on the telemetry a finder run
+// writes.
+type MockFinderRunRepo struct {
+	mu   sync.Mutex
+	runs []*models.FinderRun
+
+	CreateErr error
+}
+
+// NewMockFinderRunRepo creates an empty in-memory finder-run repo.
+func NewMockFinderRunRepo() *MockFinderRunRepo {
+	return &MockFinderRunRepo{}
+}
+
+func (m *MockFinderRunRepo) Create(run *models.FinderRun) error {
+	if m.CreateErr != nil {
+		return m.CreateErr
+	}
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	cp := *run
+	m.runs = append(m.runs, &cp)
+	return nil
+}
+
+// Runs returns a snapshot of every recorded run.
+func (m *MockFinderRunRepo) Runs() []*models.FinderRun {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	out := make([]*models.FinderRun, len(m.runs))
+	copy(out, m.runs)
+	return out
+}
+
+// --- MockExtractionEventRepo ---
+
+// MockExtractionEventRepo is an in-memory mock of repository.ExtractionEventRepo.
+type MockExtractionEventRepo struct {
+	mu     sync.Mutex
+	events []*models.ExtractionEvent
+
+	CreateErr error
+}
+
+// NewMockExtractionEventRepo creates an empty in-memory extraction-event repo.
+func NewMockExtractionEventRepo() *MockExtractionEventRepo {
+	return &MockExtractionEventRepo{}
+}
+
+func (m *MockExtractionEventRepo) Create(event *models.ExtractionEvent) error {
+	if m.CreateErr != nil {
+		return m.CreateErr
+	}
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	cp := *event
+	m.events = append(m.events, &cp)
+	return nil
+}
+
+// Events returns a snapshot of every recorded event.
+func (m *MockExtractionEventRepo) Events() []*models.ExtractionEvent {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	out := make([]*models.ExtractionEvent, len(m.events))
+	copy(out, m.events)
+	return out
+}


### PR DESCRIPTION
Data layer for two new dashboard panels (pages land next in saltybytes-dashboard, which reads these tables from the prod DB directly — both tables are additive).

## finder_runs — agent workflow metrics
One row per agent search run, written via `defer` so **every** exit path records (done / empty / error / **cancelled** — client disconnects included): query, results found + cache hit, **rank ok/error** (fallback-degradation visibility), collections **flagged → dug → cards mined** funnel, shown direct/total, and per-step latencies (search / rank / dig / total).

## extraction_events — every extraction attempt, full context
One row per terminal attempt at each chokepoint (`extractFromURL`, multi-check preview, warm, multi-resolve fetch, per collection card): url/domain, **origin flow** (import / preview / warm / finder_dig / multi_expand — context-tagged; cards carry it on the entry since they extract detached), method, stable `error_code`, error text, firecrawl involvement, duration, and a JSONB context bag (card title, collection url, attempts, html_len) for drill-downs and the upcoming "Copy for LLM" button.

Telemetry is nil-safe and best-effort everywhere — it can never fail the product flow.

## Tests
Run telemetry (happy path / rank failure / dig counters), event recording (404 failure event, JSON-LD success event, nil-repo safety). Full offline suite green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BU4UWZutHd1AnK3XAf7H19