### PR TITLE
fix(auth): case-insensitive login, email identifier, clear signup errors

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -17,6 +17,7 @@ require (
 	github.com/golang-jwt/jwt/v5 v5.3.1
 	github.com/google/uuid v1.6.0
 	github.com/gorilla/websocket v1.5.3
+	github.com/jackc/pgx/v5 v5.6.0
 	github.com/lib/pq v1.10.9
 	github.com/modelcontextprotocol/go-sdk v1.6.1
 	github.com/sashabaranov/go-openai v1.36.0
@@ -56,7 +57,6 @@ require (
 	github.com/google/jsonschema-go v0.4.3 // indirect
 	github.com/jackc/pgpassfile v1.0.0 // indirect
 	github.com/jackc/pgservicefile v0.0.0-20240606120523-5a60cdf6a761 // indirect
-	github.com/jackc/pgx/v5 v5.6.0 // indirect
 	github.com/jackc/puddle/v2 v2.2.1 // indirect
 	github.com/jinzhu/inflection v1.0.0 // indirect
 	github.com/jinzhu/now v1.1.5 // indirect

--- a/internal/db/db.go
+++ b/internal/db/db.go
@@ -95,6 +95,15 @@ func connectToDatabaseWithRetry(databaseURL string) (*gorm.DB, error) {
 		logger.Get().Warn("failed to create idx_recipes_user_created index", zap.Error(execErr))
 	}
 
+	// Login matches usernames and emails case-insensitively; expression
+	// indexes keep those lookups off a sequential scan.
+	if execErr := database.Exec(`CREATE INDEX IF NOT EXISTS idx_users_username_lower ON users (LOWER(username))`).Error; execErr != nil {
+		logger.Get().Warn("failed to create idx_users_username_lower index", zap.Error(execErr))
+	}
+	if execErr := database.Exec(`CREATE INDEX IF NOT EXISTS idx_users_email_lower ON users (LOWER(email))`).Error; execErr != nil {
+		logger.Get().Warn("failed to create idx_users_email_lower index", zap.Error(execErr))
+	}
+
 	// Add the FK from recipe_nodes.tree_id → recipe_trees.id that gorm:"-" skipped.
 	// Postgres does not support ADD CONSTRAINT IF NOT EXISTS, so guard with a
 	// pg_constraint existence check.

--- a/internal/handlers/user.go
+++ b/internal/handlers/user.go
@@ -4,6 +4,7 @@ import (
 	"errors"
 	"fmt"
 	"net/http"
+	"strings"
 	"time"
 
 	"github.com/gin-gonic/gin"
@@ -42,6 +43,13 @@ func (h *UserHandler) CreateUser(c *gin.Context) {
 		return
 	}
 
+	// Mobile keyboards autocapitalize and append stray spaces; normalize the
+	// identifier fields before validating. The password is never trimmed —
+	// spaces are legitimate password characters.
+	newUser.Username = strings.TrimSpace(newUser.Username)
+	newUser.Email = strings.TrimSpace(newUser.Email)
+	newUser.FirstName = strings.TrimSpace(newUser.FirstName)
+
 	// Validate username
 	if err := h.Service.ValidateUsername(newUser.Username); err != nil {
 		c.JSON(http.StatusBadRequest, gin.H{"error": err.Error()})
@@ -51,6 +59,19 @@ func (h *UserHandler) CreateUser(c *gin.Context) {
 	// Validate email
 	if err := h.Service.ValidateEmail(newUser.Email); err != nil {
 		c.JSON(http.StatusBadRequest, gin.H{"error": err.Error()})
+		return
+	}
+
+	// Reject duplicate emails up front with a clear message; the DB unique
+	// constraint stays as the backstop for races.
+	emailInUse, err := h.Service.EmailInUse(newUser.Email)
+	if err != nil {
+		logger.Get().Error("failed to check email availability", zap.Error(err))
+		c.JSON(http.StatusInternalServerError, gin.H{"error": "Failed to create user"})
+		return
+	}
+	if emailInUse {
+		c.JSON(http.StatusConflict, gin.H{"error": "email already in use"})
 		return
 	}
 
@@ -104,11 +125,18 @@ func (h *UserHandler) LoginUser(c *gin.Context) {
 		return
 	}
 
-	user, err := h.Service.LoginUser(userCredentials.Username, userCredentials.Password)
+	user, err := h.Service.LoginUser(strings.TrimSpace(userCredentials.Username), userCredentials.Password)
 	if err != nil {
-		// Identical generic response for unknown-user and bad-password so the
-		// endpoint cannot be used to enumerate usernames.
-		c.JSON(http.StatusUnauthorized, gin.H{"error": "invalid username or password"})
+		if errors.Is(err, service.ErrInvalidCredentials) {
+			// Identical generic response for unknown-user and bad-password so
+			// the endpoint cannot be used to enumerate usernames.
+			c.JSON(http.StatusUnauthorized, gin.H{"error": "invalid username or password"})
+			return
+		}
+		// Infrastructure failure (e.g. DB outage) — telling the user their
+		// credentials are wrong would be a lie they can't fix.
+		logger.Get().Error("login failed on internal error", zap.Error(err))
+		c.JSON(http.StatusInternalServerError, gin.H{"error": "Something went wrong, please try again"})
 		return
 	}
 

--- a/internal/handlers/user_auth_regression_test.go
+++ b/internal/handlers/user_auth_regression_test.go
@@ -1,0 +1,165 @@
+package handlers
+
+import (
+	"encoding/json"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/gin-gonic/gin"
+	"github.com/windoze95/saltybytes-api/internal/models"
+	"github.com/windoze95/saltybytes-api/internal/testutil"
+	"golang.org/x/crypto/bcrypt"
+)
+
+// Regression tests for the tester-reported signup/login failures: signups
+// that appeared to succeed but couldn't log in (case-sensitive lookup, the
+// "Username or Email" field only matching usernames) and opaque signup
+// failures (duplicate email surfacing as a 500).
+
+func postJSON(r *gin.Engine, path, body string) *httptest.ResponseRecorder {
+	req := httptest.NewRequest("POST", path, strings.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, req)
+	return w
+}
+
+func seedHandlerUser(repo *testutil.MockUserRepo, username, email, password string) {
+	hashedPwd, _ := bcrypt.GenerateFromPassword([]byte(password), 10)
+	repo.CreateUser(&models.User{
+		Username: username,
+		Email:    email,
+		Auth: &models.UserAuth{
+			HashedPassword: string(hashedPwd),
+			AuthType:       models.Standard,
+		},
+		Settings:        &models.UserSettings{KeepScreenAwake: true},
+		Personalization: &models.Personalization{UnitSystem: "us_customary"},
+	})
+}
+
+func TestSignupThenLogin_DifferentCase_Roundtrip(t *testing.T) {
+	handler, _ := newTestUserHandler()
+
+	r := gin.New()
+	r.POST("/users", handler.CreateUser)
+	r.POST("/auth/login", handler.LoginUser)
+
+	// Sign up the way an iOS keyboard types it: capitalized.
+	w := postJSON(r, "/users", `{"username": "Lincoln42", "email": "lincoln@example.com", "password": "Password1!"}`)
+	if w.Code != http.StatusOK {
+		t.Fatalf("signup status = %d, body: %s", w.Code, w.Body.String())
+	}
+
+	// Log in lowercase — this is the exact flow that used to fail.
+	w = postJSON(r, "/auth/login", `{"username": "lincoln42", "password": "Password1!"}`)
+	if w.Code != http.StatusOK {
+		t.Fatalf("login status = %d, body: %s", w.Code, w.Body.String())
+	}
+}
+
+func TestLoginUser_Handler_EmailIdentifier(t *testing.T) {
+	handler, repo := newTestUserHandler()
+	seedHandlerUser(repo, "testuser", "Test@Example.com", "Password1!")
+
+	r := gin.New()
+	r.POST("/auth/login", handler.LoginUser)
+
+	// The login screen is labeled "Username or Email" and always sends the
+	// value under the "username" key.
+	w := postJSON(r, "/auth/login", `{"username": "test@example.com", "password": "Password1!"}`)
+	if w.Code != http.StatusOK {
+		t.Fatalf("login-by-email status = %d, body: %s", w.Code, w.Body.String())
+	}
+
+	var resp map[string]interface{}
+	json.Unmarshal(w.Body.Bytes(), &resp)
+	if resp["access_token"] == nil {
+		t.Error("response should contain 'access_token'")
+	}
+}
+
+func TestLoginUser_Handler_TrimsIdentifier(t *testing.T) {
+	handler, repo := newTestUserHandler()
+	seedHandlerUser(repo, "testuser", "test@example.com", "Password1!")
+
+	r := gin.New()
+	r.POST("/auth/login", handler.LoginUser)
+
+	w := postJSON(r, "/auth/login", `{"username": " testuser ", "password": "Password1!"}`)
+	if w.Code != http.StatusOK {
+		t.Fatalf("login with padded identifier status = %d, body: %s", w.Code, w.Body.String())
+	}
+}
+
+func TestCreateUser_Handler_DuplicateEmail_409(t *testing.T) {
+	handler, repo := newTestUserHandler()
+	seedHandlerUser(repo, "existing", "taken@example.com", "Password1!")
+
+	r := gin.New()
+	r.POST("/users", handler.CreateUser)
+
+	// Same email, different case — used to slip past validation and die on
+	// the DB constraint as an opaque 500.
+	w := postJSON(r, "/users", `{"username": "newperson", "email": "Taken@Example.com", "password": "Password1!"}`)
+	if w.Code != http.StatusConflict {
+		t.Fatalf("status = %d, want %d. body: %s", w.Code, http.StatusConflict, w.Body.String())
+	}
+
+	var resp map[string]interface{}
+	json.Unmarshal(w.Body.Bytes(), &resp)
+	if msg, _ := resp["error"].(string); !strings.Contains(msg, "email") {
+		t.Errorf("error message %q should mention the email", msg)
+	}
+}
+
+func TestCreateUser_Handler_TrimsFields(t *testing.T) {
+	handler, _ := newTestUserHandler()
+
+	r := gin.New()
+	r.POST("/users", handler.CreateUser)
+	r.POST("/auth/login", handler.LoginUser)
+
+	// Keyboard autocomplete loves trailing spaces. Untrimmed, the username
+	// would fail alphanumeric validation and the email would fail format
+	// validation.
+	w := postJSON(r, "/users", `{"username": "chefbob42 ", "email": " new@example.com", "password": "Password1!"}`)
+	if w.Code != http.StatusOK {
+		t.Fatalf("signup status = %d, body: %s", w.Code, w.Body.String())
+	}
+
+	w = postJSON(r, "/auth/login", `{"username": "chefbob42", "password": "Password1!"}`)
+	if w.Code != http.StatusOK {
+		t.Fatalf("login status = %d, body: %s", w.Code, w.Body.String())
+	}
+}
+
+func TestCreateUser_Handler_PasswordWithCommonSpecialChar(t *testing.T) {
+	handler, _ := newTestUserHandler()
+
+	r := gin.New()
+	r.POST("/users", handler.CreateUser)
+
+	// '.' was not in the old special-character allowlist, so this signup
+	// used to 400 — and the app swallowed the message.
+	w := postJSON(r, "/users", `{"username": "chefbob42", "email": "new@example.com", "password": "Password1."}`)
+	if w.Code != http.StatusOK {
+		t.Fatalf("status = %d, body: %s", w.Code, w.Body.String())
+	}
+}
+
+func TestLoginUser_Handler_InfraError_500(t *testing.T) {
+	handler, repo := newTestUserHandler()
+	repo.GetUserAuthErr = errors.New("connection refused")
+
+	r := gin.New()
+	r.POST("/auth/login", handler.LoginUser)
+
+	w := postJSON(r, "/auth/login", `{"username": "testuser", "password": "Password1!"}`)
+	if w.Code != http.StatusInternalServerError {
+		t.Fatalf("status = %d, want 500 (DB outages must not read as bad credentials). body: %s", w.Code, w.Body.String())
+	}
+}

--- a/internal/repository/interfaces.go
+++ b/internal/repository/interfaces.go
@@ -118,11 +118,13 @@ type UserRepo interface {
 	GetUserByID(userID uint) (*models.User, error)
 	GetUserWithAuthByID(userID uint) (*models.User, error)
 	GetUserAuthByUsername(username string) (*models.User, error)
+	GetUserAuthByEmail(email string) (*models.User, error)
 	UpdateUserFirstName(userID uint, firstName string) error
 	UpdateUserEmail(userID uint, email string) error
 	UpdateUserSettingsKeepScreenAwake(userID uint, keepScreenAwake bool) error
 	UpdatePersonalization(userID uint, update *models.PersonalizationUpdate) error
 	UsernameExists(username string) (bool, error)
+	EmailExists(email string) (bool, error)
 	IncrementTokenVersion(userID uint) error
 	CreateSubscription(sub *models.Subscription) error
 	IncrementSubscriptionUsage(userID uint, column string) error

--- a/internal/repository/user.go
+++ b/internal/repository/user.go
@@ -5,7 +5,7 @@ import (
 	"strings"
 	"time"
 
-	"github.com/lib/pq"
+	"github.com/jackc/pgx/v5/pgconn"
 	"github.com/windoze95/saltybytes-api/internal/logger"
 	"github.com/windoze95/saltybytes-api/internal/models"
 	"go.uber.org/zap"
@@ -22,23 +22,37 @@ func NewUserRepository(db *gorm.DB) *UserRepository {
 	return &UserRepository{DB: db}
 }
 
+// mapUserUniqueViolation converts Postgres unique-constraint violations on
+// the users table into the sentinel errors handlers match with errors.Is.
+// Any other error is returned unchanged. The pgx driver (used by
+// gorm.io/driver/postgres) surfaces these as *pgconn.PgError with SQLSTATE
+// 23505; the violation fires on the INSERT itself, not on commit.
+func mapUserUniqueViolation(err error) error {
+	var pgErr *pgconn.PgError
+	if errors.As(err, &pgErr) && pgErr.Code == "23505" {
+		constraint := pgErr.ConstraintName
+		if constraint == "" {
+			constraint = pgErr.Message
+		}
+		if strings.Contains(constraint, "username") {
+			return ErrUsernameTaken
+		}
+		if strings.Contains(constraint, "email") {
+			return ErrEmailTaken
+		}
+	}
+	return err
+}
+
 // CreateUser creates a new user.
 func (r *UserRepository) CreateUser(user *models.User) (*models.User, error) {
 	tx := r.DB.Begin()
 	if err := tx.Create(user).Error; err != nil {
 		tx.Rollback()
-		return nil, err
+		return nil, mapUserUniqueViolation(err)
 	}
 	if err := tx.Commit().Error; err != nil {
-		// Check for unique constraints
-		if pgErr, ok := err.(*pq.Error); ok && pgErr.Code == "23505" {
-			if strings.Contains(pgErr.Error(), "username") {
-				return nil, ErrUsernameTaken
-			} else if strings.Contains(pgErr.Error(), "email") {
-				return nil, ErrEmailTaken
-			}
-		}
-		return nil, err
+		return nil, mapUserUniqueViolation(err)
 	}
 
 	return user, nil
@@ -71,11 +85,27 @@ func (r *UserRepository) GetUserWithAuthByID(userID uint) (*models.User, error) 
 	return &user, nil
 }
 
-// GetUserAuthByUsername retrieves a user's authentication information by their username.
+// GetUserAuthByUsername retrieves a user's authentication information by
+// their username. The match is case-insensitive: signup stores the username
+// as typed (mobile keyboards autocapitalize), so an exact match would lock
+// out anyone who types their name in a different case at login.
 func (r *UserRepository) GetUserAuthByUsername(username string) (*models.User, error) {
 	var user models.User
 	if err := r.DB.Preload("Auth").Preload("Settings").Preload("Personalization").
-		Where("username = ?", username).
+		Where("LOWER(username) = LOWER(?)", username).
+		First(&user).Error; err != nil {
+		return nil, err
+	}
+
+	return &user, nil
+}
+
+// GetUserAuthByEmail retrieves a user's authentication information by their
+// email address, case-insensitively.
+func (r *UserRepository) GetUserAuthByEmail(email string) (*models.User, error) {
+	var user models.User
+	if err := r.DB.Preload("Auth").Preload("Settings").Preload("Personalization").
+		Where("LOWER(email) = LOWER(?)", email).
 		First(&user).Error; err != nil {
 		return nil, err
 	}
@@ -101,9 +131,10 @@ func (r *UserRepository) UpdateUserEmail(userID uint, email string) error {
 		Update("Email", email).Error
 	if err != nil {
 		logger.Get().Error("failed to update user email", zap.Uint("user_id", userID), zap.Error(err))
+		return mapUserUniqueViolation(err)
 	}
 
-	return err
+	return nil
 }
 
 // UpdateUserSettingsKeepScreenAwake updates a user's KeepScreenAwake setting.
@@ -240,6 +271,22 @@ func (r *UserRepository) UsernameExists(username string) (bool, error) {
 	lowercaseUsername := strings.ToLower(username)
 	var user models.User
 	err := r.DB.Where("LOWER(username) = ?", lowercaseUsername).
+		First(&user).Error
+	if err != nil {
+		if errors.Is(err, gorm.ErrRecordNotFound) {
+			return false, nil
+		}
+		return false, err
+	}
+	return true, nil
+}
+
+// EmailExists checks if an email address is already registered, ignoring
+// case. The DB unique constraint on email is case-sensitive, so this check
+// is also what keeps Foo@x.com and foo@x.com from becoming two accounts.
+func (r *UserRepository) EmailExists(email string) (bool, error) {
+	var user models.User
+	err := r.DB.Where("LOWER(email) = LOWER(?)", email).
 		First(&user).Error
 	if err != nil {
 		if errors.Is(err, gorm.ErrRecordNotFound) {

--- a/internal/repository/user_error_mapping_test.go
+++ b/internal/repository/user_error_mapping_test.go
@@ -1,0 +1,58 @@
+package repository
+
+import (
+	"errors"
+	"fmt"
+	"testing"
+
+	"github.com/jackc/pgx/v5/pgconn"
+)
+
+// The pgx driver (gorm.io/driver/postgres) surfaces unique violations as
+// *pgconn.PgError. The old code type-asserted *pq.Error, which never
+// matched, so duplicate signups surfaced as opaque 500s.
+
+func TestMapUserUniqueViolation_Username(t *testing.T) {
+	err := mapUserUniqueViolation(&pgconn.PgError{Code: "23505", ConstraintName: "uni_users_username"})
+	if !errors.Is(err, ErrUsernameTaken) {
+		t.Errorf("err = %v, want ErrUsernameTaken", err)
+	}
+}
+
+func TestMapUserUniqueViolation_Email(t *testing.T) {
+	err := mapUserUniqueViolation(&pgconn.PgError{Code: "23505", ConstraintName: "uni_users_email"})
+	if !errors.Is(err, ErrEmailTaken) {
+		t.Errorf("err = %v, want ErrEmailTaken", err)
+	}
+}
+
+func TestMapUserUniqueViolation_FallsBackToMessage(t *testing.T) {
+	// Older schemas name the constraint differently; the message still
+	// carries the column.
+	err := mapUserUniqueViolation(&pgconn.PgError{
+		Code:    "23505",
+		Message: `duplicate key value violates unique constraint "users_email_key"`,
+	})
+	if !errors.Is(err, ErrEmailTaken) {
+		t.Errorf("err = %v, want ErrEmailTaken", err)
+	}
+}
+
+func TestMapUserUniqueViolation_WrappedError(t *testing.T) {
+	wrapped := fmt.Errorf("create user: %w", &pgconn.PgError{Code: "23505", ConstraintName: "uni_users_username"})
+	if !errors.Is(mapUserUniqueViolation(wrapped), ErrUsernameTaken) {
+		t.Error("wrapped pgconn errors should still map")
+	}
+}
+
+func TestMapUserUniqueViolation_PassthroughOtherErrors(t *testing.T) {
+	sentinel := errors.New("some other failure")
+	if got := mapUserUniqueViolation(sentinel); got != sentinel {
+		t.Errorf("non-unique-violation errors must pass through unchanged, got %v", got)
+	}
+
+	notUnique := &pgconn.PgError{Code: "23503", ConstraintName: "fk_users_something"}
+	if got := mapUserUniqueViolation(notUnique); !errors.As(got, new(*pgconn.PgError)) {
+		t.Errorf("non-23505 pg errors must pass through, got %v", got)
+	}
+}

--- a/internal/router/router.go
+++ b/internal/router/router.go
@@ -230,18 +230,23 @@ func SetupRouter(cfg *config.Config, database *gorm.DB) *gin.Engine {
 	// Group for API routes that don't require token verification
 	apiPublic := r.Group("/v1")
 	apiPublic.Use(middleware.CheckIDHeader(cfg.EnvVars.IDHeader))
-	// Rate-limit the public auth endpoints per IP (5 req/min, burst 10) to
-	// slow down credential stuffing and signup abuse.
-	apiPublic.Use(middleware.RateLimitByIP(5, 10, 5*time.Minute, 15*time.Minute))
+	// Rate-limit the public auth endpoints per IP. Signup and login share one
+	// tight bucket to slow credential stuffing and signup abuse. Refresh gets
+	// its own, much higher bucket: it needs a validly signed refresh token to
+	// be of any use to an attacker, it fires on every app cold start, and
+	// many legitimate users can share one IP (office NAT, carrier CGNAT) —
+	// starving it logs real users out.
+	credentialLimiter := middleware.RateLimitByIP(10, 20, 5*time.Minute, 15*time.Minute)
+	refreshLimiter := middleware.RateLimitByIP(60, 120, 5*time.Minute, 15*time.Minute)
 	{
 		// User-related routes
 
 		// Create a new user
-		apiPublic.POST("/users", userHandler.CreateUser)
+		apiPublic.POST("/users", credentialLimiter, userHandler.CreateUser)
 		// Login a user
-		apiPublic.POST("/auth/login", userHandler.LoginUser)
+		apiPublic.POST("/auth/login", credentialLimiter, userHandler.LoginUser)
 		// Refresh an access token
-		apiPublic.POST("/auth/refresh", userHandler.RefreshToken)
+		apiPublic.POST("/auth/refresh", refreshLimiter, userHandler.RefreshToken)
 	}
 
 	// Group for API routes that require token verification

--- a/internal/service/user.go
+++ b/internal/service/user.go
@@ -14,6 +14,7 @@ import (
 	"github.com/windoze95/saltybytes-api/internal/models"
 	"github.com/windoze95/saltybytes-api/internal/repository"
 	"golang.org/x/crypto/bcrypt"
+	"gorm.io/gorm"
 )
 
 // UserService is the business logic layer for user-related operations.
@@ -55,8 +56,14 @@ func NewUserService(cfg *config.Config, repo repository.UserRepo) *UserService {
 	}
 }
 
-// CreateUser creates a new user.
+// CreateUser creates a new user. Identifier fields are trimmed here as well
+// as in the handler so no caller can store padded values; the password is
+// never trimmed (spaces are legitimate password characters).
 func (s *UserService) CreateUser(username, firstName, email, password string) (*models.User, error) {
+	username = strings.TrimSpace(username)
+	firstName = strings.TrimSpace(firstName)
+	email = strings.TrimSpace(email)
+
 	// Hash password
 	hashedPassword, err := bcrypt.GenerateFromPassword([]byte(password), 10)
 	if err != nil {
@@ -108,9 +115,25 @@ var ErrInvalidCredentials = errors.New("invalid username or password")
 // username exists.
 var dummyBcryptHash = []byte("$2a$10$eTN04vDBzQvPQeH2t2QGHe/dB4sezgOEiN7Jd9/BB4cv7Hkgimei6")
 
-// LoginUser logs in a user.
-func (s *UserService) LoginUser(username, password string) (*models.User, error) {
-	user, err := s.Repo.GetUserAuthByUsername(username)
+// LoginUser logs in a user. The identifier may be a username or an email
+// address — usernames are alphanumeric-only, so anything containing '@' can
+// only be an email. Both are matched case-insensitively. Unknown identifier
+// and wrong password return ErrInvalidCredentials; any other error is an
+// internal failure the handler should report as such rather than blaming
+// the user's credentials.
+func (s *UserService) LoginUser(identifier, password string) (*models.User, error) {
+	identifier = strings.TrimSpace(identifier)
+
+	var user *models.User
+	var err error
+	if strings.Contains(identifier, "@") {
+		user, err = s.Repo.GetUserAuthByEmail(identifier)
+	} else {
+		user, err = s.Repo.GetUserAuthByUsername(identifier)
+	}
+	if err != nil && !errors.Is(err, gorm.ErrRecordNotFound) {
+		return nil, fmt.Errorf("login lookup failed: %w", err)
+	}
 	if err != nil || user == nil || user.Auth == nil {
 		// Burn a bcrypt compare so this path takes as long as a real
 		// password check (prevents username enumeration via timing).
@@ -123,6 +146,12 @@ func (s *UserService) LoginUser(username, password string) (*models.User, error)
 	}
 
 	return user, nil
+}
+
+// EmailInUse reports whether an account already exists with the given email
+// address, ignoring case.
+func (s *UserService) EmailInUse(email string) (bool, error) {
+	return s.Repo.EmailExists(strings.TrimSpace(email))
 }
 
 // GetUserWithAuthByID gets a user with their auth record (token version) loaded.
@@ -294,6 +323,11 @@ func (s *UserService) ValidatePassword(password string) error {
 	if len(password) < 8 {
 		return errors.New("password must be at least 8 characters long")
 	}
+	// bcrypt only reads the first 72 bytes and errors on longer input, so
+	// reject here with a clear message instead of failing at hash time.
+	if len(password) > 72 {
+		return errors.New("password must be at most 72 characters long")
+	}
 	hasUppercase, _ := regexp.MatchString(`[A-Z]`, password)
 	if !hasUppercase {
 		return errors.New("password must contain at least one uppercase letter")
@@ -306,9 +340,12 @@ func (s *UserService) ValidatePassword(password string) error {
 	if !hasNumber {
 		return errors.New("password must contain at least one digit")
 	}
-	hasSpecialChar, _ := regexp.MatchString(`[!@#$%^&*]`, password)
+	// Any non-alphanumeric character counts as special. An allowlist here
+	// (the old [!@#$%^&*]) silently rejected common choices like '.' or '?',
+	// which read to users as "signup doesn't work".
+	hasSpecialChar, _ := regexp.MatchString(`[^a-zA-Z0-9]`, password)
 	if !hasSpecialChar {
-		return errors.New("password must contain at least one special character")
+		return errors.New("password must contain at least one special character (e.g. ! @ # $ %)")
 	}
 	return nil
 }

--- a/internal/service/user_login_test.go
+++ b/internal/service/user_login_test.go
@@ -1,0 +1,171 @@
+package service
+
+import (
+	"errors"
+	"strings"
+	"testing"
+
+	"github.com/windoze95/saltybytes-api/internal/models"
+	"github.com/windoze95/saltybytes-api/internal/testutil"
+	"golang.org/x/crypto/bcrypt"
+)
+
+// seedLoginUser stores a user the way signup does (username/email kept as
+// typed) so login tests exercise the same data shape as production.
+func seedLoginUser(repo *testutil.MockUserRepo, username, email, password string) *models.User {
+	hashedPwd, _ := bcrypt.GenerateFromPassword([]byte(password), 10)
+	user := &models.User{
+		Username: username,
+		Email:    email,
+		Auth: &models.UserAuth{
+			HashedPassword: string(hashedPwd),
+			AuthType:       models.Standard,
+		},
+		Settings:        &models.UserSettings{KeepScreenAwake: true},
+		Personalization: &models.Personalization{UnitSystem: "us_customary"},
+	}
+	repo.CreateUser(user)
+	return user
+}
+
+func TestLoginUser_CaseInsensitiveUsername(t *testing.T) {
+	repo := testutil.NewMockUserRepo()
+	svc := newTestUserService(repo)
+	// Mobile keyboards autocapitalize at signup: the stored username is
+	// "Lincoln", but the user types it lowercase at login.
+	seedLoginUser(repo, "Lincoln", "lincoln@example.com", "Password1!")
+
+	for _, attempt := range []string{"lincoln", "LINCOLN", "Lincoln"} {
+		if _, err := svc.LoginUser(attempt, "Password1!"); err != nil {
+			t.Errorf("LoginUser(%q) error: %v", attempt, err)
+		}
+	}
+}
+
+func TestLoginUser_TrimsIdentifier(t *testing.T) {
+	repo := testutil.NewMockUserRepo()
+	svc := newTestUserService(repo)
+	seedLoginUser(repo, "testuser", "test@example.com", "Password1!")
+
+	if _, err := svc.LoginUser("  testuser ", "Password1!"); err != nil {
+		t.Errorf("LoginUser with padded identifier error: %v", err)
+	}
+}
+
+func TestLoginUser_ByEmail(t *testing.T) {
+	repo := testutil.NewMockUserRepo()
+	svc := newTestUserService(repo)
+	seedLoginUser(repo, "testuser", "Test@Example.com", "Password1!")
+
+	loggedIn, err := svc.LoginUser("test@example.com", "Password1!")
+	if err != nil {
+		t.Fatalf("LoginUser by email error: %v", err)
+	}
+	if loggedIn.Username != "testuser" {
+		t.Errorf("Username = %q, want 'testuser'", loggedIn.Username)
+	}
+}
+
+func TestLoginUser_UnknownEmail(t *testing.T) {
+	repo := testutil.NewMockUserRepo()
+	svc := newTestUserService(repo)
+
+	_, err := svc.LoginUser("nobody@example.com", "Password1!")
+	if !errors.Is(err, ErrInvalidCredentials) {
+		t.Errorf("err = %v, want ErrInvalidCredentials", err)
+	}
+}
+
+func TestLoginUser_WrongPasswordByEmail(t *testing.T) {
+	repo := testutil.NewMockUserRepo()
+	svc := newTestUserService(repo)
+	seedLoginUser(repo, "testuser", "test@example.com", "Correct1!")
+
+	_, err := svc.LoginUser("test@example.com", "Wrong1!")
+	if !errors.Is(err, ErrInvalidCredentials) {
+		t.Errorf("err = %v, want ErrInvalidCredentials", err)
+	}
+}
+
+func TestLoginUser_InfraErrorIsNotInvalidCredentials(t *testing.T) {
+	repo := testutil.NewMockUserRepo()
+	repo.GetUserAuthErr = errors.New("connection refused")
+	svc := newTestUserService(repo)
+
+	_, err := svc.LoginUser("testuser", "Password1!")
+	if err == nil {
+		t.Fatal("LoginUser should fail when the repo errors")
+	}
+	if errors.Is(err, ErrInvalidCredentials) {
+		t.Error("infrastructure errors must not masquerade as bad credentials")
+	}
+}
+
+func TestCreateUser_TrimsIdentifierFields(t *testing.T) {
+	repo := testutil.NewMockUserRepo()
+	svc := newTestUserService(repo)
+
+	user, err := svc.CreateUser("  chefbob42 ", " Bob ", "  bob@example.com ", "Password1!")
+	if err != nil {
+		t.Fatalf("CreateUser error: %v", err)
+	}
+	if user.Username != "chefbob42" {
+		t.Errorf("Username = %q, want trimmed 'chefbob42'", user.Username)
+	}
+	if user.FirstName != "Bob" {
+		t.Errorf("FirstName = %q, want trimmed 'Bob'", user.FirstName)
+	}
+	if user.Email != "bob@example.com" {
+		t.Errorf("Email = %q, want trimmed 'bob@example.com'", user.Email)
+	}
+}
+
+func TestEmailInUse(t *testing.T) {
+	repo := testutil.NewMockUserRepo()
+	svc := newTestUserService(repo)
+	seedLoginUser(repo, "testuser", "Bob@Example.com", "Password1!")
+
+	inUse, err := svc.EmailInUse("bob@example.com")
+	if err != nil {
+		t.Fatalf("EmailInUse error: %v", err)
+	}
+	if !inUse {
+		t.Error("EmailInUse should match case-insensitively")
+	}
+
+	inUse, err = svc.EmailInUse("free@example.com")
+	if err != nil {
+		t.Fatalf("EmailInUse error: %v", err)
+	}
+	if inUse {
+		t.Error("EmailInUse should be false for an unknown email")
+	}
+}
+
+func TestValidatePassword_AcceptsAnySpecialCharacter(t *testing.T) {
+	svc := newTestUserService(testutil.NewMockUserRepo())
+
+	// The old allowlist [!@#$%^&*] rejected all of these.
+	for _, pw := range []string{"Password1.", "Password1?", "Password1-", "Password1_", "Pass word1", "Password1("} {
+		if err := svc.ValidatePassword(pw); err != nil {
+			t.Errorf("ValidatePassword(%q) = %v, want nil", pw, err)
+		}
+	}
+}
+
+func TestValidatePassword_StillRequiresSpecialCharacter(t *testing.T) {
+	svc := newTestUserService(testutil.NewMockUserRepo())
+
+	if err := svc.ValidatePassword("Password1"); err == nil {
+		t.Error("ValidatePassword should reject passwords without a special character")
+	}
+}
+
+func TestValidatePassword_RejectsOverBcryptLimit(t *testing.T) {
+	svc := newTestUserService(testutil.NewMockUserRepo())
+
+	long := "Aa1!" + strings.Repeat("x", 72)
+	if err := svc.ValidatePassword(long); err == nil {
+		t.Error("ValidatePassword should reject passwords longer than 72 bytes")
+	}
+}

--- a/internal/testutil/mocks.go
+++ b/internal/testutil/mocks.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"sort"
+	"strings"
 	"sync"
 	"time"
 
@@ -600,6 +601,10 @@ type MockUserRepo struct {
 
 	CreateUserErr         error
 	CreateSubscriptionErr error
+	// GetUserAuthErr, when set, is returned by GetUserAuthByUsername and
+	// GetUserAuthByEmail to simulate infrastructure failures (as opposed to
+	// gorm.ErrRecordNotFound, which the mock returns for unknown users).
+	GetUserAuthErr error
 }
 
 // NewMockUserRepo creates a new MockUserRepo with initialized maps.
@@ -646,15 +651,34 @@ func (m *MockUserRepo) GetUserWithAuthByID(userID uint) (*models.User, error) {
 }
 
 func (m *MockUserRepo) GetUserAuthByUsername(username string) (*models.User, error) {
+	if m.GetUserAuthErr != nil {
+		return nil, m.GetUserAuthErr
+	}
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	// Case-insensitive, mirroring the LOWER(username) match in the real repo.
+	for _, u := range m.Users {
+		if strings.EqualFold(u.Username, username) {
+			return u, nil
+		}
+	}
+	return nil, gorm.ErrRecordNotFound
+}
+
+func (m *MockUserRepo) GetUserAuthByEmail(email string) (*models.User, error) {
+	if m.GetUserAuthErr != nil {
+		return nil, m.GetUserAuthErr
+	}
 	m.mu.Lock()
 	defer m.mu.Unlock()
 
 	for _, u := range m.Users {
-		if u.Username == username {
+		if u.Email != "" && strings.EqualFold(u.Email, email) {
 			return u, nil
 		}
 	}
-	return nil, fmt.Errorf("user not found")
+	return nil, gorm.ErrRecordNotFound
 }
 
 func (m *MockUserRepo) UpdateUserFirstName(userID uint, firstName string) error {
@@ -716,7 +740,19 @@ func (m *MockUserRepo) UsernameExists(username string) (bool, error) {
 	defer m.mu.Unlock()
 
 	for _, u := range m.Users {
-		if u.Username == username {
+		if strings.EqualFold(u.Username, username) {
+			return true, nil
+		}
+	}
+	return false, nil
+}
+
+func (m *MockUserRepo) EmailExists(email string) (bool, error) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	for _, u := range m.Users {
+		if u.Email != "" && strings.EqualFold(u.Email, email) {
 			return true, nil
 		}
 	}


### PR DESCRIPTION
## Why

Testers report signup "does not work" and new accounts can't log in; everyone is sharing one old account. Prod's `users` table confirms it: **no real tester account has been created since Feb 26**, there's a rolled-back INSERT (gap at id 14), and the one capitalized username (`Lincoln`) could never log in lowercase.

## Root causes fixed

1. **Case-sensitive login lookup.** Signup stores the username as typed (iOS autocapitalizes) and dup-checks case-insensitively, but login matched `username = ?` exactly. `Lincoln` signs up → `lincoln` can never log in. Lookup is now `LOWER()` on username and email, with expression indexes.
2. **"Username or Email" field never matched emails.** The app's login field is labeled Username *or Email* and always sends the `username` key — the API only matched the username column. Identifiers containing `@` now match the email column (usernames are alphanumeric-only, so no ambiguity). **This fixes login for app builds already in testers' hands.**
3. **Duplicate email = opaque 500.** The unique-violation check type-asserted `*pq.Error` on `tx.Commit()`, but the pgx driver raises `*pgconn.PgError` on the INSERT — the mapping was dead code. Now mapped with `errors.As` on the Create error, plus a case-insensitive email pre-check returning a clean 409 (which also stops `Foo@x.com` / `foo@x.com` double accounts).
4. **Password special-char allowlist `[!@#$%^&*]`** rejected `.`, `?`, `-`, etc. — reads as "signup doesn't work". Any non-alphanumeric now counts; length capped at bcrypt's 72-byte limit with a clear 400 instead of a hash-time 500.
5. **Shared 5 req/min/IP bucket across signup+login+refresh.** Multiple testers behind one NAT/CGNAT starve it; a 429'd refresh makes the app wipe tokens (spurious logout → "wonky sign in"). Refresh now has its own 60/min bucket (it requires a validly signed JWT to be useful to an attacker); signup+login share 10/min.
6. **DB outages reported as bad credentials.** Login now distinguishes `ErrInvalidCredentials` (401) from infra errors (logged, 500).
7. **Trim identifier fields** (username/email/first name) at signup and login; passwords never trimmed.

## Safety

- No schema changes — new indexes are additive `CREATE INDEX IF NOT EXISTS` (dashboard unaffected).
- Prod data verified: no case-collisions in usernames or emails, so case-insensitive matching cannot make an existing login ambiguous.
- Existing exact-case logins keep working; the change is strictly more permissive.
- Full suite green: `go test ./... -count=1` (593 tests incl. 16 new regression tests across service/handler/repository layers).

## Companion

Flutter PR (separate repo) fixes the client half: silent signup-error swallowing via router recreation, splash screen on cold start, token wipe on transient refresh failures, and keyboard field hygiene.

🤖 Generated with [Claude Code](https://claude.com/claude-code)