### PR TITLE
feat(auth): signup email verification with 6-digit codes, gated AI endpoints

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -6,7 +6,7 @@ require (
 	github.com/TwiN/go-away v1.6.14
 	github.com/anthropics/anthropic-sdk-go v0.2.0-beta.3
 	github.com/asaskevich/govalidator v0.0.0-20230301143203-a9d515a09cc2
-	github.com/aws/aws-sdk-go-v2 v1.36.3
+	github.com/aws/aws-sdk-go-v2 v1.42.1
 	github.com/aws/aws-sdk-go-v2/config v1.29.6
 	github.com/aws/aws-sdk-go-v2/credentials v1.17.59
 	github.com/aws/aws-sdk-go-v2/feature/s3/manager v1.17.61
@@ -32,18 +32,19 @@ require (
 require (
 	github.com/aws/aws-sdk-go-v2/aws/protocol/eventstream v1.6.8 // indirect
 	github.com/aws/aws-sdk-go-v2/feature/ec2/imds v1.16.28 // indirect
-	github.com/aws/aws-sdk-go-v2/internal/configsources v1.3.32 // indirect
-	github.com/aws/aws-sdk-go-v2/internal/endpoints/v2 v2.6.32 // indirect
+	github.com/aws/aws-sdk-go-v2/internal/configsources v1.4.30 // indirect
+	github.com/aws/aws-sdk-go-v2/internal/endpoints/v2 v2.7.30 // indirect
 	github.com/aws/aws-sdk-go-v2/internal/ini v1.8.2 // indirect
-	github.com/aws/aws-sdk-go-v2/internal/v4a v1.3.32 // indirect
+	github.com/aws/aws-sdk-go-v2/internal/v4a v1.4.31 // indirect
 	github.com/aws/aws-sdk-go-v2/service/internal/accept-encoding v1.12.2 // indirect
 	github.com/aws/aws-sdk-go-v2/service/internal/checksum v1.6.0 // indirect
 	github.com/aws/aws-sdk-go-v2/service/internal/presigned-url v1.12.13 // indirect
 	github.com/aws/aws-sdk-go-v2/service/internal/s3shared v1.18.13 // indirect
+	github.com/aws/aws-sdk-go-v2/service/sesv2 v1.62.6 // indirect
 	github.com/aws/aws-sdk-go-v2/service/sso v1.24.15 // indirect
 	github.com/aws/aws-sdk-go-v2/service/ssooidc v1.28.14 // indirect
 	github.com/aws/aws-sdk-go-v2/service/sts v1.33.14 // indirect
-	github.com/aws/smithy-go v1.22.2 // indirect
+	github.com/aws/smithy-go v1.27.3 // indirect
 	github.com/bytedance/sonic v1.11.6 // indirect
 	github.com/bytedance/sonic/loader v0.1.1 // indirect
 	github.com/cloudwego/base64x v0.1.4 // indirect

--- a/go.sum
+++ b/go.sum
@@ -6,6 +6,8 @@ github.com/asaskevich/govalidator v0.0.0-20230301143203-a9d515a09cc2 h1:DklsrG3d
 github.com/asaskevich/govalidator v0.0.0-20230301143203-a9d515a09cc2/go.mod h1:WaHUgvxTVq04UNunO+XhnAqY/wQc+bxr74GqbsZ/Jqw=
 github.com/aws/aws-sdk-go-v2 v1.36.3 h1:mJoei2CxPutQVxaATCzDUjcZEjVRdpsiiXi2o38yqWM=
 github.com/aws/aws-sdk-go-v2 v1.36.3/go.mod h1:LLXuLpgzEbD766Z5ECcRmi8AzSwfZItDtmABVkRLGzg=
+github.com/aws/aws-sdk-go-v2 v1.42.1 h1:9eOTgu1z/dVtYpNZ3/8/XbbaX0x/BqE3HUzAzs6K0ek=
+github.com/aws/aws-sdk-go-v2 v1.42.1/go.mod h1:5pKeft2eJj+gElQ38Jqg4ibCqh+/AK33/0X3hip7IjM=
 github.com/aws/aws-sdk-go-v2/aws/protocol/eventstream v1.6.8 h1:zAxi9p3wsZMIaVCdoiQp2uZ9k1LsZvmAnoTBeZPXom0=
 github.com/aws/aws-sdk-go-v2/aws/protocol/eventstream v1.6.8/go.mod h1:3XkePX5dSaxveLAYY7nsbsZZrKxCyEuE5pM4ziFxyGg=
 github.com/aws/aws-sdk-go-v2/config v1.29.6 h1:fqgqEKK5HaZVWLQoLiC9Q+xDlSp+1LYidp6ybGE2OGg=
@@ -18,12 +20,18 @@ github.com/aws/aws-sdk-go-v2/feature/s3/manager v1.17.61 h1:BBIPjlEWLxX1huGTkBu/
 github.com/aws/aws-sdk-go-v2/feature/s3/manager v1.17.61/go.mod h1:6dkLZQM1D/wKKFJEvyB1OCXJ0f68wcIPDOiXm0KyT8A=
 github.com/aws/aws-sdk-go-v2/internal/configsources v1.3.32 h1:BjUcr3X3K0wZPGFg2bxOWW3VPN8rkE3/61zhP+IHviA=
 github.com/aws/aws-sdk-go-v2/internal/configsources v1.3.32/go.mod h1:80+OGC/bgzzFFTUmcuwD0lb4YutwQeKLFpmt6hoWapU=
+github.com/aws/aws-sdk-go-v2/internal/configsources v1.4.30 h1:xM/Is9cKMHa8Jj8zkvWhvrFkZsXJV9E+BB4g0HW0duQ=
+github.com/aws/aws-sdk-go-v2/internal/configsources v1.4.30/go.mod h1:WueJeNDZvK1fMYEWJIkcivBfEzUkTpBhzlrUKKY8EuA=
 github.com/aws/aws-sdk-go-v2/internal/endpoints/v2 v2.6.32 h1:m1GeXHVMJsRsUAqG6HjZWx9dj7F5TR+cF1bjyfYyBd4=
 github.com/aws/aws-sdk-go-v2/internal/endpoints/v2 v2.6.32/go.mod h1:IitoQxGfaKdVLNg0hD8/DXmAqNy0H4K2H2Sf91ti8sI=
+github.com/aws/aws-sdk-go-v2/internal/endpoints/v2 v2.7.30 h1:jn46zC9LdsVR/ZpMIJqMqb8hHv31BlLx3ulVqNspUOk=
+github.com/aws/aws-sdk-go-v2/internal/endpoints/v2 v2.7.30/go.mod h1:1hTMsAgbdS/AtUi4bw8+gUuh1pceo+eXRLfpSuSQj3M=
 github.com/aws/aws-sdk-go-v2/internal/ini v1.8.2 h1:Pg9URiobXy85kgFev3og2CuOZ8JZUBENF+dcgWBaYNk=
 github.com/aws/aws-sdk-go-v2/internal/ini v1.8.2/go.mod h1:FbtygfRFze9usAadmnGJNc8KsP346kEe+y2/oyhGAGc=
 github.com/aws/aws-sdk-go-v2/internal/v4a v1.3.32 h1:OIHj/nAhVzIXGzbAE+4XmZ8FPvro3THr6NlqErJc3wY=
 github.com/aws/aws-sdk-go-v2/internal/v4a v1.3.32/go.mod h1:LiBEsDo34OJXqdDlRGsilhlIiXR7DL+6Cx2f4p1EgzI=
+github.com/aws/aws-sdk-go-v2/internal/v4a v1.4.31 h1:3GUprIsfmGcC5SACIyB0e7E0BM1O1b3Erl5CePYIAeQ=
+github.com/aws/aws-sdk-go-v2/internal/v4a v1.4.31/go.mod h1:7PuV1yl5e2xnUbm+RqvVg5i2iBM8EyijZNoI9wsOoOc=
 github.com/aws/aws-sdk-go-v2/service/internal/accept-encoding v1.12.2 h1:D4oz8/CzT9bAEYtVhSBmFj2dNOtaHOtMKc2vHBwYizA=
 github.com/aws/aws-sdk-go-v2/service/internal/accept-encoding v1.12.2/go.mod h1:Za3IHqTQ+yNcRHxu1OFucBh0ACZT4j4VQFF0BqpZcLY=
 github.com/aws/aws-sdk-go-v2/service/internal/checksum v1.6.0 h1:kT2WeWcFySdYpPgyqJMSUE7781Qucjtn6wBvrgm9P+M=
@@ -34,6 +42,8 @@ github.com/aws/aws-sdk-go-v2/service/internal/s3shared v1.18.13 h1:OBsrtam3rk8Nf
 github.com/aws/aws-sdk-go-v2/service/internal/s3shared v1.18.13/go.mod h1:3U4gFA5pmoCOja7aq4nSaIAGbaOHv2Yl2ug018cmC+Q=
 github.com/aws/aws-sdk-go-v2/service/s3 v1.76.1 h1:d4ZG8mELlLeUWFBMCqPtRfEP3J6aQgg/KTC9jLSlkMs=
 github.com/aws/aws-sdk-go-v2/service/s3 v1.76.1/go.mod h1:uZoEIR6PzGOZEjgAZE4hfYfsqK2zOHhq68JLKEvvXj4=
+github.com/aws/aws-sdk-go-v2/service/sesv2 v1.62.6 h1:P3eoIM/ULwU8Q1xWvh0CrWybeVgkSFNTHhkRtLLzUDA=
+github.com/aws/aws-sdk-go-v2/service/sesv2 v1.62.6/go.mod h1:HlQu5hAX7DOaLl8AK1ac10N4PhMhslC7mds020yPKJ8=
 github.com/aws/aws-sdk-go-v2/service/sso v1.24.15 h1:/eE3DogBjYlvlbhd2ssWyeuovWunHLxfgw3s/OJa4GQ=
 github.com/aws/aws-sdk-go-v2/service/sso v1.24.15/go.mod h1:2PCJYpi7EKeA5SkStAmZlF6fi0uUABuhtF8ILHjGc3Y=
 github.com/aws/aws-sdk-go-v2/service/ssooidc v1.28.14 h1:M/zwXiL2iXUrHputuXgmO94TVNmcenPHxgLXLutodKE=
@@ -42,6 +52,8 @@ github.com/aws/aws-sdk-go-v2/service/sts v1.33.14 h1:TzeR06UCMUq+KA3bDkujxK1GVGy
 github.com/aws/aws-sdk-go-v2/service/sts v1.33.14/go.mod h1:dspXf/oYWGWo6DEvj98wpaTeqt5+DMidZD0A9BYTizc=
 github.com/aws/smithy-go v1.22.2 h1:6D9hW43xKFrRx/tXXfAlIZc4JI+yQe6snnWcQyxSyLQ=
 github.com/aws/smithy-go v1.22.2/go.mod h1:irrKGvNn1InZwb2d7fkIRNucdfwR8R+Ts3wxYa/cJHg=
+github.com/aws/smithy-go v1.27.3 h1:F3Zb497UhhskkfpJmfkXswyo+t0sh9OTBnIHjogWbVY=
+github.com/aws/smithy-go v1.27.3/go.mod h1:YE2RhdIuDbA5E5bTdciG9KrW3+TiEONeUWCqxX9i1Fc=
 github.com/bytedance/sonic v1.11.6 h1:oUp34TzMlL+OY1OUWxHqsdkgC/Zfc85zGqw9siXjrc0=
 github.com/bytedance/sonic v1.11.6/go.mod h1:LysEHSvpvDySVdC2f87zGWf6CIKJcAvqab1ZaiQtds4=
 github.com/bytedance/sonic/loader v0.1.1 h1:c+e5Pt1k/cy5wMveRDyk2X4B9hF4g7an8N3zCYjJFNM=

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -89,6 +89,21 @@ type EnvVars struct {
 	// OAuth issuer identifier and the base of the MCP resource URL, so it must
 	// match what MCP hosts (Claude/ChatGPT connectors) are configured with.
 	PublicBaseURL string `env:"PUBLIC_BASE_URL" envDefault:"https://api.saltybytes.ai" optional:"true"`
+	// EmailFrom is the From header for verification emails, e.g.
+	// "SaltyBytes <no-reply@saltybytes.ai>". Must be an SES-verified identity.
+	EmailFrom string `env:"EMAIL_FROM" optional:"true"`
+	// EmailVerificationEnabled turns on signup email verification: signup
+	// sends a 6-digit code, and AI-cost endpoints require a verified email.
+	// While false (the default), signups are marked verified immediately and
+	// nothing is gated, so the feature can ship dark and be flipped on once
+	// the SES domain identity and production access are in place.
+	EmailVerificationEnabled bool `env:"EMAIL_VERIFICATION_ENABLED" optional:"true"`
+}
+
+// EmailVerificationActive reports whether the signup email-verification flow
+// is fully configured: the flag is on and a From identity is set.
+func (c *Config) EmailVerificationActive() bool {
+	return c.EnvVars.EmailVerificationEnabled && c.EnvVars.EmailFrom != ""
 }
 
 // LoadConfig parses environment variables into the Config struct.

--- a/internal/db/db.go
+++ b/internal/db/db.go
@@ -47,6 +47,7 @@ func connectToDatabaseWithRetry(databaseURL string) (*gorm.DB, error) {
 	if migrateErr := database.AutoMigrate(
 		&models.User{},
 		&models.UserAuth{},
+		&models.EmailVerification{},
 		&models.Subscription{},
 		&models.UserSettings{},
 		&models.Personalization{},

--- a/internal/email/email.go
+++ b/internal/email/email.go
@@ -1,0 +1,75 @@
+// Package email sends transactional email (signup verification codes)
+// through Amazon SES. The Sender interface exists so services can be tested
+// offline and so the app runs cleanly with email disabled.
+package email
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	awsconfig "github.com/aws/aws-sdk-go-v2/config"
+	"github.com/aws/aws-sdk-go-v2/credentials"
+	"github.com/aws/aws-sdk-go-v2/service/sesv2"
+	"github.com/aws/aws-sdk-go-v2/service/sesv2/types"
+	"github.com/windoze95/saltybytes-api/internal/config"
+)
+
+// Sender delivers a single email.
+type Sender interface {
+	Send(ctx context.Context, to, subject, textBody, htmlBody string) error
+}
+
+// SESSender sends email through Amazon SES v2.
+type SESSender struct {
+	client *sesv2.Client
+	from   string
+}
+
+// NewSESSender builds an SES sender using the same credential strategy as
+// the S3 client: static credentials when provided, otherwise the default
+// chain (ECS task role).
+func NewSESSender(ctx context.Context, cfg *config.Config) (*SESSender, error) {
+	opts := []func(*awsconfig.LoadOptions) error{
+		awsconfig.WithRegion(cfg.EnvVars.AWSRegion),
+	}
+	if cfg.EnvVars.AWSAccessKeyID != "" && cfg.EnvVars.AWSSecretAccessKey != "" {
+		opts = append(opts, awsconfig.WithCredentialsProvider(credentials.NewStaticCredentialsProvider(
+			cfg.EnvVars.AWSAccessKeyID,
+			cfg.EnvVars.AWSSecretAccessKey,
+			"",
+		)))
+	}
+
+	awsCfg, err := awsconfig.LoadDefaultConfig(ctx, opts...)
+	if err != nil {
+		return nil, fmt.Errorf("failed to load AWS config for SES: %v", err)
+	}
+	return &SESSender{
+		client: sesv2.NewFromConfig(awsCfg),
+		from:   cfg.EnvVars.EmailFrom,
+	}, nil
+}
+
+// Send delivers one email to a single recipient.
+func (s *SESSender) Send(ctx context.Context, to, subject, textBody, htmlBody string) error {
+	input := &sesv2.SendEmailInput{
+		FromEmailAddress: aws.String(s.from),
+		Destination: &types.Destination{
+			ToAddresses: []string{to},
+		},
+		Content: &types.EmailContent{
+			Simple: &types.Message{
+				Subject: &types.Content{Data: aws.String(subject)},
+				Body: &types.Body{
+					Text: &types.Content{Data: aws.String(textBody)},
+					Html: &types.Content{Data: aws.String(htmlBody)},
+				},
+			},
+		},
+	}
+	if _, err := s.client.SendEmail(ctx, input); err != nil {
+		return fmt.Errorf("ses send failed: %w", err)
+	}
+	return nil
+}

--- a/internal/handlers/email_verification.go
+++ b/internal/handlers/email_verification.go
@@ -1,0 +1,90 @@
+package handlers
+
+import (
+	"errors"
+	"net/http"
+
+	"github.com/gin-gonic/gin"
+	"github.com/windoze95/saltybytes-api/internal/logger"
+	"github.com/windoze95/saltybytes-api/internal/service"
+	"github.com/windoze95/saltybytes-api/internal/util"
+	"go.uber.org/zap"
+)
+
+// EmailVerificationHandler serves the signup email-verification endpoints.
+type EmailVerificationHandler struct {
+	Service *service.EmailVerificationService
+}
+
+// NewEmailVerificationHandler constructs the handler.
+func NewEmailVerificationHandler(svc *service.EmailVerificationService) *EmailVerificationHandler {
+	return &EmailVerificationHandler{Service: svc}
+}
+
+// RequestVerification (re)sends the 6-digit code to the user's email.
+// POST /v1/users/me/email/verification
+func (h *EmailVerificationHandler) RequestVerification(c *gin.Context) {
+	user, err := util.GetUserFromContext(c)
+	if err != nil {
+		c.JSON(http.StatusUnauthorized, gin.H{"error": "unauthorized"})
+		return
+	}
+
+	if err := h.Service.StartVerification(c.Request.Context(), user); err != nil {
+		switch {
+		case errors.Is(err, service.ErrVerificationDisabled):
+			c.JSON(http.StatusConflict, gin.H{"error": err.Error(), "error_code": "verification_disabled"})
+		case errors.Is(err, service.ErrAlreadyVerified):
+			c.JSON(http.StatusConflict, gin.H{"error": err.Error(), "error_code": "already_verified"})
+		case errors.Is(err, service.ErrNoEmailOnAccount):
+			c.JSON(http.StatusConflict, gin.H{"error": err.Error(), "error_code": "no_email"})
+		case errors.Is(err, service.ErrResendCooldown):
+			c.JSON(http.StatusTooManyRequests, gin.H{"error": err.Error(), "error_code": "resend_cooldown"})
+		case errors.Is(err, service.ErrDailySendLimit):
+			c.JSON(http.StatusTooManyRequests, gin.H{"error": err.Error(), "error_code": "daily_limit"})
+		default:
+			logger.Get().Error("failed to send verification email", zap.Uint("user_id", user.ID), zap.Error(err))
+			c.JSON(http.StatusInternalServerError, gin.H{"error": "Couldn't send the verification email — please try again"})
+		}
+		return
+	}
+
+	c.Status(http.StatusNoContent)
+}
+
+// ConfirmVerification checks the entered code and marks the email verified.
+// POST /v1/users/me/email/verification/confirm
+func (h *EmailVerificationHandler) ConfirmVerification(c *gin.Context) {
+	user, err := util.GetUserFromContext(c)
+	if err != nil {
+		c.JSON(http.StatusUnauthorized, gin.H{"error": "unauthorized"})
+		return
+	}
+
+	var req struct {
+		Code string `json:"code" binding:"required"`
+	}
+	if err := c.ShouldBindJSON(&req); err != nil {
+		c.JSON(http.StatusBadRequest, gin.H{"error": "code is required"})
+		return
+	}
+
+	if err := h.Service.ConfirmCode(user, req.Code); err != nil {
+		switch {
+		case errors.Is(err, service.ErrVerificationDisabled):
+			c.JSON(http.StatusConflict, gin.H{"error": err.Error(), "error_code": "verification_disabled"})
+		case errors.Is(err, service.ErrCodeInvalid):
+			c.JSON(http.StatusBadRequest, gin.H{"error": "That code didn't match. Try again.", "error_code": "code_invalid"})
+		case errors.Is(err, service.ErrCodeExpired):
+			c.JSON(http.StatusBadRequest, gin.H{"error": "That code expired — request a new one.", "error_code": "code_expired"})
+		case errors.Is(err, service.ErrTooManyAttempts):
+			c.JSON(http.StatusTooManyRequests, gin.H{"error": "Too many wrong codes — request a new one.", "error_code": "too_many_attempts"})
+		default:
+			logger.Get().Error("failed to confirm verification code", zap.Uint("user_id", user.ID), zap.Error(err))
+			c.JSON(http.StatusInternalServerError, gin.H{"error": "Something went wrong, please try again"})
+		}
+		return
+	}
+
+	c.JSON(http.StatusOK, gin.H{"message": "Email verified", "user": service.ToUserResponse(user)})
+}

--- a/internal/handlers/email_verification_handler_test.go
+++ b/internal/handlers/email_verification_handler_test.go
@@ -1,0 +1,203 @@
+package handlers
+
+import (
+	"encoding/json"
+	"net/http"
+	"regexp"
+	"testing"
+	"time"
+
+	"github.com/gin-gonic/gin"
+	"github.com/windoze95/saltybytes-api/internal/config"
+	"github.com/windoze95/saltybytes-api/internal/middleware"
+	"github.com/windoze95/saltybytes-api/internal/service"
+	"github.com/windoze95/saltybytes-api/internal/testutil"
+)
+
+var sixDigits = regexp.MustCompile(`\b\d{6}\b`)
+
+func verificationOnConfig() *config.Config {
+	return &config.Config{EnvVars: config.EnvVars{
+		JwtSecretKey:             "test-jwt-secret-key",
+		EmailVerificationEnabled: true,
+		EmailFrom:                "SaltyBytes <no-reply@saltybytes.ai>",
+	}}
+}
+
+// newVerificationTestStack wires a real UserHandler + EmailVerificationHandler
+// against in-memory mocks with verification enabled.
+func newVerificationTestStack() (*UserHandler, *EmailVerificationHandler, *testutil.MockUserRepo, *testutil.MockEmailSender) {
+	cfg := verificationOnConfig()
+	users := testutil.NewMockUserRepo()
+	codes := testutil.NewMockEmailVerificationRepo()
+	sender := &testutil.MockEmailSender{}
+
+	userService := service.NewUserService(cfg, users)
+	verification := service.NewEmailVerificationService(cfg, users, codes, sender)
+
+	userHandler := NewUserHandler(userService)
+	userHandler.EmailVerification = verification
+	return userHandler, NewEmailVerificationHandler(verification), users, sender
+}
+
+func TestSignup_SendsVerificationCode_WhenEnabled(t *testing.T) {
+	userHandler, _, users, sender := newVerificationTestStack()
+
+	r := gin.New()
+	r.POST("/users", userHandler.CreateUser)
+
+	w := postJSON(r, "/users", `{"username": "newchef", "email": "newchef@example.com", "password": "Password1!"}`)
+	if w.Code != http.StatusOK {
+		t.Fatalf("signup status = %d, body: %s", w.Code, w.Body.String())
+	}
+
+	sent := sender.LastSent()
+	if sent == nil {
+		t.Fatal("signup should have sent a verification email")
+	}
+	if sent.To != "newchef@example.com" {
+		t.Errorf("sent to %q", sent.To)
+	}
+
+	var resp map[string]interface{}
+	json.Unmarshal(w.Body.Bytes(), &resp)
+	user, _ := resp["user"].(map[string]interface{})
+	if user == nil {
+		t.Fatal("response missing user")
+	}
+	if verified, _ := user["email_verified"].(bool); verified {
+		t.Error("new signups must report email_verified=false while the feature is on")
+	}
+
+	// The account exists and is unverified in the repo.
+	stored, _ := users.GetUserAuthByUsername("newchef")
+	if stored.EmailVerified() {
+		t.Error("stored user should be unverified")
+	}
+}
+
+func TestConfirmVerification_Roundtrip(t *testing.T) {
+	userHandler, evHandler, users, sender := newVerificationTestStack()
+
+	r := gin.New()
+	r.POST("/users", userHandler.CreateUser)
+
+	w := postJSON(r, "/users", `{"username": "newchef", "email": "newchef@example.com", "password": "Password1!"}`)
+	if w.Code != http.StatusOK {
+		t.Fatalf("signup status = %d, body: %s", w.Code, w.Body.String())
+	}
+	code := sixDigits.FindString(sender.LastSent().Text)
+	user, _ := users.GetUserAuthByUsername("newchef")
+
+	rc := gin.New()
+	rc.POST("/confirm", setUser(user), evHandler.ConfirmVerification)
+
+	// Wrong code first.
+	wrong := "000000"
+	if wrong == code {
+		wrong = "000001"
+	}
+	w = postJSON(rc, "/confirm", `{"code": "`+wrong+`"}`)
+	if w.Code != http.StatusBadRequest {
+		t.Fatalf("wrong code status = %d, body: %s", w.Code, w.Body.String())
+	}
+	var resp map[string]interface{}
+	json.Unmarshal(w.Body.Bytes(), &resp)
+	if resp["error_code"] != "code_invalid" {
+		t.Errorf("error_code = %v, want code_invalid", resp["error_code"])
+	}
+
+	// Then the right one.
+	w = postJSON(rc, "/confirm", `{"code": "`+code+`"}`)
+	if w.Code != http.StatusOK {
+		t.Fatalf("confirm status = %d, body: %s", w.Code, w.Body.String())
+	}
+	json.Unmarshal(w.Body.Bytes(), &resp)
+	userResp, _ := resp["user"].(map[string]interface{})
+	if verified, _ := userResp["email_verified"].(bool); !verified {
+		t.Error("confirm response must report email_verified=true")
+	}
+}
+
+func TestRequestVerification_CooldownReturns429(t *testing.T) {
+	userHandler, evHandler, users, _ := newVerificationTestStack()
+
+	r := gin.New()
+	r.POST("/users", userHandler.CreateUser)
+	postJSON(r, "/users", `{"username": "newchef", "email": "newchef@example.com", "password": "Password1!"}`)
+	user, _ := users.GetUserAuthByUsername("newchef")
+
+	rr := gin.New()
+	rr.POST("/resend", setUser(user), evHandler.RequestVerification)
+
+	// Signup already sent one; an immediate resend is inside the cooldown.
+	w := postJSON(rr, "/resend", `{}`)
+	if w.Code != http.StatusTooManyRequests {
+		t.Fatalf("status = %d, want 429. body: %s", w.Code, w.Body.String())
+	}
+}
+
+func TestRequireVerifiedEmail_GatesUnverifiedUsers(t *testing.T) {
+	unverified := testutil.TestUser()
+	unverified.EmailVerifiedAt = nil
+
+	r := gin.New()
+	r.POST("/gated", setUser(unverified), middleware.RequireVerifiedEmail(true), func(c *gin.Context) {
+		c.JSON(http.StatusOK, gin.H{"ok": true})
+	})
+
+	w := postJSON(r, "/gated", `{}`)
+	if w.Code != http.StatusForbidden {
+		t.Fatalf("status = %d, want 403. body: %s", w.Code, w.Body.String())
+	}
+	var resp map[string]interface{}
+	json.Unmarshal(w.Body.Bytes(), &resp)
+	if resp["error_code"] != "email_unverified" {
+		t.Errorf("error_code = %v, want email_unverified", resp["error_code"])
+	}
+}
+
+func TestRequireVerifiedEmail_PassesVerifiedAndDisabled(t *testing.T) {
+	verified := testutil.TestUser()
+	now := time.Now()
+	verified.EmailVerifiedAt = &now
+
+	// Verified user through an enabled gate.
+	r := gin.New()
+	r.POST("/gated", setUser(verified), middleware.RequireVerifiedEmail(true), func(c *gin.Context) {
+		c.JSON(http.StatusOK, gin.H{"ok": true})
+	})
+	if w := postJSON(r, "/gated", `{}`); w.Code != http.StatusOK {
+		t.Fatalf("verified user: status = %d, want 200", w.Code)
+	}
+
+	// Unverified user through a DISABLED gate (feature dark) must pass.
+	unverified := testutil.TestUser()
+	unverified.EmailVerifiedAt = nil
+	rd := gin.New()
+	rd.POST("/gated", setUser(unverified), middleware.RequireVerifiedEmail(false), func(c *gin.Context) {
+		c.JSON(http.StatusOK, gin.H{"ok": true})
+	})
+	if w := postJSON(rd, "/gated", `{}`); w.Code != http.StatusOK {
+		t.Fatalf("disabled gate: status = %d, want 200", w.Code)
+	}
+}
+
+func TestSignup_MailFailureDoesNotFailSignup(t *testing.T) {
+	userHandler, _, _, sender := newVerificationTestStack()
+	sender.SendErr = errTestMailDown
+
+	r := gin.New()
+	r.POST("/users", userHandler.CreateUser)
+
+	w := postJSON(r, "/users", `{"username": "newchef", "email": "newchef@example.com", "password": "Password1!"}`)
+	if w.Code != http.StatusOK {
+		t.Fatalf("signup must succeed even when the mail send fails; status = %d, body: %s", w.Code, w.Body.String())
+	}
+}
+
+var errTestMailDown = &mailDownError{}
+
+type mailDownError struct{}
+
+func (e *mailDownError) Error() string { return "smtp on fire" }

--- a/internal/handlers/user.go
+++ b/internal/handlers/user.go
@@ -21,6 +21,9 @@ import (
 // UserHandler is the handler for user-related requests.
 type UserHandler struct {
 	Service *service.UserService
+	// EmailVerification, when set and enabled, sends the signup verification
+	// code after account creation. Nil in tests that don't exercise it.
+	EmailVerification *service.EmailVerificationService
 }
 
 // NewUserHandler is the constructor function for initializing a new UserHandler.
@@ -63,14 +66,15 @@ func (h *UserHandler) CreateUser(c *gin.Context) {
 	}
 
 	// Reject duplicate emails up front with a clear message; the DB unique
-	// constraint stays as the backstop for races.
-	emailInUse, err := h.Service.EmailInUse(newUser.Email)
+	// constraint stays as the backstop for races. Stale unverified signups
+	// release the address instead of squatting it forever.
+	emailTaken, err := h.Service.EmailTakenForSignup(newUser.Email)
 	if err != nil {
 		logger.Get().Error("failed to check email availability", zap.Error(err))
 		c.JSON(http.StatusInternalServerError, gin.H{"error": "Failed to create user"})
 		return
 	}
-	if emailInUse {
+	if emailTaken {
 		c.JSON(http.StatusConflict, gin.H{"error": "email already in use"})
 		return
 	}
@@ -94,6 +98,14 @@ func (h *UserHandler) CreateUser(c *gin.Context) {
 			c.JSON(http.StatusInternalServerError, gin.H{"error": "Failed to create user"})
 		}
 		return
+	}
+
+	// Send the verification code (best-effort — a mail hiccup must never
+	// fail the signup; the app offers resend from the verify screen).
+	if h.EmailVerification != nil && h.EmailVerification.Enabled() {
+		if err := h.EmailVerification.StartVerification(c.Request.Context(), user); err != nil {
+			logger.Get().Warn("failed to send signup verification email", zap.Uint("user_id", user.ID), zap.Error(err))
+		}
 	}
 
 	// Log the user in

--- a/internal/middleware/verified_email.go
+++ b/internal/middleware/verified_email.go
@@ -1,0 +1,39 @@
+package middleware
+
+import (
+	"net/http"
+
+	"github.com/gin-gonic/gin"
+	"github.com/windoze95/saltybytes-api/internal/util"
+)
+
+// RequireVerifiedEmail gates AI-cost endpoints behind a verified email
+// address, so throwaway signups can't farm free-tier AI quota. Must run
+// after AttachUserToContext. A no-op while email verification is disabled
+// (enabled=false), so the feature can ship dark.
+func RequireVerifiedEmail(enabled bool) gin.HandlerFunc {
+	return func(c *gin.Context) {
+		if !enabled {
+			c.Next()
+			return
+		}
+
+		user, err := util.GetUserFromContext(c)
+		if err != nil || user == nil {
+			c.JSON(http.StatusUnauthorized, gin.H{"error": "unauthorized"})
+			c.Abort()
+			return
+		}
+
+		if !user.EmailVerified() {
+			c.JSON(http.StatusForbidden, gin.H{
+				"error":      "Please verify your email address to use this feature",
+				"error_code": "email_unverified",
+			})
+			c.Abort()
+			return
+		}
+
+		c.Next()
+	}
+}

--- a/internal/models/user.go
+++ b/internal/models/user.go
@@ -12,14 +12,41 @@ import (
 // User is the model for a user.
 type User struct {
 	gorm.Model
-	Username         string           `gorm:"unique;index"`
-	FirstName        string           `gorm:"default:null"`
-	Email            string           `gorm:"unique;default:null"`
+	Username  string `gorm:"unique;index"`
+	FirstName string `gorm:"default:null"`
+	Email     string `gorm:"unique;default:null"`
+	// EmailVerifiedAt is set when the user proves ownership of Email (or
+	// immediately at signup while email verification is disabled). Nil means
+	// unverified: AI-cost endpoints are gated and a stale signup releases its
+	// email address for reuse.
+	EmailVerifiedAt  *time.Time
 	Auth             *UserAuth        `gorm:"foreignKey:UserID"`
 	Subscription     *Subscription    `gorm:"foreignKey:UserID"`
 	Settings         *UserSettings    `gorm:"foreignKey:UserID"`
 	Personalization  *Personalization `gorm:"foreignKey:UserID"`
 	CollectedRecipes []*Recipe        `gorm:"many2many:user_collected_recipes;"`
+}
+
+// EmailVerified reports whether the user's email address is verified.
+func (u *User) EmailVerified() bool {
+	return u.EmailVerifiedAt != nil
+}
+
+// EmailVerification holds the pending 6-digit signup verification code for a
+// user. One row per user; resends overwrite it. The code itself is stored
+// bcrypt-hashed so a database leak can't be replayed.
+type EmailVerification struct {
+	gorm.Model
+	UserID    uint   `gorm:"uniqueIndex;not null"`
+	CodeHash  string `gorm:"not null"`
+	ExpiresAt time.Time
+	// Attempts counts wrong codes entered for the current code; capped so a
+	// 6-digit space can't be brute-forced.
+	Attempts int `gorm:"default:0"`
+	// SendCount counts emails sent during the UTC day of LastSentAt,
+	// bounding daily sends per user.
+	SendCount  int `gorm:"default:0"`
+	LastSentAt time.Time
 }
 
 // UserAuth is the model for a user's authentication information.

--- a/internal/repository/email_verification.go
+++ b/internal/repository/email_verification.go
@@ -1,0 +1,58 @@
+package repository
+
+import (
+	"errors"
+
+	"github.com/windoze95/saltybytes-api/internal/models"
+	"gorm.io/gorm"
+	"gorm.io/gorm/clause"
+)
+
+// EmailVerificationRepository persists pending signup verification codes.
+type EmailVerificationRepository struct {
+	DB *gorm.DB
+}
+
+// NewEmailVerificationRepository creates a new EmailVerificationRepository.
+func NewEmailVerificationRepository(db *gorm.DB) *EmailVerificationRepository {
+	return &EmailVerificationRepository{DB: db}
+}
+
+// Upsert writes the user's pending verification, replacing any existing row
+// (one pending code per user).
+func (r *EmailVerificationRepository) Upsert(v *models.EmailVerification) error {
+	return r.DB.Clauses(clause.OnConflict{
+		Columns: []clause.Column{{Name: "user_id"}},
+		DoUpdates: clause.AssignmentColumns([]string{
+			"code_hash", "expires_at", "attempts", "send_count", "last_sent_at", "updated_at",
+		}),
+	}).Create(v).Error
+}
+
+// GetByUserID returns the user's pending verification, or nil when none
+// exists.
+func (r *EmailVerificationRepository) GetByUserID(userID uint) (*models.EmailVerification, error) {
+	var v models.EmailVerification
+	if err := r.DB.Where("user_id = ?", userID).First(&v).Error; err != nil {
+		if errors.Is(err, gorm.ErrRecordNotFound) {
+			return nil, nil
+		}
+		return nil, err
+	}
+	return &v, nil
+}
+
+// IncrementAttempts counts one wrong code entry.
+func (r *EmailVerificationRepository) IncrementAttempts(userID uint) error {
+	return r.DB.Model(&models.EmailVerification{}).
+		Where("user_id = ?", userID).
+		UpdateColumn("attempts", gorm.Expr("attempts + 1")).Error
+}
+
+// DeleteByUserID removes the user's pending verification (after success, or
+// when their email is released).
+func (r *EmailVerificationRepository) DeleteByUserID(userID uint) error {
+	return r.DB.Unscoped().
+		Where("user_id = ?", userID).
+		Delete(&models.EmailVerification{}).Error
+}

--- a/internal/repository/interfaces.go
+++ b/internal/repository/interfaces.go
@@ -125,6 +125,8 @@ type UserRepo interface {
 	UpdatePersonalization(userID uint, update *models.PersonalizationUpdate) error
 	UsernameExists(username string) (bool, error)
 	EmailExists(email string) (bool, error)
+	SetEmailVerified(userID uint) error
+	ClearUserEmail(userID uint) error
 	IncrementTokenVersion(userID uint) error
 	CreateSubscription(sub *models.Subscription) error
 	IncrementSubscriptionUsage(userID uint, column string) error
@@ -132,8 +134,17 @@ type UserRepo interface {
 	ResetSubscriptionUsage(userID uint, nextReset time.Time) error
 }
 
+// EmailVerificationRepo persists pending signup email-verification codes.
+type EmailVerificationRepo interface {
+	Upsert(v *models.EmailVerification) error
+	GetByUserID(userID uint) (*models.EmailVerification, error)
+	IncrementAttempts(userID uint) error
+	DeleteByUserID(userID uint) error
+}
+
 // Compile-time check that the concrete repository satisfies the interface.
 var _ UserRepo = (*UserRepository)(nil)
+var _ EmailVerificationRepo = (*EmailVerificationRepository)(nil)
 var _ FamilyRepo = (*FamilyRepository)(nil)
 var _ AllergenRepo = (*AllergenRepository)(nil)
 var _ FinderSessionRepo = (*FinderSessionRepository)(nil)

--- a/internal/repository/user.go
+++ b/internal/repository/user.go
@@ -137,6 +137,30 @@ func (r *UserRepository) UpdateUserEmail(userID uint, email string) error {
 	return nil
 }
 
+// SetEmailVerified stamps the user's email as verified now.
+func (r *UserRepository) SetEmailVerified(userID uint) error {
+	err := r.DB.Model(&models.User{}).
+		Where("id = ?", userID).
+		Update("email_verified_at", time.Now()).Error
+	if err != nil {
+		logger.Get().Error("failed to set email verified", zap.Uint("user_id", userID), zap.Error(err))
+	}
+	return err
+}
+
+// ClearUserEmail releases a user's email address (used when a stale
+// unverified signup is squatting an address someone else wants to register
+// with). The account keeps working via username login.
+func (r *UserRepository) ClearUserEmail(userID uint) error {
+	err := r.DB.Model(&models.User{}).
+		Where("id = ?", userID).
+		Update("email", nil).Error
+	if err != nil {
+		logger.Get().Error("failed to clear user email", zap.Uint("user_id", userID), zap.Error(err))
+	}
+	return err
+}
+
 // UpdateUserSettingsKeepScreenAwake updates a user's KeepScreenAwake setting.
 func (r *UserRepository) UpdateUserSettingsKeepScreenAwake(userID uint, keepScreenAwake bool) error {
 	err := r.DB.Model(&models.UserSettings{}).

--- a/internal/router/router.go
+++ b/internal/router/router.go
@@ -8,6 +8,7 @@ import (
 	"github.com/gin-gonic/gin"
 	"github.com/windoze95/saltybytes-api/internal/ai"
 	"github.com/windoze95/saltybytes-api/internal/config"
+	"github.com/windoze95/saltybytes-api/internal/email"
 	"github.com/windoze95/saltybytes-api/internal/handlers"
 	"github.com/windoze95/saltybytes-api/internal/logger"
 	"github.com/windoze95/saltybytes-api/internal/mcpserver"
@@ -99,6 +100,30 @@ func SetupRouter(cfg *config.Config, database *gorm.DB) *gin.Engine {
 	userRepo := repository.NewUserRepository(database)
 	userService := service.NewUserService(cfg, userRepo)
 	userHandler := handlers.NewUserHandler(userService)
+
+	// Signup email verification. Ships dark: without EMAIL_VERIFICATION_ENABLED
+	// + EMAIL_FROM the sender stays nil, signups auto-verify, and the
+	// verified-email gate below is a no-op.
+	var emailSender email.Sender
+	if cfg.EmailVerificationActive() {
+		sesSender, err := email.NewSESSender(context.Background(), cfg)
+		if err != nil {
+			logger.Get().Error("email verification requested but SES init failed — running with verification disabled", zap.Error(err))
+		} else {
+			emailSender = sesSender
+			logger.Get().Info("signup email verification enabled")
+		}
+	} else {
+		logger.Get().Info("signup email verification disabled")
+	}
+	emailVerificationRepo := repository.NewEmailVerificationRepository(database)
+	emailVerificationService := service.NewEmailVerificationService(cfg, userRepo, emailVerificationRepo, emailSender)
+	emailVerificationHandler := handlers.NewEmailVerificationHandler(emailVerificationService)
+	userHandler.EmailVerification = emailVerificationService
+
+	// Gate for AI-cost endpoints: throwaway signups must verify their email
+	// before they can spend AI quota. No-op while verification is disabled.
+	verifiedOnly := middleware.RequireVerifiedEmail(emailVerificationService.Enabled())
 
 	// Subscription service (shared by AI-generation, allergen, search and
 	// subscription routes for usage gating)
@@ -266,6 +291,10 @@ func SetupRouter(cfg *config.Config, database *gorm.DB) *gin.Engine {
 		// Get a user's settings
 		apiProtected.GET("/users/me/settings", middleware.AttachUserToContext(userService), userHandler.GetUserSettings)
 
+		// Signup email verification: (re)send the 6-digit code / confirm it
+		apiProtected.POST("/users/me/email/verification", middleware.AttachUserToContext(userService), emailVerificationHandler.RequestVerification)
+		apiProtected.POST("/users/me/email/verification/confirm", middleware.AttachUserToContext(userService), emailVerificationHandler.ConfirmVerification)
+
 		// Recipe-related routes
 
 		// Get a single recipe by its ID (any authenticated user may view any
@@ -275,18 +304,18 @@ func SetupRouter(cfg *config.Config, database *gorm.DB) *gin.Engine {
 		// List the authenticated user's recipes
 		apiProtected.GET("/recipes", middleware.AttachUserToContext(userService), recipeHandler.ListRecipes)
 		// Regenerate a recipe in place based on a previous recipe and the user's chat
-		apiProtected.PUT("/recipes/:recipe_id/chat", middleware.AttachUserToContext(userService), recipeHandler.RegenerateRecipe)
+		apiProtected.PUT("/recipes/:recipe_id/chat", middleware.AttachUserToContext(userService), verifiedOnly, recipeHandler.RegenerateRecipe)
 
-		apiProtected.POST("/recipes/:recipe_id/fork", middleware.AttachUserToContext(userService), recipeHandler.GenerateRecipeWithFork)
+		apiProtected.POST("/recipes/:recipe_id/fork", middleware.AttachUserToContext(userService), verifiedOnly, recipeHandler.GenerateRecipeWithFork)
 
 		// Recipe import routes
 		apiProtected.POST("/recipes/import/url", middleware.AttachUserToContext(userService), importHandler.ImportFromURL)
-		apiProtected.POST("/recipes/import/photo", middleware.AttachUserToContext(userService), importHandler.ImportFromPhoto)
-		apiProtected.POST("/recipes/import/files", middleware.AttachUserToContext(userService), importHandler.ImportFromFiles)
-		apiProtected.POST("/recipes/import/voice", middleware.AttachUserToContext(userService), importHandler.ImportFromVoice)
-		apiProtected.POST("/recipes/import/video", middleware.AttachUserToContext(userService), importHandler.ImportFromVideo)
+		apiProtected.POST("/recipes/import/photo", middleware.AttachUserToContext(userService), verifiedOnly, importHandler.ImportFromPhoto)
+		apiProtected.POST("/recipes/import/files", middleware.AttachUserToContext(userService), verifiedOnly, importHandler.ImportFromFiles)
+		apiProtected.POST("/recipes/import/voice", middleware.AttachUserToContext(userService), verifiedOnly, importHandler.ImportFromVoice)
+		apiProtected.POST("/recipes/import/video", middleware.AttachUserToContext(userService), verifiedOnly, importHandler.ImportFromVideo)
 		apiProtected.GET("/recipes/import/video/:id", middleware.AttachUserToContext(userService), importHandler.GetVideoImportStatus)
-		apiProtected.POST("/recipes/import/text", middleware.AttachUserToContext(userService), importHandler.ImportFromText)
+		apiProtected.POST("/recipes/import/text", middleware.AttachUserToContext(userService), verifiedOnly, importHandler.ImportFromText)
 		apiProtected.POST("/recipes/import/manual", middleware.AttachUserToContext(userService), importHandler.ImportManual)
 		apiProtected.POST("/recipes/import/canonical", middleware.AttachUserToContext(userService), importHandler.ImportFromCanonical)
 
@@ -315,16 +344,16 @@ func SetupRouter(cfg *config.Config, database *gorm.DB) *gin.Engine {
 	apiProtected.PUT("/family/members/:member_id", middleware.AttachUserToContext(userService), familyHandler.UpdateMember)
 	apiProtected.DELETE("/family/members/:member_id", middleware.AttachUserToContext(userService), familyHandler.DeleteMember)
 	apiProtected.PUT("/family/members/:member_id/dietary", middleware.AttachUserToContext(userService), familyHandler.UpdateDietaryProfile)
-	apiProtected.POST("/family/members/:member_id/dietary/interview", middleware.AttachUserToContext(userService), familyHandler.DietaryInterview)
+	apiProtected.POST("/family/members/:member_id/dietary/interview", middleware.AttachUserToContext(userService), verifiedOnly, familyHandler.DietaryInterview)
 
 	// Allergen analysis routes setup
 	allergenRepo := repository.NewAllergenRepository(database)
 	allergenService := service.NewAllergenService(cfg, allergenRepo, familyRepo, recipeRepo, mainTextProvider, subService)
 	allergenHandler := handlers.NewAllergenHandler(allergenService)
 
-	apiProtected.POST("/recipes/:recipe_id/allergens/analyze", middleware.AttachUserToContext(userService), allergenHandler.AnalyzeRecipe)
+	apiProtected.POST("/recipes/:recipe_id/allergens/analyze", middleware.AttachUserToContext(userService), verifiedOnly, allergenHandler.AnalyzeRecipe)
 	apiProtected.GET("/recipes/:recipe_id/allergens", middleware.AttachUserToContext(userService), allergenHandler.GetAnalysis)
-	apiProtected.POST("/recipes/:recipe_id/allergens/check-family", middleware.AttachUserToContext(userService), allergenHandler.CheckFamily)
+	apiProtected.POST("/recipes/:recipe_id/allergens/check-family", middleware.AttachUserToContext(userService), verifiedOnly, allergenHandler.CheckFamily)
 
 	// User update routes
 	apiProtected.PUT("/users/me", middleware.AttachUserToContext(userService), userHandler.UpdateUser)
@@ -376,7 +405,7 @@ func SetupRouter(cfg *config.Config, database *gorm.DB) *gin.Engine {
 	finderService.Runs = repository.NewFinderRunRepository(database)
 	importService.Events = repository.NewExtractionEventRepository(database)
 	finderHandler := &handlers.FinderHandler{Service: finderService, SubService: subService}
-	apiProtected.POST("/recipes/find", middleware.AttachUserToContext(userService), finderHandler.FindRecipes)
+	apiProtected.POST("/recipes/find", middleware.AttachUserToContext(userService), verifiedOnly, finderHandler.FindRecipes)
 	apiProtected.GET("/recipes/finder/sessions", middleware.AttachUserToContext(userService), finderSessionHandler.ListSessions)
 	apiProtected.GET("/recipes/finder/sessions/:session_id", middleware.AttachUserToContext(userService), finderSessionHandler.GetSession)
 	apiProtected.DELETE("/recipes/finder/sessions/:session_id", middleware.AttachUserToContext(userService), finderSessionHandler.DeleteSession)

--- a/internal/service/email_verification.go
+++ b/internal/service/email_verification.go
@@ -1,0 +1,178 @@
+package service
+
+import (
+	"context"
+	"crypto/rand"
+	"errors"
+	"fmt"
+	"math/big"
+	"time"
+
+	"github.com/windoze95/saltybytes-api/internal/config"
+	"github.com/windoze95/saltybytes-api/internal/email"
+	"github.com/windoze95/saltybytes-api/internal/models"
+	"github.com/windoze95/saltybytes-api/internal/repository"
+	"golang.org/x/crypto/bcrypt"
+)
+
+// Sentinel errors the handlers map to HTTP responses.
+var (
+	ErrVerificationDisabled = errors.New("email verification is not enabled")
+	ErrAlreadyVerified      = errors.New("email is already verified")
+	ErrNoEmailOnAccount     = errors.New("no email address on this account")
+	ErrResendCooldown       = errors.New("a code was just sent — wait a minute before requesting another")
+	ErrDailySendLimit       = errors.New("daily verification email limit reached — try again tomorrow")
+	ErrCodeInvalid          = errors.New("that code didn't match")
+	ErrCodeExpired          = errors.New("that code expired — request a new one")
+	ErrTooManyAttempts      = errors.New("too many wrong codes — request a new one")
+)
+
+const (
+	codeTTL          = 15 * time.Minute
+	resendCooldown   = 60 * time.Second
+	maxDailySends    = 6
+	maxCodeAttempts  = 5
+	staleSignupAfter = 48 * time.Hour
+)
+
+// EmailVerificationService owns the signup email-verification flow: sending
+// 6-digit codes, confirming them, and the rules that keep the flow from
+// being abused (resend cooldown, daily send cap, attempt cap).
+type EmailVerificationService struct {
+	Cfg    *config.Config
+	Users  repository.UserRepo
+	Codes  repository.EmailVerificationRepo
+	Sender email.Sender
+}
+
+// NewEmailVerificationService constructs the service. Sender may be nil when
+// email is disabled; Enabled() guards every path that would send.
+func NewEmailVerificationService(cfg *config.Config, users repository.UserRepo, codes repository.EmailVerificationRepo, sender email.Sender) *EmailVerificationService {
+	return &EmailVerificationService{Cfg: cfg, Users: users, Codes: codes, Sender: sender}
+}
+
+// Enabled reports whether the verification flow is live.
+func (s *EmailVerificationService) Enabled() bool {
+	return s.Cfg.EmailVerificationActive() && s.Sender != nil
+}
+
+// StartVerification generates a fresh code for the user and emails it,
+// subject to the resend cooldown and daily send cap.
+func (s *EmailVerificationService) StartVerification(ctx context.Context, user *models.User) error {
+	if !s.Enabled() {
+		return ErrVerificationDisabled
+	}
+	if user.EmailVerified() {
+		return ErrAlreadyVerified
+	}
+	if user.Email == "" {
+		return ErrNoEmailOnAccount
+	}
+
+	existing, err := s.Codes.GetByUserID(user.ID)
+	if err != nil {
+		return fmt.Errorf("loading pending verification: %w", err)
+	}
+
+	now := time.Now()
+	sendCount := 0
+	if existing != nil {
+		if now.Sub(existing.LastSentAt) < resendCooldown {
+			return ErrResendCooldown
+		}
+		if sameUTCDay(existing.LastSentAt, now) {
+			if existing.SendCount >= maxDailySends {
+				return ErrDailySendLimit
+			}
+			sendCount = existing.SendCount
+		}
+	}
+
+	code, err := generateVerificationCode()
+	if err != nil {
+		return fmt.Errorf("generating code: %w", err)
+	}
+	hash, err := bcrypt.GenerateFromPassword([]byte(code), 10)
+	if err != nil {
+		return fmt.Errorf("hashing code: %w", err)
+	}
+
+	if err := s.Codes.Upsert(&models.EmailVerification{
+		UserID:     user.ID,
+		CodeHash:   string(hash),
+		ExpiresAt:  now.Add(codeTTL),
+		Attempts:   0,
+		SendCount:  sendCount + 1,
+		LastSentAt: now,
+	}); err != nil {
+		return fmt.Errorf("saving verification: %w", err)
+	}
+
+	subject := "Your SaltyBytes verification code"
+	text := fmt.Sprintf("Your SaltyBytes verification code is %s\n\nIt expires in 15 minutes. If you didn't create a SaltyBytes account, you can ignore this email.", code)
+	html := fmt.Sprintf(`<div style="font-family:sans-serif;max-width:420px;margin:0 auto">
+<h2 style="color:#E91E63">SaltyBytes</h2>
+<p>Your verification code is:</p>
+<p style="font-size:32px;font-weight:700;letter-spacing:8px;margin:16px 0">%s</p>
+<p style="color:#666">It expires in 15 minutes. If you didn't create a SaltyBytes account, you can ignore this email.</p>
+</div>`, code)
+
+	if err := s.Sender.Send(ctx, user.Email, subject, text, html); err != nil {
+		return fmt.Errorf("sending verification email: %w", err)
+	}
+	return nil
+}
+
+// ConfirmCode checks the entered code and, on match, marks the user's email
+// verified. Idempotent for already-verified users.
+func (s *EmailVerificationService) ConfirmCode(user *models.User, code string) error {
+	if !s.Enabled() {
+		return ErrVerificationDisabled
+	}
+	if user.EmailVerified() {
+		return nil
+	}
+
+	pending, err := s.Codes.GetByUserID(user.ID)
+	if err != nil {
+		return fmt.Errorf("loading pending verification: %w", err)
+	}
+	if pending == nil || time.Now().After(pending.ExpiresAt) {
+		return ErrCodeExpired
+	}
+	if pending.Attempts >= maxCodeAttempts {
+		return ErrTooManyAttempts
+	}
+
+	if bcrypt.CompareHashAndPassword([]byte(pending.CodeHash), []byte(code)) != nil {
+		if err := s.Codes.IncrementAttempts(user.ID); err != nil {
+			return fmt.Errorf("recording failed attempt: %w", err)
+		}
+		return ErrCodeInvalid
+	}
+
+	if err := s.Users.SetEmailVerified(user.ID); err != nil {
+		return fmt.Errorf("marking email verified: %w", err)
+	}
+	_ = s.Codes.DeleteByUserID(user.ID) // best-effort cleanup
+
+	now := time.Now()
+	user.EmailVerifiedAt = &now
+	return nil
+}
+
+// generateVerificationCode returns a crypto-random 6-digit code.
+func generateVerificationCode() (string, error) {
+	n, err := rand.Int(rand.Reader, big.NewInt(1000000))
+	if err != nil {
+		return "", err
+	}
+	return fmt.Sprintf("%06d", n.Int64()), nil
+}
+
+// sameUTCDay reports whether two instants fall on the same UTC calendar day.
+func sameUTCDay(a, b time.Time) bool {
+	ay, am, ad := a.UTC().Date()
+	by, bm, bd := b.UTC().Date()
+	return ay == by && am == bm && ad == bd
+}

--- a/internal/service/email_verification_test.go
+++ b/internal/service/email_verification_test.go
@@ -1,0 +1,301 @@
+package service
+
+import (
+	"context"
+	"errors"
+	"regexp"
+	"testing"
+	"time"
+
+	"github.com/windoze95/saltybytes-api/internal/config"
+	"github.com/windoze95/saltybytes-api/internal/models"
+	"github.com/windoze95/saltybytes-api/internal/testutil"
+)
+
+var codePattern = regexp.MustCompile(`\b\d{6}\b`)
+
+func verificationEnabledConfig() *config.Config {
+	return &config.Config{EnvVars: config.EnvVars{
+		EmailVerificationEnabled: true,
+		EmailFrom:                "SaltyBytes <no-reply@saltybytes.ai>",
+	}}
+}
+
+func newVerificationHarness(cfg *config.Config) (*EmailVerificationService, *testutil.MockUserRepo, *testutil.MockEmailVerificationRepo, *testutil.MockEmailSender) {
+	users := testutil.NewMockUserRepo()
+	codes := testutil.NewMockEmailVerificationRepo()
+	sender := &testutil.MockEmailSender{}
+	svc := NewEmailVerificationService(cfg, users, codes, sender)
+	return svc, users, codes, sender
+}
+
+func seedUnverifiedUser(users *testutil.MockUserRepo) *models.User {
+	user := &models.User{
+		Username: "newchef",
+		Email:    "newchef@example.com",
+		Auth:     &models.UserAuth{AuthType: models.Standard},
+	}
+	users.CreateUser(user)
+	return user
+}
+
+func TestEmailVerification_DisabledWithoutFlagOrFrom(t *testing.T) {
+	for _, cfg := range []*config.Config{
+		{EnvVars: config.EnvVars{EmailVerificationEnabled: false, EmailFrom: "x@y.z"}},
+		{EnvVars: config.EnvVars{EmailVerificationEnabled: true, EmailFrom: ""}},
+	} {
+		svc, users, _, _ := newVerificationHarness(cfg)
+		if svc.Enabled() {
+			t.Errorf("Enabled() = true for cfg %+v, want false", cfg.EnvVars)
+		}
+		user := seedUnverifiedUser(users)
+		if err := svc.StartVerification(context.Background(), user); !errors.Is(err, ErrVerificationDisabled) {
+			t.Errorf("StartVerification = %v, want ErrVerificationDisabled", err)
+		}
+	}
+}
+
+func TestStartVerification_SendsCodeEmail(t *testing.T) {
+	svc, users, codes, sender := newVerificationHarness(verificationEnabledConfig())
+	user := seedUnverifiedUser(users)
+
+	if err := svc.StartVerification(context.Background(), user); err != nil {
+		t.Fatalf("StartVerification error: %v", err)
+	}
+
+	sent := sender.LastSent()
+	if sent == nil {
+		t.Fatal("no email was sent")
+	}
+	if sent.To != "newchef@example.com" {
+		t.Errorf("sent to %q", sent.To)
+	}
+	if !codePattern.MatchString(sent.Text) {
+		t.Errorf("email text has no 6-digit code: %q", sent.Text)
+	}
+
+	row, _ := codes.GetByUserID(user.ID)
+	if row == nil {
+		t.Fatal("no verification row persisted")
+	}
+	if row.CodeHash == codePattern.FindString(sent.Text) {
+		t.Error("code must be stored hashed, not in plaintext")
+	}
+	if time.Until(row.ExpiresAt) <= 0 {
+		t.Error("expiry must be in the future")
+	}
+}
+
+func TestConfirmCode_Roundtrip(t *testing.T) {
+	svc, users, codes, sender := newVerificationHarness(verificationEnabledConfig())
+	user := seedUnverifiedUser(users)
+
+	if err := svc.StartVerification(context.Background(), user); err != nil {
+		t.Fatalf("StartVerification error: %v", err)
+	}
+	code := codePattern.FindString(sender.LastSent().Text)
+
+	if err := svc.ConfirmCode(user, code); err != nil {
+		t.Fatalf("ConfirmCode error: %v", err)
+	}
+	if !user.EmailVerified() {
+		t.Error("user should be marked verified in memory")
+	}
+	stored, _ := users.GetUserByID(user.ID)
+	if !stored.EmailVerified() {
+		t.Error("user should be marked verified in the repo")
+	}
+	if row, _ := codes.GetByUserID(user.ID); row != nil {
+		t.Error("verification row should be deleted after success")
+	}
+
+	// Idempotent for already-verified users.
+	if err := svc.ConfirmCode(user, "000000"); err != nil {
+		t.Errorf("ConfirmCode on verified user = %v, want nil", err)
+	}
+}
+
+func TestConfirmCode_WrongCodeCountsAttempts(t *testing.T) {
+	svc, users, codes, sender := newVerificationHarness(verificationEnabledConfig())
+	user := seedUnverifiedUser(users)
+	svc.StartVerification(context.Background(), user)
+	right := codePattern.FindString(sender.LastSent().Text)
+	wrong := "000000"
+	if wrong == right {
+		wrong = "000001"
+	}
+
+	for i := 0; i < 5; i++ {
+		if err := svc.ConfirmCode(user, wrong); !errors.Is(err, ErrCodeInvalid) {
+			t.Fatalf("attempt %d: err = %v, want ErrCodeInvalid", i+1, err)
+		}
+	}
+	// Attempt cap reached: even the RIGHT code is now rejected.
+	if err := svc.ConfirmCode(user, right); !errors.Is(err, ErrTooManyAttempts) {
+		t.Errorf("after cap: err = %v, want ErrTooManyAttempts", err)
+	}
+	if row, _ := codes.GetByUserID(user.ID); row.Attempts != 5 {
+		t.Errorf("attempts = %d, want 5", row.Attempts)
+	}
+}
+
+func TestConfirmCode_Expired(t *testing.T) {
+	svc, users, codes, _ := newVerificationHarness(verificationEnabledConfig())
+	user := seedUnverifiedUser(users)
+	codes.Upsert(&models.EmailVerification{
+		UserID:     user.ID,
+		CodeHash:   "irrelevant",
+		ExpiresAt:  time.Now().Add(-time.Minute),
+		LastSentAt: time.Now().Add(-20 * time.Minute),
+	})
+
+	if err := svc.ConfirmCode(user, "123456"); !errors.Is(err, ErrCodeExpired) {
+		t.Errorf("err = %v, want ErrCodeExpired", err)
+	}
+}
+
+func TestConfirmCode_NoPendingRow(t *testing.T) {
+	svc, users, _, _ := newVerificationHarness(verificationEnabledConfig())
+	user := seedUnverifiedUser(users)
+
+	if err := svc.ConfirmCode(user, "123456"); !errors.Is(err, ErrCodeExpired) {
+		t.Errorf("err = %v, want ErrCodeExpired (request a new code)", err)
+	}
+}
+
+func TestStartVerification_ResendCooldown(t *testing.T) {
+	svc, users, _, _ := newVerificationHarness(verificationEnabledConfig())
+	user := seedUnverifiedUser(users)
+
+	if err := svc.StartVerification(context.Background(), user); err != nil {
+		t.Fatalf("first send error: %v", err)
+	}
+	if err := svc.StartVerification(context.Background(), user); !errors.Is(err, ErrResendCooldown) {
+		t.Errorf("immediate resend err = %v, want ErrResendCooldown", err)
+	}
+}
+
+func TestStartVerification_DailySendCap(t *testing.T) {
+	svc, users, codes, _ := newVerificationHarness(verificationEnabledConfig())
+	user := seedUnverifiedUser(users)
+	codes.Upsert(&models.EmailVerification{
+		UserID:     user.ID,
+		CodeHash:   "x",
+		ExpiresAt:  time.Now().Add(10 * time.Minute),
+		SendCount:  6,
+		LastSentAt: time.Now().Add(-5 * time.Minute), // past cooldown, same day
+	})
+
+	if err := svc.StartVerification(context.Background(), user); !errors.Is(err, ErrDailySendLimit) {
+		t.Errorf("err = %v, want ErrDailySendLimit", err)
+	}
+}
+
+func TestStartVerification_AlreadyVerifiedAndNoEmail(t *testing.T) {
+	svc, users, _, _ := newVerificationHarness(verificationEnabledConfig())
+
+	verified := seedUnverifiedUser(users)
+	now := time.Now()
+	verified.EmailVerifiedAt = &now
+	if err := svc.StartVerification(context.Background(), verified); !errors.Is(err, ErrAlreadyVerified) {
+		t.Errorf("err = %v, want ErrAlreadyVerified", err)
+	}
+
+	noEmail := &models.User{Username: "squatter"}
+	users.CreateUser(noEmail)
+	if err := svc.StartVerification(context.Background(), noEmail); !errors.Is(err, ErrNoEmailOnAccount) {
+		t.Errorf("err = %v, want ErrNoEmailOnAccount", err)
+	}
+}
+
+func TestCreateUser_AutoVerifiedWhileFeatureOff(t *testing.T) {
+	repo := testutil.NewMockUserRepo()
+	svc := newTestUserService(repo) // empty config = verification off
+
+	user, err := svc.CreateUser("chefbob42", "", "bob@example.com", "Password1!")
+	if err != nil {
+		t.Fatalf("CreateUser error: %v", err)
+	}
+	if !user.EmailVerified() {
+		t.Error("signups must be auto-verified while verification is disabled")
+	}
+}
+
+func TestCreateUser_UnverifiedWhileFeatureOn(t *testing.T) {
+	repo := testutil.NewMockUserRepo()
+	svc := &UserService{Cfg: verificationEnabledConfig(), Repo: repo}
+
+	user, err := svc.CreateUser("chefbob42", "", "bob@example.com", "Password1!")
+	if err != nil {
+		t.Fatalf("CreateUser error: %v", err)
+	}
+	if user.EmailVerified() {
+		t.Error("signups must start unverified while verification is enabled")
+	}
+}
+
+func TestEmailTakenForSignup_ReleasesStaleUnverifiedSquatter(t *testing.T) {
+	repo := testutil.NewMockUserRepo()
+	svc := &UserService{Cfg: verificationEnabledConfig(), Repo: repo}
+
+	squatter := &models.User{
+		Username: "squatter",
+		Email:    "victim@example.com",
+		Auth:     &models.UserAuth{AuthType: models.Standard},
+	}
+	repo.CreateUser(squatter)
+	squatter.CreatedAt = time.Now().Add(-72 * time.Hour) // stale
+
+	taken, err := svc.EmailTakenForSignup("Victim@Example.com")
+	if err != nil {
+		t.Fatalf("EmailTakenForSignup error: %v", err)
+	}
+	if taken {
+		t.Error("stale unverified signup must release the email")
+	}
+	freed, _ := repo.GetUserByID(squatter.ID)
+	if freed.Email != "" {
+		t.Errorf("squatter email = %q, want cleared", freed.Email)
+	}
+}
+
+func TestEmailTakenForSignup_KeepsFreshAndVerifiedHolders(t *testing.T) {
+	repo := testutil.NewMockUserRepo()
+	svc := &UserService{Cfg: verificationEnabledConfig(), Repo: repo}
+
+	fresh := &models.User{Username: "fresh", Email: "fresh@example.com", Auth: &models.UserAuth{AuthType: models.Standard}}
+	repo.CreateUser(fresh)
+	fresh.CreatedAt = time.Now().Add(-1 * time.Hour)
+
+	now := time.Now()
+	verified := &models.User{Username: "settled", Email: "settled@example.com", EmailVerifiedAt: &now, Auth: &models.UserAuth{AuthType: models.Standard}}
+	repo.CreateUser(verified)
+	verified.CreatedAt = time.Now().Add(-100 * 24 * time.Hour)
+
+	for _, email := range []string{"fresh@example.com", "settled@example.com"} {
+		taken, err := svc.EmailTakenForSignup(email)
+		if err != nil {
+			t.Fatalf("EmailTakenForSignup(%q) error: %v", email, err)
+		}
+		if !taken {
+			t.Errorf("EmailTakenForSignup(%q) = false, want true", email)
+		}
+	}
+}
+
+func TestEmailTakenForSignup_NeverReleasesWhileFeatureOff(t *testing.T) {
+	repo := testutil.NewMockUserRepo()
+	svc := newTestUserService(repo) // verification off
+
+	holder := &models.User{Username: "holder", Email: "held@example.com", Auth: &models.UserAuth{AuthType: models.Standard}}
+	repo.CreateUser(holder)
+	holder.CreatedAt = time.Now().Add(-72 * time.Hour)
+
+	taken, err := svc.EmailTakenForSignup("held@example.com")
+	if err != nil {
+		t.Fatalf("EmailTakenForSignup error: %v", err)
+	}
+	if !taken {
+		t.Error("emails must never be released while verification is off")
+	}
+}

--- a/internal/service/user.go
+++ b/internal/service/user.go
@@ -29,6 +29,7 @@ type UserResponse struct {
 	Username        string                  `json:"username"`
 	FirstName       string                  `json:"first_name"`
 	Email           string                  `json:"email"`
+	EmailVerified   bool                    `json:"email_verified"`
 	Settings        SettingsResponse        `json:"settings"`
 	Personalization PersonalizationResponse `json:"personalization"`
 	CreatedAt       time.Time               `json:"createdAt"`
@@ -72,11 +73,21 @@ func (s *UserService) CreateUser(username, firstName, email, password string) (*
 
 	hashedPasswordStr := string(hashedPassword)
 
+	// While email verification is disabled, accounts are verified at birth so
+	// nothing gates on it; once enabled, new accounts start unverified and
+	// the signup handler sends the code.
+	var emailVerifiedAt *time.Time
+	if !s.Cfg.EmailVerificationActive() {
+		now := time.Now()
+		emailVerifiedAt = &now
+	}
+
 	// Create User and UserSettings
 	user := &models.User{
-		Username:  username,
-		FirstName: firstName,
-		Email:     email,
+		Username:        username,
+		FirstName:       firstName,
+		Email:           email,
+		EmailVerifiedAt: emailVerifiedAt,
 		Auth: &models.UserAuth{
 			HashedPassword: hashedPasswordStr,
 			AuthType:       models.Standard,
@@ -154,6 +165,34 @@ func (s *UserService) EmailInUse(email string) (bool, error) {
 	return s.Repo.EmailExists(strings.TrimSpace(email))
 }
 
+// EmailTakenForSignup reports whether an email is unavailable to a new
+// signup. Unlike EmailInUse, a stale squatter — an account that never
+// verified the address within 48 hours of signup (only possible while email
+// verification is on) — releases the address and does not block the signup.
+// The squatting account keeps working via username login.
+func (s *UserService) EmailTakenForSignup(email string) (bool, error) {
+	holder, err := s.Repo.GetUserAuthByEmail(strings.TrimSpace(email))
+	if err != nil {
+		if errors.Is(err, gorm.ErrRecordNotFound) {
+			return false, nil
+		}
+		return true, err
+	}
+	if holder == nil {
+		return false, nil
+	}
+	if holder.EmailVerified() || !s.Cfg.EmailVerificationActive() {
+		return true, nil
+	}
+	if time.Since(holder.CreatedAt) < staleSignupAfter {
+		return true, nil
+	}
+	if err := s.Repo.ClearUserEmail(holder.ID); err != nil {
+		return true, err
+	}
+	return false, nil
+}
+
 // GetUserWithAuthByID gets a user with their auth record (token version) loaded.
 func (s *UserService) GetUserWithAuthByID(userID uint) (*models.User, error) {
 	return s.Repo.GetUserWithAuthByID(userID)
@@ -168,12 +207,13 @@ func (s *UserService) LogoutUser(userID uint) error {
 // ToUserResponse converts a User to a UserResponse.
 func ToUserResponse(user *models.User) *UserResponse {
 	resp := &UserResponse{
-		ID:        strconv.FormatUint(uint64(user.ID), 10),
-		Username:  user.Username,
-		FirstName: user.FirstName,
-		Email:     user.Email,
-		CreatedAt: user.CreatedAt,
-		UpdatedAt: user.UpdatedAt,
+		ID:            strconv.FormatUint(uint64(user.ID), 10),
+		Username:      user.Username,
+		FirstName:     user.FirstName,
+		Email:         user.Email,
+		EmailVerified: user.EmailVerified(),
+		CreatedAt:     user.CreatedAt,
+		UpdatedAt:     user.UpdatedAt,
 	}
 	if user.Settings != nil {
 		resp.Settings = SettingsResponse{

--- a/internal/testutil/mocks.go
+++ b/internal/testutil/mocks.go
@@ -759,6 +759,31 @@ func (m *MockUserRepo) EmailExists(email string) (bool, error) {
 	return false, nil
 }
 
+func (m *MockUserRepo) SetEmailVerified(userID uint) error {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	u, ok := m.Users[userID]
+	if !ok {
+		return fmt.Errorf("user not found")
+	}
+	now := time.Now()
+	u.EmailVerifiedAt = &now
+	return nil
+}
+
+func (m *MockUserRepo) ClearUserEmail(userID uint) error {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	u, ok := m.Users[userID]
+	if !ok {
+		return fmt.Errorf("user not found")
+	}
+	u.Email = ""
+	return nil
+}
+
 func (m *MockUserRepo) IncrementTokenVersion(userID uint) error {
 	m.mu.Lock()
 	defer m.mu.Unlock()
@@ -1339,4 +1364,101 @@ func (m *MockExtractionEventRepo) Events() []*models.ExtractionEvent {
 	out := make([]*models.ExtractionEvent, len(m.events))
 	copy(out, m.events)
 	return out
+}
+
+// --- MockEmailVerificationRepo ---
+
+// MockEmailVerificationRepo is an in-memory implementation of
+// repository.EmailVerificationRepo.
+type MockEmailVerificationRepo struct {
+	mu   sync.Mutex
+	Rows map[uint]*models.EmailVerification
+
+	UpsertErr error
+	GetErr    error
+}
+
+// NewMockEmailVerificationRepo creates an initialized mock.
+func NewMockEmailVerificationRepo() *MockEmailVerificationRepo {
+	return &MockEmailVerificationRepo{Rows: make(map[uint]*models.EmailVerification)}
+}
+
+func (m *MockEmailVerificationRepo) Upsert(v *models.EmailVerification) error {
+	if m.UpsertErr != nil {
+		return m.UpsertErr
+	}
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	cp := *v
+	m.Rows[v.UserID] = &cp
+	return nil
+}
+
+func (m *MockEmailVerificationRepo) GetByUserID(userID uint) (*models.EmailVerification, error) {
+	if m.GetErr != nil {
+		return nil, m.GetErr
+	}
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	v, ok := m.Rows[userID]
+	if !ok {
+		return nil, nil
+	}
+	cp := *v
+	return &cp, nil
+}
+
+func (m *MockEmailVerificationRepo) IncrementAttempts(userID uint) error {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	if v, ok := m.Rows[userID]; ok {
+		v.Attempts++
+	}
+	return nil
+}
+
+func (m *MockEmailVerificationRepo) DeleteByUserID(userID uint) error {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	delete(m.Rows, userID)
+	return nil
+}
+
+// --- MockEmailSender ---
+
+// SentEmail records one delivery through MockEmailSender.
+type SentEmail struct {
+	To      string
+	Subject string
+	Text    string
+	HTML    string
+}
+
+// MockEmailSender records sends for assertions; set SendErr to simulate
+// delivery failures.
+type MockEmailSender struct {
+	mu      sync.Mutex
+	Sent    []SentEmail
+	SendErr error
+}
+
+func (m *MockEmailSender) Send(ctx context.Context, to, subject, textBody, htmlBody string) error {
+	if m.SendErr != nil {
+		return m.SendErr
+	}
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	m.Sent = append(m.Sent, SentEmail{To: to, Subject: subject, Text: textBody, HTML: htmlBody})
+	return nil
+}
+
+// LastSent returns the most recent delivery, or nil when none happened.
+func (m *MockEmailSender) LastSent() *SentEmail {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	if len(m.Sent) == 0 {
+		return nil
+	}
+	cp := m.Sent[len(m.Sent)-1]
+	return &cp
 }


### PR DESCRIPTION
## Why

Unlimited accounts with arbitrary emails = free-tier AI quota farming + email squatting. Follows the auth fixes in #116.

## Design (ships dark)

- **6-digit code over email (SES)** — bcrypt-hashed at rest, 15-min TTL, 5 attempts/code, 60s resend cooldown, 6 sends/day.
- **Soft gate**: signup stays instant; `RequireVerifiedEmail` returns 403 `email_unverified` on the AI-cost endpoints only (regen, fork, photo/files/voice/video/text imports, finder, allergens, dietary interview). Browse/save/URL-import stay open.
- **Squat release**: unverified accounts older than 48h release their email when someone else registers it.
- **Fully dark until flipped**: without `EMAIL_VERIFICATION_ENABLED`+`EMAIL_FROM`, signups auto-verify and every gate is a no-op — zero behavior change on deploy. Flip via SSM + force-new-deployment once SES domain identity + production access are in place (infra provisioning handled separately).
- `email_verified` added to user payloads; `email_verifications` table is new; `users.email_verified_at` is an additive nullable column (dashboard unaffected).

## Tests

Full suite green (`go test ./... -count=1`), including 19 new tests: code roundtrip, attempt caps, expiry, cooldowns, daily cap, squat release rules, signup-sends-code, mail-failure-never-fails-signup, gate 403/pass/dark modes.

## Companion

Flutter PR (next) adds the verify-code screen, unverified banner, and 403 `email_unverified` handling.

🤖 Generated with [Claude Code](https://claude.com/claude-code)