### PR TITLE
fix(finder): make collection digging actually yield picks

### DIFF
--- a/internal/ai/web_search.go
+++ b/internal/ai/web_search.go
@@ -7,6 +7,7 @@ import (
 	"io"
 	"net/http"
 	"net/url"
+	"strings"
 	"sync/atomic"
 	"time"
 
@@ -215,13 +216,24 @@ type braveThumbnail struct {
 	Src string `json:"src"`
 }
 
+// braveSearchQuery steers a query toward recipe results, without stuttering
+// when the caller's query already says "recipe" (user-typed "chicken parmesan
+// recipe" or the finder's composed "<facets> recipe -shellfish" must not become
+// "... recipe recipe").
+func braveSearchQuery(query string) string {
+	if strings.Contains(strings.ToLower(query), "recipe") {
+		return query
+	}
+	return query + " recipe"
+}
+
 func (p *WebSearchProvider) searchBrave(ctx context.Context, query string, count int, offset int) ([]SearchResult, error) {
 	if count > 20 {
 		count = 20
 	}
 
 	params := url.Values{}
-	params.Set("q", query+" recipe")
+	params.Set("q", braveSearchQuery(query))
 	params.Set("count", fmt.Sprintf("%d", count))
 	if offset > 0 {
 		params.Set("offset", fmt.Sprintf("%d", offset))

--- a/internal/ai/web_search_query_test.go
+++ b/internal/ai/web_search_query_test.go
@@ -1,0 +1,24 @@
+package ai
+
+import "testing"
+
+func TestBraveSearchQuery(t *testing.T) {
+	cases := []struct {
+		in   string
+		want string
+	}{
+		// Plain keywords get the recipe steer.
+		{"chicken parmesan", "chicken parmesan recipe"},
+		// A query that already says "recipe" must not stutter.
+		{"chicken parmesan recipe", "chicken parmesan recipe"},
+		{"Chicken Parmesan Recipe", "Chicken Parmesan Recipe"},
+		{"best pasta recipes", "best pasta recipes"},
+		// The finder's composed query ends in "recipe" plus allergen excludes.
+		{"beef comfort food recipe -shellfish", "beef comfort food recipe -shellfish"},
+	}
+	for _, c := range cases {
+		if got := braveSearchQuery(c.in); got != c.want {
+			t.Errorf("braveSearchQuery(%q) = %q, want %q", c.in, got, c.want)
+		}
+	}
+}

--- a/internal/service/multi_recipe.go
+++ b/internal/service/multi_recipe.go
@@ -550,6 +550,22 @@ func (r *MultiRecipeResolver) DetectMultiFromHTML(ctx context.Context, sourceURL
 	return len(r.detectCards(ctx, sourceURL, html)) > 1
 }
 
+// preferOwnPageCards stably reorders cards so those that resolved to their own
+// recipe page (SourceURL differs from the collection page) come first. Order
+// within each group is preserved.
+func preferOwnPageCards(cards []MultiRecipeCard, pageURL string) []MultiRecipeCard {
+	ordered := make([]MultiRecipeCard, 0, len(cards))
+	var inline []MultiRecipeCard
+	for _, c := range cards {
+		if u := strings.TrimSpace(c.SourceURL); u != "" && u != pageURL {
+			ordered = append(ordered, c)
+		} else {
+			inline = append(inline, c)
+		}
+	}
+	return append(ordered, inline...)
+}
+
 // MultiResolver is the finder's seam over the multi-recipe resolver. Digging
 // depends only on this interface so the finder's tests can inject a fake and
 // stay fully offline.
@@ -576,13 +592,20 @@ func (r *MultiRecipeResolver) resolveFromHTMLN(ctx context.Context, sourceURL st
 		return nil
 	}
 
-	if maxCards > 0 && len(cards) > maxCards {
-		cards = cards[:maxCards]
-	}
-
 	// Point cards at their own recipe pages when this is a collection/listicle
 	// of links (so each card extracts from its real recipe page, not the index).
+	// Runs before any cap so a capped resolve can keep the cards that lead
+	// somewhere instead of whichever happened to be listed first.
 	assignRecipeURLs(cards, html, sourceURL)
+
+	if maxCards > 0 && len(cards) > maxCards {
+		if extractionOrigin(ctx) == ExtractionOriginFinderDig {
+			// Digging can only fold cards that extract quickly and reliably,
+			// which in practice means cards with their own recipe page.
+			cards = preferOwnPageCards(cards, sourceURL)
+		}
+		cards = cards[:maxCards]
+	}
 
 	entry, isNew := r.Registry.Register(sourceURL)
 	if !isNew {
@@ -943,6 +966,20 @@ func (r *MultiRecipeResolver) extractSingleCard(entry *MultiRecipeEntry, idx int
 		r.finishInlineCard(entry, idx, title, sourceURL, *def, hashtags, models.ExtractionJSONLD, log)
 		log.Info("inline recipe extracted from page JSON-LD", zap.Int("ingredients", len(def.Ingredients)))
 		record("inline_jsonld", true, "", "", nil)
+		return
+	}
+
+	// During finder digging, a card with no own page and no inline JSON-LD is
+	// dropped instead of falling through to AI text extraction: link-index
+	// roundups carry no inline ingredients, so that path burns seconds per card
+	// (and light-tier quota) to fail with "recipe has no ingredients" nearly
+	// every time. Preview/import flows keep the AI fallback — there the user
+	// explicitly asked for this page and can wait.
+	if origin == ExtractionOriginFinderDig {
+		entry.mu.Lock()
+		entry.Cards[idx].ExtractionStatus = "failed"
+		entry.mu.Unlock()
+		record("inline_ai", false, "skipped_dig", "inline AI extraction skipped during finder digging (no own page, no inline JSON-LD)", nil)
 		return
 	}
 

--- a/internal/service/multi_recipe_dig_test.go
+++ b/internal/service/multi_recipe_dig_test.go
@@ -1,0 +1,95 @@
+package service
+
+import (
+	"context"
+	"sync/atomic"
+	"testing"
+
+	"github.com/windoze95/saltybytes-api/internal/ai"
+	"github.com/windoze95/saltybytes-api/internal/testutil"
+)
+
+func TestPreferOwnPageCards(t *testing.T) {
+	page := "https://example.com/roundup"
+	cards := []MultiRecipeCard{
+		{Title: "Inline One", SourceURL: page},
+		{Title: "Own A", SourceURL: "https://example.com/recipe/own-a"},
+		{Title: "Inline Two", SourceURL: page},
+		{Title: "Own B", SourceURL: "https://example.com/recipe/own-b"},
+	}
+	got := preferOwnPageCards(cards, page)
+	wantOrder := []string{"Own A", "Own B", "Inline One", "Inline Two"}
+	if len(got) != len(wantOrder) {
+		t.Fatalf("got %d cards, want %d", len(got), len(wantOrder))
+	}
+	for i, title := range wantOrder {
+		if got[i].Title != title {
+			t.Errorf("card[%d] = %q, want %q (own-page cards first, stable)", i, got[i].Title, title)
+		}
+	}
+}
+
+// TestExtractSingleCard_DigSkipsInlineAI locks the dig-context cost guard: a
+// card with no own recipe page and no matching inline JSON-LD is dropped
+// WITHOUT calling the AI text extractor (in prod that path failed 10/10,
+// burning seconds and light-tier quota per card). Non-dig flows keep the AI
+// fallback.
+func TestExtractSingleCard_DigSkipsInlineAI(t *testing.T) {
+	page := "https://example.com/roundup"
+	// JSON-LD blocks carry names only (no ingredients), so inline JSON-LD
+	// extraction misses and the AI fallback is the next step.
+	html := multiRecipeHTML("Pancakes", "Waffles")
+
+	t.Run("finder_dig skips AI and fails the card", func(t *testing.T) {
+		var aiCalls atomic.Int32
+		preview := &testutil.MockTextProvider{
+			ExtractRecipeFromTextFunc: func(ctx context.Context, text string, unitSystem string) (*ai.RecipeResult, error) {
+				aiCalls.Add(1)
+				return testutil.TestRecipeResult(), nil
+			},
+		}
+		resolver := newResolverForTest(preview, &testutil.MockCanonicalRecipeRepo{})
+
+		ctx := WithExtractionOrigin(context.Background(), ExtractionOriginFinderDig)
+		entry := resolver.ResolveFromHTML(ctx, page, html)
+		if entry == nil {
+			t.Fatal("ResolveFromHTML returned nil for a multi-recipe page")
+		}
+		waitResolved(t, entry)
+
+		if n := aiCalls.Load(); n != 0 {
+			t.Errorf("AI extractor called %d times during digging, want 0", n)
+		}
+		for _, card := range entry.GetCards() {
+			if card.ExtractionStatus != "failed" {
+				t.Errorf("dig card %q status = %q, want failed (skipped, not extracted)", card.Title, card.ExtractionStatus)
+			}
+		}
+	})
+
+	t.Run("preview flow keeps the AI fallback", func(t *testing.T) {
+		var aiCalls atomic.Int32
+		preview := &testutil.MockTextProvider{
+			ExtractRecipeFromTextFunc: func(ctx context.Context, text string, unitSystem string) (*ai.RecipeResult, error) {
+				aiCalls.Add(1)
+				return testutil.TestRecipeResult(), nil
+			},
+		}
+		resolver := newResolverForTest(preview, &testutil.MockCanonicalRecipeRepo{})
+
+		entry := resolver.ResolveFromHTML(context.Background(), page, html)
+		if entry == nil {
+			t.Fatal("ResolveFromHTML returned nil for a multi-recipe page")
+		}
+		waitResolved(t, entry)
+
+		if n := aiCalls.Load(); n == 0 {
+			t.Error("AI extractor never called in a non-dig flow, want fallback to run")
+		}
+		for _, card := range entry.GetCards() {
+			if card.ExtractionStatus != "done" {
+				t.Errorf("preview card %q status = %q, want done", card.Title, card.ExtractionStatus)
+			}
+		}
+	})
+}

--- a/internal/service/recipe_finder.go
+++ b/internal/service/recipe_finder.go
@@ -249,6 +249,13 @@ func (s *RecipeFinderService) FindRecipes(ctx context.Context, user *models.User
 	// (and in the dig queue) even when the ranking call failed entirely and
 	// fallbackRanking returned no flags.
 	s.applyKnownCollections(results, rank)
+	// When the ranking call failed there are NO model expand flags at all, so
+	// first-seen roundups would render as recipe cards. Fall back to
+	// high-precision URL/title pattern flags — heuristics only fill in for a
+	// dead model, they never override a successful ranking.
+	if rankErr != "" {
+		applyHeuristicCollections(results, rank)
+	}
 	run.CollectionsFlagged = countExpandFlags(rank)
 
 	// 5. Curate the shown picks: INDIVIDUAL recipes only (collections excluded),
@@ -282,7 +289,7 @@ func (s *RecipeFinderService) FindRecipes(ctx context.Context, user *models.User
 		room = finderDigMaxCards
 	}
 	digStart := time.Now()
-	folded, dug := s.digCollections(ctx, events, results, rank, room, &shortlistEmitted, searchRes.HasMore)
+	folded, dug := s.digCollections(ctx, events, results, rank, room, &shortlistEmitted, searchRes.HasMore, seenResultKeys(shown))
 	run.DigMS = time.Since(digStart).Milliseconds()
 	run.CollectionsDug = dug
 	run.CardsMined = len(folded)
@@ -369,9 +376,12 @@ func countExpandFlags(rank *ai.FinderRankResult) int {
 // was shown (shortlistEmitted false), the first mined batch seeds the shortlist
 // instead so build-89 gets a proper base list. Returns every folded recipe plus
 // how many collections were actually dug (for run telemetry).
-func (s *RecipeFinderService) digCollections(ctx context.Context, events chan<- FinderEvent, results []ai.SearchResult, rank *ai.FinderRankResult, room int, shortlistEmitted *bool, hasMore bool) ([]FinderResultItem, int) {
+func (s *RecipeFinderService) digCollections(ctx context.Context, events chan<- FinderEvent, results []ai.SearchResult, rank *ai.FinderRankResult, room int, shortlistEmitted *bool, hasMore bool, seen map[string]bool) ([]FinderResultItem, int) {
 	if s.MultiResolver == nil || rank == nil || room <= 0 {
 		return nil, 0
+	}
+	if seen == nil {
+		seen = make(map[string]bool)
 	}
 	// Card extractions kicked off below are the finder's own digging.
 	ctx = WithExtractionOrigin(ctx, ExtractionOriginFinderDig)
@@ -434,6 +444,11 @@ func (s *RecipeFinderService) digCollections(ctx context.Context, events chan<- 
 			}
 			cached := strings.TrimSpace(card.CachedURL)
 			if cached == "" {
+				continue
+			}
+			// The same recipe often appears in several roundups (and sometimes as
+			// a direct pick too) — fold each distinct recipe once.
+			if !markResultSeen(seen, cached, card.Title) {
 				continue
 			}
 			batch = append(batch, FinderResultItem{
@@ -641,6 +656,145 @@ func (s *RecipeFinderService) applyKnownCollections(results []ai.SearchResult, r
 			}
 		}
 	}
+}
+
+// applyHeuristicCollections flags candidates whose URL or title carries a
+// near-certain collection/listicle signal. It runs ONLY when the ranking call
+// failed (no model expand flags exist), because a false positive here hides a
+// real single recipe — the patterns are deliberately high-precision, not
+// comprehensive.
+func applyHeuristicCollections(results []ai.SearchResult, rank *ai.FinderRankResult) {
+	if rank == nil {
+		return
+	}
+	for i := range rank.Ranked {
+		r := &rank.Ranked[i]
+		if r.Expand || r.Index < 0 || r.Index >= len(results) {
+			continue
+		}
+		if looksLikeCollectionPage(results[r.Index].URL, results[r.Index].Title) {
+			r.Expand = true
+			if r.ExpandPriority == 0 {
+				// Below applyKnownCollections' DB-certain priority (4).
+				r.ExpandPriority = 3
+			}
+		}
+	}
+}
+
+// looksLikeCollectionPage reports whether a URL/title pair carries a
+// near-certain roundup/listicle signal: a counting title ("40 Easy Weeknight
+// Dinners"), a counting slug (/40-easy-weeknight-dinners), or an index-ish
+// path segment (/gallery/, /collection/, ...).
+func looksLikeCollectionPage(rawURL, title string) bool {
+	if u, err := url.Parse(rawURL); err == nil {
+		p := strings.ToLower(u.Path)
+		for _, seg := range []string{"/gallery/", "/galleries/", "/slideshow", "/roundup", "/collection/", "/collections/", "/category/"} {
+			if strings.Contains(p, seg) {
+				return true
+			}
+		}
+		if countingListSignal(lastPathSegment(p)) {
+			return true
+		}
+	}
+	return countingListSignal(strings.ToLower(strings.TrimSpace(title)))
+}
+
+// lastPathSegment returns the final non-empty segment of an already-lowercased
+// URL path ("" when none).
+func lastPathSegment(p string) string {
+	segs := strings.Split(strings.Trim(p, "/"), "/")
+	if len(segs) == 0 {
+		return ""
+	}
+	return segs[len(segs)-1]
+}
+
+// countQualifiers are words that make a leading number describe ONE recipe
+// ("5-ingredient brownies", "30-minute chili", "15 bean soup") rather than
+// count a list ("40 easy weeknight dinners"). Precision beats recall here: a
+// missed collection just shows one odd card; a false positive hides a real
+// recipe.
+var countQualifiers = map[string]bool{
+	"minute": true, "minutes": true, "min": true, "hour": true, "hours": true,
+	"ingredient": true, "ingredients": true, "step": true, "steps": true,
+	"layer": true, "layers": true, "pot": true, "pan": true, "sheet": true,
+	"day": true, "days": true, "week": true, "weeks": true,
+	"bean": true, "beans": true, "spice": true, "spices": true,
+	"cheese": true, "grain": true, "grains": true, "seed": true, "seeds": true,
+}
+
+// countingListSignal reports whether an already-lowercased title or slug starts
+// with an integer >= 2 counting a LIST ("40 easy weeknight dinners",
+// "23-best-chicken-dinners", "12+ cozy soups"), excluding single-recipe
+// qualifiers ("5-ingredient brownies").
+func countingListSignal(s string) bool {
+	i := 0
+	for i < len(s) && s[i] >= '0' && s[i] <= '9' {
+		i++
+	}
+	if i == 0 || i > 3 {
+		return false // no leading number, or an absurdly long digit run
+	}
+	n := 0
+	for _, c := range s[:i] {
+		n = n*10 + int(c-'0')
+	}
+	if n < 2 {
+		return false
+	}
+	rest := s[i:]
+	if rest != "" && rest[0] == '+' {
+		rest = rest[1:]
+	}
+	if rest == "" || (rest[0] != ' ' && rest[0] != '-') {
+		return false
+	}
+	next := strings.FieldsFunc(rest, func(r rune) bool {
+		return !((r >= 'a' && r <= 'z') || (r >= '0' && r <= '9'))
+	})
+	return len(next) > 0 && !countQualifiers[next[0]]
+}
+
+// seenResultKeys seeds a dedup set from already-shown picks so digging never
+// folds a recipe the user is already looking at.
+func seenResultKeys(items []FinderResultItem) map[string]bool {
+	seen := make(map[string]bool, len(items)*2)
+	for _, it := range items {
+		markResultSeen(seen, it.Result.URL, it.Result.Title)
+	}
+	return seen
+}
+
+// markResultSeen records a recipe's URL+title dedup keys, reporting true when
+// the recipe was NOT seen before (i.e. the caller should keep it). A recipe is
+// a duplicate when either its normalized URL or its normalized title was
+// already recorded — the same dish mined from two roundups usually shares a
+// URL, but titles catch same-recipe-different-tracking-params cases.
+func markResultSeen(seen map[string]bool, rawURL, title string) bool {
+	urlKey := ""
+	if u := strings.TrimSpace(rawURL); u != "" {
+		if norm, err := NormalizeURL(u); err == nil {
+			urlKey = "u:" + norm
+		} else {
+			urlKey = "u:" + strings.ToLower(u)
+		}
+	}
+	titleKey := ""
+	if t := strings.Join(strings.Fields(strings.ToLower(title)), " "); t != "" {
+		titleKey = "t:" + t
+	}
+	if (urlKey != "" && seen[urlKey]) || (titleKey != "" && seen[titleKey]) {
+		return false
+	}
+	if urlKey != "" {
+		seen[urlKey] = true
+	}
+	if titleKey != "" {
+		seen[titleKey] = true
+	}
+	return true
 }
 
 // dietContext compacts the owner's family dietary needs into a model-facing

--- a/internal/service/recipe_finder_digging_test.go
+++ b/internal/service/recipe_finder_digging_test.go
@@ -407,3 +407,140 @@ func TestFindRecipes_KnownMultiExcludedEvenWhenRankingFails(t *testing.T) {
 		t.Errorf("mined recipe not folded into results: %v", titles)
 	}
 }
+
+// TestFindRecipes_HeuristicCollectionsExcludedWhenRankingFails locks the second
+// fail-closed layer: when ranking fails, FIRST-SEEN roundups (not yet in the
+// canonical cache, so applyKnownCollections can't catch them) must still be
+// pulled out of the results by URL/title pattern and dug instead of being
+// painted as recipe cards.
+func TestFindRecipes_HeuristicCollectionsExcludedWhenRankingFails(t *testing.T) {
+	slugCollection := "https://example.com/40-easy-weeknight-dinners"
+	pathCollection := "https://example.com/gallery/cozy-fall-soups"
+	results := []ai.SearchResult{
+		{Title: "Sheet Pan Chicken Fajitas", URL: "https://example.com/recipe/sheet-pan-chicken-fajitas", Source: "example.com", Description: "Quick weeknight fajitas."},
+		{Title: "40 Easy Weeknight Dinner Recipes", URL: slugCollection, Source: "example.com", Description: "Our favorite quick dinners."},
+		{Title: "Cozy Fall Soups", URL: pathCollection, Source: "example.com", Description: "A gallery of soups."},
+		{Title: "5-Ingredient Brownies", URL: "https://example.com/recipe/5-ingredient-brownies", Source: "example.com", Description: "One bowl, five ingredients."},
+	}
+	searchProvider := &testutil.MockSearchProvider{
+		SearchRecipesFunc: func(ctx context.Context, query string, count, offset int) ([]ai.SearchResult, error) {
+			return results, nil
+		},
+	}
+	ranker := &testutil.MockTextProvider{
+		ExpandAndRankRecipesFunc: func(ctx context.Context, req ai.FinderRankRequest) (*ai.FinderRankResult, error) {
+			return nil, fmt.Errorf("model exploded")
+		},
+	}
+	fake := &fakeMultiResolver{entries: map[string]*MultiRecipeEntry{
+		slugCollection: resolvedEntry(slugCollection, doneCard("Skillet Chicken Parm", "https://example.com/recipe/skillet-chicken-parm")),
+		pathCollection: resolvedEntry(pathCollection, doneCard("Butternut Squash Soup", "https://example.com/recipe/butternut-squash-soup")),
+	}}
+
+	svc := newFinderService(searchProvider, ranker, &testutil.MockFamilyRepo{})
+	svc.MultiResolver = fake
+
+	events := runFinder(svc, testutil.TestUser(), FinderRequest{Facets: FinderFacets{Occasion: "weeknight"}})
+
+	// Neither pattern-flagged collection is ever shown as a card...
+	for _, u := range []string{slugCollection, pathCollection} {
+		if shownHasURL(events, u) {
+			t.Errorf("heuristic collection %q shown as a result despite ranking failure", u)
+		}
+	}
+	// ...but the real singles are, INCLUDING the count-qualified single recipe.
+	for _, u := range []string{results[0].URL, results[3].URL} {
+		if !shownHasURL(events, u) {
+			t.Errorf("real single recipe %q missing from results", u)
+		}
+	}
+	// Both heuristic collections were dug and their recipes folded in.
+	if len(fake.calls) != 2 {
+		t.Errorf("resolver calls = %v, want both heuristic collections dug", fake.calls)
+	}
+	for _, mined := range []string{"https://example.com/recipe/skillet-chicken-parm", "https://example.com/recipe/butternut-squash-soup"} {
+		if !shownHasURL(events, mined) {
+			t.Errorf("mined recipe %q not folded into results", mined)
+		}
+	}
+}
+
+// TestFindRecipes_DedupsMinedAcrossCollectionsAndDirect: the same recipe often
+// appears in several roundups and as a direct pick; each distinct recipe is
+// folded at most once (URL and normalized-title keys).
+func TestFindRecipes_DedupsMinedAcrossCollectionsAndDirect(t *testing.T) {
+	direct := ai.SearchResult{Title: "One-Pot Chicken and Rice", URL: "https://example.com/recipe/one-pot-chicken-rice", Source: "example.com", Description: "A comforting classic."}
+	collA := ai.SearchResult{Title: "Roundup A", URL: "https://example.com/roundup-a", Source: "example.com"}
+	collB := ai.SearchResult{Title: "Roundup B", URL: "https://example.com/roundup-b", Source: "example.com"}
+	results := []ai.SearchResult{direct, collA, collB}
+
+	searchProvider := &testutil.MockSearchProvider{
+		SearchRecipesFunc: func(ctx context.Context, query string, count, offset int) ([]ai.SearchResult, error) {
+			return results, nil
+		},
+	}
+	ranker := rankAllFlagging(results, map[int]int{1: 5, 2: 4})
+
+	fake := &fakeMultiResolver{entries: map[string]*MultiRecipeEntry{
+		collA.URL: resolvedEntry(collA.URL,
+			doneCard("One-Pot Chicken and Rice", direct.URL), // duplicate of the direct pick
+			doneCard("Ground Beef Gyros", "https://example.com/recipe/ground-beef-gyros"),
+			doneCard("Skillet Lasagna", "https://example.com/recipe/skillet-lasagna"),
+		),
+		collB.URL: resolvedEntry(collB.URL,
+			doneCard("Ground Beef Gyros", "https://example.com/recipe/ground-beef-gyros"), // dup by URL
+			doneCard("Skillet  Lasagna", "https://example.com/recipe/skillet-lasagna-two"), // dup by normalized title
+			doneCard("Chicken Tikka Masala", "https://example.com/recipe/chicken-tikka-masala"),
+		),
+	}}
+
+	svc := newFinderService(searchProvider, ranker, &testutil.MockFamilyRepo{})
+	svc.MultiResolver = fake
+
+	events := runFinder(svc, testutil.TestUser(), FinderRequest{Facets: FinderFacets{Protein: "chicken"}})
+
+	shown := shownItems(events)
+	counts := map[string]int{}
+	for _, it := range shown {
+		counts[strings.ToLower(strings.Join(strings.Fields(it.Result.Title), " "))]++
+	}
+	for title, n := range counts {
+		if n > 1 {
+			t.Errorf("recipe %q shown %d times, want 1", title, n)
+		}
+	}
+	// Exactly the 4 distinct recipes: direct + gyros + lasagna + tikka.
+	if len(shown) != 4 {
+		titles := make([]string, 0, len(shown))
+		for _, it := range shown {
+			titles = append(titles, it.Result.Title)
+		}
+		t.Errorf("shown %d items %v, want the 4 distinct recipes", len(shown), titles)
+	}
+}
+
+func TestLooksLikeCollectionPage(t *testing.T) {
+	cases := []struct {
+		url, title string
+		want       bool
+	}{
+		{"https://example.com/40-easy-weeknight-dinners", "40 Easy Weeknight Dinner Recipes", true},
+		{"https://example.com/dinners", "23 Best Chicken Dinners", true},
+		{"https://example.com/dinners", "12+ Cozy Soups for Fall", true},
+		{"https://example.com/gallery/best-soups", "Our Best Soups", true},
+		{"https://example.com/recipes/category/desserts", "Desserts", true},
+		{"https://example.com/slideshow/comfort-food", "Comfort Food", true},
+		// Single recipes with counting qualifiers must NOT be flagged.
+		{"https://example.com/recipe/5-ingredient-brownies", "5-Ingredient Brownies", false},
+		{"https://example.com/recipe/30-minute-chili", "30-Minute Chili", false},
+		{"https://example.com/recipe/15-bean-soup", "15 Bean Soup", false},
+		{"https://example.com/recipe/3-cheese-lasagna", "3 Cheese Lasagna", false},
+		{"https://example.com/recipe/lemon-garlic-chicken", "Creamy Lemon Garlic Chicken", false},
+		{"https://example.com/recipe/one-pot-pasta", "1 Pot Pasta", false},
+	}
+	for _, c := range cases {
+		if got := looksLikeCollectionPage(c.url, c.title); got != c.want {
+			t.Errorf("looksLikeCollectionPage(%q, %q) = %v, want %v", c.url, c.title, got, c.want)
+		}
+	}
+}


### PR DESCRIPTION
## Why

Prod telemetry (`finder_runs` + `extraction_events`) shows agent-mode digging is structurally broken: **10 of 15 dig card extractions failed**. Cards without their own recipe page fell back to AI text extraction from the roundup page — a link index with no inline ingredients — so every attempt burned 5–30s of Gemini quota to fail with "recipe has no ingredients" or a 429. A typical broad query ("popular dinner recipe", 9/10 candidates = collections) took 38s to show 4 results. Separately, a rank failure painted first-seen roundups as recipe cards, and the same recipe mined from two roundups displayed twice.

## What

- **Dig only what works**: in `finder_dig` context, a card with no own page and no inline JSON-LD is dropped instead of AI-extracted (own-page cards succeeded 5/5 in prod; inline-AI 0/10). Telemetry code `skipped_dig`. Preview/import flows keep the AI fallback.
- **Cap keeps minable cards**: own-page URL assignment now runs before the dig card cap, and dig-context capping stably prefers own-page cards.
- **Dedup mined picks** against direct picks and across collections (normalized URL + title keys).
- **Fail-closed for first-seen roundups**: when ranking fails, high-precision URL/title patterns (counting titles/slugs, `/gallery/` etc.) flag collections so they're dug, never shown as fake recipe cards. Counting qualifiers (`5-ingredient`, `30-minute`, `15-bean`) excluded. Heuristics never override a successful ranking.
- **Query stutter fix**: `braveSearchQuery` no longer appends " recipe" to a query that already contains it (also fixes plain search: "chicken recipe" → was searching "chicken recipe recipe").

## Tests

Full offline suite green. New: dig-skips-inline-AI (both flows), own-page-first capping, cross-collection dedup, heuristic fail-closed run, `looksLikeCollectionPage` table, `braveSearchQuery` table.

Part 1 of the agent-mode overhaul (diagnosis: 2026-07-05). Part 2 = instant results + final top-picks curation; part 3 = Gemini json_schema extraction fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01My8N5v3zDNtM47E55bPP1v