### PR TITLE
Fix deploy: bump Docker builder + CI to Go 1.25

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,7 +15,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v5
         with:
-          go-version: "1.24"
+          go-version: "1.25"
 
       - name: Vet
         run: go vet ./...

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -30,7 +30,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v5
         with:
-          go-version: "1.24"
+          go-version: "1.25"
 
       - name: Vet
         run: go vet ./...

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # Stage 1: Build
-FROM golang:1.24 AS builder
+FROM golang:1.25 AS builder
 
 # Set the working directory in the builder
 WORKDIR /app


### PR DESCRIPTION
#114 raised go.mod to `go 1.25.0` (required by `modelcontextprotocol/go-sdk`). CI passed because `actions/setup-go` auto-downloads newer toolchains, but the `golang:1.24` builder image sets `GOTOOLCHAIN=local`, so the deploy's Docker build failed at `go mod download` — the deploy stopped before pushing, prod is still on the previous image.

This bumps the builder to `golang:1.25` and aligns `go-version` in both workflows.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0135RSi6FBDow4ohd34spVtj