### PR TITLE
feat(finder): instant results, late harvest, and a real top-picks curation

### DIFF
--- a/internal/handlers/finder.go
+++ b/internal/handlers/finder.go
@@ -23,8 +23,10 @@ type FinderHandler struct {
 }
 
 // FindRecipes handles POST /v1/recipes/find. It runs the bounded finder
-// trajectory and streams each step (searching → found → filtering → shortlist →
-// warming → refine_ready → done, or a terminal empty/error) as an SSE event.
+// trajectory and streams each step (searching → found → results → filtering →
+// shortlist → digging/expanded → picks → warming → refine_ready → done, or a
+// terminal empty/error) as an SSE event. `results` (instant pre-rank paint)
+// and `picks` (final curation) are additive — older clients ignore them.
 func (h *FinderHandler) FindRecipes(c *gin.Context) {
 	user, err := util.GetUserFromContext(c)
 	if err != nil {

--- a/internal/models/search_cache.go
+++ b/internal/models/search_cache.go
@@ -30,6 +30,20 @@ type SearchResultItem struct {
 	Rating      float64 `json:"rating"`
 	ImageURL    string  `json:"image_url"`
 	Description string  `json:"description"`
+	// Finder-session extras (additive; absent for plain cached searches): the
+	// agent's one-line rationale, per-member dietary safety and — for recipes
+	// mined out of a roundup — the collection title they came from.
+	Reason string             `json:"reason,omitempty"`
+	Safety []ResultSafetyItem `json:"safety,omitempty"`
+	Via    string             `json:"via,omitempty"`
+}
+
+// ResultSafetyItem mirrors the finder's per-member safety badge for JSONB
+// storage (models must not import the ai package).
+type ResultSafetyItem struct {
+	MemberName string `json:"member_name"`
+	Status     string `json:"status"`
+	Note       string `json:"note,omitempty"`
 }
 
 // SearchResultList is a slice of SearchResultItem for JSONB storage.

--- a/internal/models/telemetry.go
+++ b/internal/models/telemetry.go
@@ -45,11 +45,20 @@ type FinderRun struct {
 	Terminal  string `gorm:"size:16;index" json:"terminal"`
 	ErrorText string `gorm:"type:text" json:"error_text,omitempty"`
 
-	// Step latencies.
-	SearchMS int64 `json:"search_ms"`
-	RankMS   int64 `json:"rank_ms"`
-	DigMS    int64 `json:"dig_ms"`
-	TotalMS  int64 `json:"total_ms"`
+	// Picks step: the final curation pass across direct + mined recipes.
+	// PickRankOK=false means the picks ranking call failed and the picks
+	// degraded to pre-pick order (only possible when something was mined).
+	PicksTotal int  `json:"picks_total"`
+	PickRankOK bool `json:"pick_rank_ok"`
+
+	// Step latencies. FirstResultsMS is time-to-first-paint: how long until the
+	// instant (pre-rank) results event was emitted.
+	SearchMS       int64 `json:"search_ms"`
+	FirstResultsMS int64 `json:"first_results_ms"`
+	RankMS         int64 `json:"rank_ms"`
+	DigMS          int64 `json:"dig_ms"`
+	PicksMS        int64 `json:"picks_ms"`
+	TotalMS        int64 `json:"total_ms"`
 }
 
 // ExtractionEvent records one terminal recipe-extraction attempt — success or

--- a/internal/service/recipe_finder.go
+++ b/internal/service/recipe_finder.go
@@ -58,6 +58,11 @@ const (
 	FinderEventSearching FinderEventType = "searching"
 	// FinderEventFound reports how many real candidates search returned.
 	FinderEventFound FinderEventType = "found"
+	// FinderEventResults carries the instant, pre-rank candidate set (obvious
+	// collections withheld) so the client can paint tappable results
+	// immediately, before any model call. Additive: older clients ignore it and
+	// keep revealing at shortlist/done.
+	FinderEventResults FinderEventType = "results"
 	// FinderEventFiltering signals the single ranking/filtering model call.
 	FinderEventFiltering FinderEventType = "filtering"
 	// FinderEventShortlist carries the ranked real results with rationales+safety.
@@ -67,6 +72,10 @@ const (
 	FinderEventDigging FinderEventType = "digging"
 	// FinderEventExpanded carries the individual recipes dug out of a collection.
 	FinderEventExpanded FinderEventType = "expanded"
+	// FinderEventPicks carries the agent's FINAL curated top picks: direct
+	// picks and mined recipes re-ranked together, each with a fresh rationale.
+	// Additive: older clients ignore it. First-page runs only.
+	FinderEventPicks FinderEventType = "picks"
 	// FinderEventWarming lists the top URLs being proactively cache-warmed.
 	FinderEventWarming FinderEventType = "warming"
 	// FinderEventRefineReady offers tap-to-refine chips + broaden suggestions.
@@ -86,6 +95,9 @@ type FinderResultItem struct {
 	Result ai.SearchResult   `json:"result"`
 	Reason string            `json:"reason,omitempty"`
 	Safety []ai.MemberSafety `json:"safety,omitempty"`
+	// Via is the collection/roundup title this recipe was mined out of
+	// (provenance for the "found inside ..." chip); empty for direct picks.
+	Via string `json:"via,omitempty"`
 }
 
 // FinderEvent is a single event streamed to the client during a find. Only the
@@ -233,7 +245,23 @@ func (s *RecipeFinderService) FindRecipes(ctx context.Context, user *models.User
 		return
 	}
 
-	// 4. The one and only model call: expand + rank + rationale + safety.
+	// 3.5. Instant results: paint the real candidates NOW, before any model
+	// call, withholding only obvious collections (canonical-cache fact or
+	// near-certain URL/title pattern). A pattern false positive is benign —
+	// the recipe reappears in the ranked shortlist moments later.
+	instant := make([]FinderResultItem, 0, len(results))
+	for _, r := range results {
+		if s.isLikelyCollection(r) {
+			continue
+		}
+		instant = append(instant, FinderResultItem{Result: r})
+	}
+	if !s.emit(ctx, events, FinderEvent{Type: FinderEventResults, Items: instant, HasMore: searchRes.HasMore}) {
+		return
+	}
+	run.FirstResultsMS = time.Since(runStart).Milliseconds()
+
+	// 4. The first model call: expand + rank + rationale + safety.
 	if !s.emit(ctx, events, FinderEvent{Type: FinderEventFiltering}) {
 		return
 	}
@@ -288,8 +316,17 @@ func (s *RecipeFinderService) FindRecipes(ctx context.Context, user *models.User
 	if room > finderDigMaxCards {
 		room = finderDigMaxCards
 	}
+	seen := seenResultKeys(shown)
 	digStart := time.Now()
-	folded, dug := s.digCollections(ctx, events, results, rank, room, &shortlistEmitted, searchRes.HasMore, seenResultKeys(shown))
+	folded, dug, dugEntries := s.digCollections(ctx, events, results, rank, room, &shortlistEmitted, searchRes.HasMore, seen)
+
+	// 6.6. Late harvest: cards keep extracting in the background after their
+	// collection's dig window closes — sweep the dug collections once more (at
+	// zero added wait, except a single grace window when nothing folded at all)
+	// so a card that finished at second 6 still makes this run.
+	room -= len(folded)
+	late := s.lateHarvest(ctx, events, dugEntries, seen, room, len(folded), &shortlistEmitted, searchRes.HasMore)
+	folded = append(folded, late...)
 	run.DigMS = time.Since(digStart).Milliseconds()
 	run.CollectionsDug = dug
 	run.CardsMined = len(folded)
@@ -303,9 +340,35 @@ func (s *RecipeFinderService) FindRecipes(ctx context.Context, user *models.User
 		return
 	}
 
-	// 8. Proactively warm the top curated picks (best-effort) so a later tap is
-	// an instant cache hit. Mined recipes are already cached by extraction.
-	if warmURLs := topURLs(shown, finderWarmTopN); len(warmURLs) > 0 {
+	// 7.5. Final curation: re-rank direct picks + mined recipes TOGETHER into
+	// the agent's top picks, each with a fresh rationale (mined recipes get a
+	// real "why", not just provenance). First-page runs only — load-more pages
+	// are browsing material, not a new curation.
+	var picks []FinderResultItem
+	if offset == 0 {
+		picksStart := time.Now()
+		var pickErr string
+		picks, pickErr = s.buildPicks(ctx, user, req, dietSummary, shown, folded)
+		run.PicksMS = time.Since(picksStart).Milliseconds()
+		run.PickRankOK = pickErr == ""
+		run.PicksTotal = len(picks)
+		if len(picks) > 0 {
+			if !s.emit(ctx, events, FinderEvent{Type: FinderEventPicks, Items: picks}) {
+				return
+			}
+		}
+	} else {
+		run.PickRankOK = true
+	}
+
+	// 8. Proactively warm the top picks (best-effort) so a later tap is an
+	// instant cache hit. Mined recipes are already cached by extraction; the
+	// warm service skips already-cached URLs cheaply.
+	warmPool := picks
+	if len(warmPool) == 0 {
+		warmPool = shown
+	}
+	if warmURLs := topURLs(warmPool, finderWarmTopN); len(warmURLs) > 0 {
 		if s.Warm != nil {
 			s.Warm.WarmURLs(warmURLs)
 		}
@@ -326,7 +389,17 @@ func (s *RecipeFinderService) FindRecipes(ctx context.Context, user *models.User
 	assembled := make([]FinderResultItem, 0, len(shown)+len(folded))
 	assembled = append(assembled, shown...)
 	assembled = append(assembled, folded...)
-	s.autoSaveSession(user, req, query, len(results), len(folded), assembled)
+	s.autoSaveSession(user, req, query, len(results), len(folded), len(picks), assembled)
+}
+
+// isLikelyCollection reports whether a candidate is an obvious collection page
+// — a canonical-cache fact (IsMultiPage) or a near-certain URL/title pattern —
+// cheap enough to run before the instant results emit.
+func (s *RecipeFinderService) isLikelyCollection(r ai.SearchResult) bool {
+	if looksLikeCollectionPage(r.URL, r.Title) {
+		return true
+	}
+	return s.Warm != nil && s.Warm.IsKnownMulti(r.URL)
 }
 
 // emit sends one event, returning false if the context is cancelled (e.g. the
@@ -376,9 +449,9 @@ func countExpandFlags(rank *ai.FinderRankResult) int {
 // was shown (shortlistEmitted false), the first mined batch seeds the shortlist
 // instead so build-89 gets a proper base list. Returns every folded recipe plus
 // how many collections were actually dug (for run telemetry).
-func (s *RecipeFinderService) digCollections(ctx context.Context, events chan<- FinderEvent, results []ai.SearchResult, rank *ai.FinderRankResult, room int, shortlistEmitted *bool, hasMore bool, seen map[string]bool) ([]FinderResultItem, int) {
+func (s *RecipeFinderService) digCollections(ctx context.Context, events chan<- FinderEvent, results []ai.SearchResult, rank *ai.FinderRankResult, room int, shortlistEmitted *bool, hasMore bool, seen map[string]bool) ([]FinderResultItem, int, []dugCollection) {
 	if s.MultiResolver == nil || rank == nil || room <= 0 {
-		return nil, 0
+		return nil, 0, nil
 	}
 	if seen == nil {
 		seen = make(map[string]bool)
@@ -404,7 +477,7 @@ func (s *RecipeFinderService) digCollections(ctx context.Context, events chan<- 
 		collections = append(collections, collection{url: u, title: results[r.Index].Title, prio: r.ExpandPriority})
 	}
 	if len(collections) == 0 {
-		return nil, 0
+		return nil, 0, nil
 	}
 	sort.SliceStable(collections, func(i, j int) bool { return collections[i].prio > collections[j].prio })
 	if len(collections) > finderDigK {
@@ -412,13 +485,14 @@ func (s *RecipeFinderService) digCollections(ctx context.Context, events chan<- 
 	}
 
 	var folded []FinderResultItem
+	var entries []dugCollection
 	dug := 0
 	for _, c := range collections {
 		if room <= 0 {
 			break
 		}
 		if !s.emit(ctx, events, FinderEvent{Type: FinderEventDigging, CollectionTitle: c.title}) {
-			return folded, dug
+			return folded, dug, entries
 		}
 		dug++
 
@@ -431,58 +505,112 @@ func (s *RecipeFinderService) digCollections(ctx context.Context, events chan<- 
 		if entry == nil {
 			continue
 		}
+		entries = append(entries, dugCollection{entry: entry, title: c.title})
 
-		var batch []FinderResultItem
-		for _, card := range s.waitForCollection(ctx, entry) {
-			if len(batch) >= room {
-				break
-			}
-			// Only fold recipes that finished extracting and have a cache key —
-			// the folded URL must be an instant cache hit on tap.
-			if card.ExtractionStatus != "done" {
-				continue
-			}
-			cached := strings.TrimSpace(card.CachedURL)
-			if cached == "" {
-				continue
-			}
-			// The same recipe often appears in several roundups (and sometimes as
-			// a direct pick too) — fold each distinct recipe once.
-			if !markResultSeen(seen, cached, card.Title) {
-				continue
-			}
-			batch = append(batch, FinderResultItem{
-				Result: ai.SearchResult{
-					Title:       card.Title,
-					URL:         cached,
-					Source:      hostOf(cached),
-					ImageURL:    card.ImageURL,
-					Description: card.Description,
-				},
-				Reason: fmt.Sprintf("from '%s'", c.title),
-			})
-		}
+		batch := foldDoneCards(s.waitForCollection(ctx, entry), seen, room, c.title)
 		if len(batch) == 0 {
 			continue
 		}
 		folded = append(folded, batch...)
 		room -= len(batch)
-
-		// Seed the shortlist from the first mined batch when there were no direct
-		// picks (search was all collections); otherwise append via expanded. Both
-		// carry only individual recipes — never a collection card.
-		var ev FinderEvent
-		if *shortlistEmitted {
-			ev = FinderEvent{Type: FinderEventExpanded, Items: batch, CollectionTitle: c.title}
-		} else {
-			ev = FinderEvent{Type: FinderEventShortlist, Items: batch, HasMore: hasMore}
-			*shortlistEmitted = true
-		}
-		if !s.emit(ctx, events, ev) {
-			return folded, dug
+		if !s.emitFoldBatch(ctx, events, batch, c.title, shortlistEmitted, hasMore) {
+			return folded, dug, entries
 		}
 	}
-	return folded, dug
+	return folded, dug, entries
+}
+
+// dugCollection pairs a resolving multi-recipe entry with the collection title
+// it was dug from, so the late harvest can attribute its cards.
+type dugCollection struct {
+	entry *MultiRecipeEntry
+	title string
+}
+
+// foldDoneCards maps a collection's DONE cards (with a cache key, not yet seen)
+// into result items, up to room. The folded URL must be an instant cache hit on
+// tap; the same recipe folded from two roundups (or already a direct pick) is
+// kept once.
+func foldDoneCards(cards []MultiRecipeCard, seen map[string]bool, room int, collectionTitle string) []FinderResultItem {
+	var batch []FinderResultItem
+	for _, card := range cards {
+		if len(batch) >= room {
+			break
+		}
+		if card.ExtractionStatus != "done" {
+			continue
+		}
+		cached := strings.TrimSpace(card.CachedURL)
+		if cached == "" {
+			continue
+		}
+		if !markResultSeen(seen, cached, card.Title) {
+			continue
+		}
+		batch = append(batch, FinderResultItem{
+			Result: ai.SearchResult{
+				Title:       card.Title,
+				URL:         cached,
+				Source:      hostOf(cached),
+				ImageURL:    card.ImageURL,
+				Description: card.Description,
+			},
+			Reason: fmt.Sprintf("from '%s'", collectionTitle),
+			Via:    collectionTitle,
+		})
+	}
+	return batch
+}
+
+// emitFoldBatch appends mined recipes via expanded, or seeds the shortlist with
+// the first mined batch when there were no direct picks (search was all
+// collections). Both carry only individual recipes — never a collection card.
+func (s *RecipeFinderService) emitFoldBatch(ctx context.Context, events chan<- FinderEvent, batch []FinderResultItem, collectionTitle string, shortlistEmitted *bool, hasMore bool) bool {
+	var ev FinderEvent
+	if *shortlistEmitted {
+		ev = FinderEvent{Type: FinderEventExpanded, Items: batch, CollectionTitle: collectionTitle}
+	} else {
+		ev = FinderEvent{Type: FinderEventShortlist, Items: batch, HasMore: hasMore}
+		*shortlistEmitted = true
+	}
+	return s.emit(ctx, events, ev)
+}
+
+// lateHarvest sweeps the already-dug collections one final time before the
+// picks stage: cards keep extracting in the background after their collection's
+// dig window closes, so a card that finished while later collections were being
+// dug still makes this run — at zero added wait. The one exception: when
+// digging folded NOTHING (foldedSoFar == 0), it waits a single extra grace
+// window on the first still-extracting collection rather than ending the run
+// empty-handed.
+func (s *RecipeFinderService) lateHarvest(ctx context.Context, events chan<- FinderEvent, entries []dugCollection, seen map[string]bool, room, foldedSoFar int, shortlistEmitted *bool, hasMore bool) []FinderResultItem {
+	if len(entries) == 0 || room <= 0 {
+		return nil
+	}
+	grace := foldedSoFar == 0
+	var folded []FinderResultItem
+	for _, de := range entries {
+		if room <= 0 {
+			break
+		}
+		cards := de.entry.GetCards()
+		if grace {
+			if status := de.entry.GetStatus(); status != "resolved" && status != "failed" {
+				cards = s.waitForCollection(ctx, de.entry)
+				grace = false
+			}
+		}
+		batch := foldDoneCards(cards, seen, room, de.title)
+		if len(batch) == 0 {
+			continue
+		}
+		folded = append(folded, batch...)
+		room -= len(batch)
+		if !s.emitFoldBatch(ctx, events, batch, de.title, shortlistEmitted, hasMore) {
+			return folded
+		}
+	}
+	return folded
 }
 
 // waitForCollection polls a resolving collection until it is terminal (resolved
@@ -509,21 +637,31 @@ func (s *RecipeFinderService) waitForCollection(ctx context.Context, entry *Mult
 // ungated and best-effort: only first-page runs with at least one result are
 // saved, on a context detached from the request (so a client disconnect after
 // "done" doesn't cancel the write), and any error is logged, never surfaced.
-func (s *RecipeFinderService) autoSaveSession(user *models.User, req FinderRequest, query string, foundCount, foldedCount int, assembled []FinderResultItem) {
+func (s *RecipeFinderService) autoSaveSession(user *models.User, req FinderRequest, query string, foundCount, foldedCount, picksCount int, assembled []FinderResultItem) {
 	if s.Sessions == nil || user == nil || req.Offset != 0 || len(assembled) == 0 {
 		return
 	}
 
 	results := make(models.SearchResultList, 0, len(assembled))
 	for _, it := range assembled {
-		results = append(results, models.SearchResultItem{
+		item := models.SearchResultItem{
 			Title:       it.Result.Title,
 			URL:         it.Result.URL,
 			Source:      it.Result.Source,
 			Rating:      it.Result.Rating,
 			ImageURL:    it.Result.ImageURL,
 			Description: it.Result.Description,
-		})
+			Reason:      it.Reason,
+			Via:         it.Via,
+		}
+		for _, sf := range it.Safety {
+			item.Safety = append(item.Safety, models.ResultSafetyItem{
+				MemberName: sf.MemberName,
+				Status:     sf.Status,
+				Note:       sf.Note,
+			})
+		}
+		results = append(results, item)
 	}
 
 	narration := models.StringList{
@@ -532,6 +670,9 @@ func (s *RecipeFinderService) autoSaveSession(user *models.User, req FinderReque
 	}
 	if foldedCount > 0 {
 		narration = append(narration, fmt.Sprintf("Dug %d more from collections", foldedCount))
+	}
+	if picksCount > 0 {
+		narration = append(narration, fmt.Sprintf("Curated %d top picks", picksCount))
 	}
 	narration = append(narration, fmt.Sprintf("Shortlisted %d", len(assembled)))
 
@@ -613,6 +754,18 @@ func (s *RecipeFinderService) rankCandidates(ctx context.Context, user *models.U
 		}
 	}
 
+	res, err := s.RankProvider.ExpandAndRankRecipes(ctx, s.buildRankRequest(user, req, dietSummary, candidates))
+	if err != nil {
+		logger.Get().Warn("recipe finder ranking failed; showing unranked real results", zap.Error(err))
+		return fallbackRanking(len(results)), truncateErr(err)
+	}
+	return res, ""
+}
+
+// buildRankRequest assembles the model-facing ranking request from the
+// server-side steering context plus the given candidates. Shared by the
+// initial ranking and the final picks curation.
+func (s *RecipeFinderService) buildRankRequest(user *models.User, req FinderRequest, dietSummary string, candidates []ai.FinderCandidate) ai.FinderRankRequest {
 	rankReq := ai.FinderRankRequest{
 		Facets:      facetsSummary(req),
 		FreeText:    strings.TrimSpace(req.FreeText),
@@ -624,13 +777,73 @@ func (s *RecipeFinderService) rankCandidates(ctx context.Context, user *models.U
 		rankReq.CookingContext = user.Personalization.CookingContextPrompt()
 		rankReq.Requirements = user.Personalization.Requirements
 	}
+	return rankReq
+}
 
-	res, err := s.RankProvider.ExpandAndRankRecipes(ctx, rankReq)
-	if err != nil {
-		logger.Get().Warn("recipe finder ranking failed; showing unranked real results", zap.Error(err))
-		return fallbackRanking(len(results)), truncateErr(err)
+// buildPicks curates the agent's FINAL top picks across the direct picks and
+// everything mined from collections. When recipes were mined it spends one more
+// cheap ranking call so mined recipes get a real rationale and the two sets are
+// genuinely ordered together; when nothing was mined the direct picks are
+// already ranked and reasoned, so they pass through unchanged (no model call).
+// The second return is the picks-rank failure text ("" when it succeeded or
+// was skipped) — on failure the picks degrade to pre-pick order.
+func (s *RecipeFinderService) buildPicks(ctx context.Context, user *models.User, req FinderRequest, dietSummary string, direct, mined []FinderResultItem) ([]FinderResultItem, string) {
+	pool := make([]FinderResultItem, 0, len(direct)+len(mined))
+	pool = append(pool, direct...)
+	pool = append(pool, mined...)
+	if len(pool) == 0 {
+		return nil, ""
 	}
-	return res, ""
+	if len(pool) > finderCuratedCap {
+		pool = pool[:finderCuratedCap]
+	}
+	if len(mined) == 0 {
+		return pool, ""
+	}
+
+	candidates := make([]ai.FinderCandidate, len(pool))
+	for i, it := range pool {
+		candidates[i] = ai.FinderCandidate{
+			Index:       i,
+			Title:       it.Result.Title,
+			URL:         it.Result.URL,
+			Source:      it.Result.Source,
+			Description: it.Result.Description,
+		}
+	}
+
+	res, err := s.RankProvider.ExpandAndRankRecipes(ctx, s.buildRankRequest(user, req, dietSummary, candidates))
+	if err != nil {
+		logger.Get().Warn("recipe finder picks ranking failed; keeping pre-pick order", zap.Error(err))
+		return pool, truncateErr(err)
+	}
+
+	picks := make([]FinderResultItem, 0, len(pool))
+	used := make(map[int]bool, len(res.Ranked))
+	for _, r := range res.Ranked {
+		if r.Index < 0 || r.Index >= len(pool) || used[r.Index] {
+			continue
+		}
+		used[r.Index] = true
+		// Every pool item is an individual recipe (collections were excluded
+		// before digging), so a spurious expand flag must not hide one.
+		if hasAvoid(r.Safety) {
+			continue
+		}
+		item := pool[r.Index]
+		if reason := strings.TrimSpace(r.Reason); reason != "" {
+			item.Reason = reason
+		}
+		if len(r.Safety) > 0 {
+			item.Safety = r.Safety
+		}
+		picks = append(picks, item)
+	}
+	if len(picks) == 0 {
+		// The model dropped everything — curation must never erase real picks.
+		return pool, ""
+	}
+	return picks, ""
 }
 
 // applyKnownCollections force-flags ranked candidates whose URL the canonical

--- a/internal/service/recipe_finder_digging_test.go
+++ b/internal/service/recipe_finder_digging_test.go
@@ -488,7 +488,7 @@ func TestFindRecipes_DedupsMinedAcrossCollectionsAndDirect(t *testing.T) {
 			doneCard("Skillet Lasagna", "https://example.com/recipe/skillet-lasagna"),
 		),
 		collB.URL: resolvedEntry(collB.URL,
-			doneCard("Ground Beef Gyros", "https://example.com/recipe/ground-beef-gyros"), // dup by URL
+			doneCard("Ground Beef Gyros", "https://example.com/recipe/ground-beef-gyros"),  // dup by URL
 			doneCard("Skillet  Lasagna", "https://example.com/recipe/skillet-lasagna-two"), // dup by normalized title
 			doneCard("Chicken Tikka Masala", "https://example.com/recipe/chicken-tikka-masala"),
 		),
@@ -542,5 +542,285 @@ func TestLooksLikeCollectionPage(t *testing.T) {
 		if got := looksLikeCollectionPage(c.url, c.title); got != c.want {
 			t.Errorf("looksLikeCollectionPage(%q, %q) = %v, want %v", c.url, c.title, got, c.want)
 		}
+	}
+}
+
+// TestFindRecipes_InstantResultsWithholdLikelyCollections: the pre-rank
+// `results` event paints immediately but never paints an obvious roundup.
+func TestFindRecipes_InstantResultsWithholdLikelyCollections(t *testing.T) {
+	results := []ai.SearchResult{
+		{Title: "Sheet Pan Chicken Fajitas", URL: "https://example.com/recipe/sheet-pan-chicken-fajitas", Source: "example.com", Description: "Quick fajitas."},
+		{Title: "40 Easy Weeknight Dinner Recipes", URL: "https://example.com/40-easy-weeknight-dinners", Source: "example.com", Description: "Roundup."},
+		{Title: "One-Pot Chicken and Rice", URL: "https://example.com/recipe/one-pot-chicken-rice", Source: "example.com", Description: "Classic."},
+	}
+	searchProvider := &testutil.MockSearchProvider{
+		SearchRecipesFunc: func(ctx context.Context, query string, count, offset int) ([]ai.SearchResult, error) {
+			return results, nil
+		},
+	}
+	ranker := rankAllFlagging(results, map[int]int{1: 5})
+
+	svc := newFinderService(searchProvider, ranker, &testutil.MockFamilyRepo{})
+	events := runFinder(svc, testutil.TestUser(), FinderRequest{Facets: FinderFacets{Protein: "chicken"}})
+
+	instant, ok := firstEventOfType(events, FinderEventResults)
+	if !ok {
+		t.Fatalf("no results event (%v)", eventTypes(events))
+	}
+	if len(instant.Items) != 2 {
+		t.Fatalf("instant results has %d items, want 2 (roundup withheld)", len(instant.Items))
+	}
+	for _, it := range instant.Items {
+		if it.Result.URL == results[1].URL {
+			t.Errorf("obvious roundup %q painted in instant results", it.Result.URL)
+		}
+	}
+	// The results event precedes the model call (filtering).
+	ri, fi := indexOfType(events, FinderEventResults), indexOfType(events, FinderEventFiltering)
+	if !(ri >= 0 && fi >= 0 && ri < fi) {
+		t.Errorf("results (%d) must precede filtering (%d): %v", ri, fi, eventTypes(events))
+	}
+}
+
+// TestFindRecipes_PicksCurateAcrossDirectAndMined: after digging, one more
+// cheap ranking call orders direct + mined TOGETHER; mined picks get a real
+// model rationale (provenance kept in via) and warming targets the picks.
+func TestFindRecipes_PicksCurateAcrossDirectAndMined(t *testing.T) {
+	direct := ai.SearchResult{Title: "Sheet Pan Chicken Fajitas", URL: "https://example.com/recipe/sheet-pan-chicken-fajitas", Source: "example.com", Description: "Quick fajitas."}
+	coll := ai.SearchResult{Title: "Best Weeknight Dinners", URL: "https://example.com/roundup-weeknight", Source: "example.com", Description: "Roundup."}
+	results := []ai.SearchResult{direct, coll}
+	minedURL := "https://example.com/recipe/ground-beef-gyros"
+
+	searchProvider := &testutil.MockSearchProvider{
+		SearchRecipesFunc: func(ctx context.Context, query string, count, offset int) ([]ai.SearchResult, error) {
+			return results, nil
+		},
+	}
+	rankCalls := 0
+	ranker := &testutil.MockTextProvider{
+		ExpandAndRankRecipesFunc: func(ctx context.Context, req ai.FinderRankRequest) (*ai.FinderRankResult, error) {
+			rankCalls++
+			if rankCalls == 1 {
+				return &ai.FinderRankResult{Ranked: []ai.FinderRanking{
+					{Index: 0, Reason: "Solid fajitas."},
+					{Index: 1, Expand: true, ExpandPriority: 5},
+				}}, nil
+			}
+			// Picks call: pool = [direct, mined]; put the mined recipe first
+			// with a fresh rationale.
+			if len(req.Candidates) != 2 {
+				t.Errorf("picks call got %d candidates, want 2", len(req.Candidates))
+			}
+			return &ai.FinderRankResult{Ranked: []ai.FinderRanking{
+				{Index: 1, Reason: "Weeknight hero: 20 minutes, one skillet."},
+				{Index: 0, Reason: "Fajitas fit the brief."},
+			}}, nil
+		},
+	}
+	fake := &fakeMultiResolver{entries: map[string]*MultiRecipeEntry{
+		coll.URL: resolvedEntry(coll.URL, doneCard("Ground Beef Gyros", minedURL)),
+	}}
+
+	svc := newFinderService(searchProvider, ranker, &testutil.MockFamilyRepo{})
+	svc.MultiResolver = fake
+
+	events := runFinder(svc, testutil.TestUser(), FinderRequest{Facets: FinderFacets{Occasion: "weeknight"}})
+
+	if rankCalls != 2 {
+		t.Fatalf("rank calls = %d, want 2 (initial + picks)", rankCalls)
+	}
+	picks, ok := firstEventOfType(events, FinderEventPicks)
+	if !ok {
+		t.Fatalf("no picks event (%v)", eventTypes(events))
+	}
+	if len(picks.Items) != 2 {
+		t.Fatalf("picks has %d items, want 2", len(picks.Items))
+	}
+	top := picks.Items[0]
+	if top.Result.URL != minedURL {
+		t.Errorf("picks[0] = %q, want the mined recipe ranked first", top.Result.URL)
+	}
+	if top.Reason != "Weeknight hero: 20 minutes, one skillet." {
+		t.Errorf("picks[0] reason = %q, want the fresh model rationale", top.Reason)
+	}
+	if top.Via != coll.Title {
+		t.Errorf("picks[0] via = %q, want provenance %q kept", top.Via, coll.Title)
+	}
+	// Warming targets the picks order (mined recipe first).
+	warming, _ := firstEventOfType(events, FinderEventWarming)
+	if len(warming.URLs) == 0 || warming.URLs[0] != minedURL {
+		t.Errorf("warming URLs = %v, want picks-first (%q)", warming.URLs, minedURL)
+	}
+	// The picks event lands after digging/expanded and before warming.
+	pi, ei, wi := indexOfType(events, FinderEventPicks), indexOfType(events, FinderEventExpanded), indexOfType(events, FinderEventWarming)
+	if !(ei < pi && pi < wi) {
+		t.Errorf("event order wrong: expanded=%d picks=%d warming=%d (%v)", ei, pi, wi, eventTypes(events))
+	}
+}
+
+// TestFindRecipes_PicksFallbackOnPickRankFailure: a failed picks call degrades
+// to pre-pick order (direct then mined, provenance reasons intact) — curation
+// can improve the result, never erase it.
+func TestFindRecipes_PicksFallbackOnPickRankFailure(t *testing.T) {
+	direct := ai.SearchResult{Title: "Sheet Pan Chicken Fajitas", URL: "https://example.com/recipe/sheet-pan-chicken-fajitas", Source: "example.com", Description: "Quick fajitas."}
+	coll := ai.SearchResult{Title: "Best Weeknight Dinners", URL: "https://example.com/roundup-weeknight", Source: "example.com", Description: "Roundup."}
+	results := []ai.SearchResult{direct, coll}
+
+	searchProvider := &testutil.MockSearchProvider{
+		SearchRecipesFunc: func(ctx context.Context, query string, count, offset int) ([]ai.SearchResult, error) {
+			return results, nil
+		},
+	}
+	rankCalls := 0
+	ranker := &testutil.MockTextProvider{
+		ExpandAndRankRecipesFunc: func(ctx context.Context, req ai.FinderRankRequest) (*ai.FinderRankResult, error) {
+			rankCalls++
+			if rankCalls == 1 {
+				return &ai.FinderRankResult{Ranked: []ai.FinderRanking{
+					{Index: 0, Reason: "Solid fajitas."},
+					{Index: 1, Expand: true, ExpandPriority: 5},
+				}}, nil
+			}
+			return nil, fmt.Errorf("picks model exploded")
+		},
+	}
+	fake := &fakeMultiResolver{entries: map[string]*MultiRecipeEntry{
+		coll.URL: resolvedEntry(coll.URL, doneCard("Ground Beef Gyros", "https://example.com/recipe/ground-beef-gyros")),
+	}}
+
+	svc := newFinderService(searchProvider, ranker, &testutil.MockFamilyRepo{})
+	svc.MultiResolver = fake
+
+	events := runFinder(svc, testutil.TestUser(), FinderRequest{Facets: FinderFacets{Occasion: "weeknight"}})
+
+	picks, ok := firstEventOfType(events, FinderEventPicks)
+	if !ok {
+		t.Fatalf("no picks event after picks-rank failure (%v)", eventTypes(events))
+	}
+	if len(picks.Items) != 2 {
+		t.Fatalf("picks has %d items, want 2 (pre-pick order fallback)", len(picks.Items))
+	}
+	if picks.Items[0].Result.URL != direct.URL {
+		t.Errorf("picks[0] = %q, want direct pick first on fallback", picks.Items[0].Result.URL)
+	}
+	if picks.Items[1].Reason == "" || picks.Items[1].Via != coll.Title {
+		t.Errorf("mined fallback pick lost provenance: reason=%q via=%q", picks.Items[1].Reason, picks.Items[1].Via)
+	}
+	// done still terminates the run.
+	if indexOfType(events, FinderEventDone) < 0 {
+		t.Errorf("run did not finish after picks fallback (%v)", eventTypes(events))
+	}
+}
+
+// TestFindRecipes_NoPicksOnPagedRuns: load-more pages are browsing material —
+// no picks event, no second model call.
+func TestFindRecipes_NoPicksOnPagedRuns(t *testing.T) {
+	results := digSearchResults(3)
+	searchProvider := &testutil.MockSearchProvider{
+		SearchRecipesFunc: func(ctx context.Context, query string, count, offset int) ([]ai.SearchResult, error) {
+			return results, nil
+		},
+	}
+	rankCalls := 0
+	ranker := &testutil.MockTextProvider{
+		ExpandAndRankRecipesFunc: func(ctx context.Context, req ai.FinderRankRequest) (*ai.FinderRankResult, error) {
+			rankCalls++
+			ranked := make([]ai.FinderRanking, len(req.Candidates))
+			for i := range req.Candidates {
+				ranked[i] = ai.FinderRanking{Index: i, Reason: "fits"}
+			}
+			return &ai.FinderRankResult{Ranked: ranked}, nil
+		},
+	}
+
+	svc := newFinderService(searchProvider, ranker, &testutil.MockFamilyRepo{})
+	events := runFinder(svc, testutil.TestUser(), FinderRequest{Facets: FinderFacets{Protein: "chicken"}, Offset: 10})
+
+	if n := countEventsOfType(events, FinderEventPicks); n != 0 {
+		t.Errorf("paged run emitted %d picks events, want 0", n)
+	}
+	if rankCalls != 1 {
+		t.Errorf("paged run made %d rank calls, want 1", rankCalls)
+	}
+	// Instant results still paint on paged runs.
+	if countEventsOfType(events, FinderEventResults) != 1 {
+		t.Errorf("paged run missing instant results event (%v)", eventTypes(events))
+	}
+}
+
+// TestFindRecipes_LateHarvestNoDoubleFold: digging and the late-harvest sweep
+// both read the same entries; every foldable card must be folded exactly once.
+// (The slow-card recovery itself is exercised directly in
+// TestLateHarvest_FoldsCardsMissedByDigging.)
+func TestFindRecipes_LateHarvestNoDoubleFold(t *testing.T) {
+	coll := ai.SearchResult{Title: "Best Weeknight Dinners", URL: "https://example.com/roundup-weeknight", Source: "example.com", Description: "Roundup."}
+	results := []ai.SearchResult{coll}
+	searchProvider := &testutil.MockSearchProvider{
+		SearchRecipesFunc: func(ctx context.Context, query string, count, offset int) ([]ai.SearchResult, error) {
+			return results, nil
+		},
+	}
+	ranker := rankAllFlagging(results, map[int]int{0: 5})
+	fake := &fakeMultiResolver{entries: map[string]*MultiRecipeEntry{
+		coll.URL: resolvedEntry(coll.URL,
+			doneCard("Ground Beef Gyros", "https://example.com/recipe/ground-beef-gyros"),
+			doneCard("Skillet Lasagna", "https://example.com/recipe/skillet-lasagna"),
+		),
+	}}
+
+	svc := newFinderService(searchProvider, ranker, &testutil.MockFamilyRepo{})
+	svc.MultiResolver = fake
+
+	events := runFinder(svc, testutil.TestUser(), FinderRequest{Facets: FinderFacets{Occasion: "weeknight"}})
+
+	shown := shownItems(events)
+	counts := map[string]int{}
+	for _, it := range shown {
+		counts[it.Result.URL]++
+	}
+	for u, n := range counts {
+		if n > 1 {
+			t.Errorf("recipe %q folded %d times across dig + late harvest, want 1", u, n)
+		}
+	}
+	if len(shown) != 2 {
+		t.Errorf("shown %d items, want 2", len(shown))
+	}
+}
+
+// TestLateHarvest_FoldsCardsMissedByDigging exercises the sweep directly: a
+// card that was NOT folded during the dig window (its key is absent from seen)
+// is folded by the sweep, deduped against what digging already took, and
+// emitted as expanded with its collection's provenance.
+func TestLateHarvest_FoldsCardsMissedByDigging(t *testing.T) {
+	svc := newFinderService(&testutil.MockSearchProvider{}, &testutil.MockTextProvider{}, &testutil.MockFamilyRepo{})
+
+	entry := resolvedEntry("https://example.com/roundup-weeknight",
+		doneCard("Ground Beef Gyros", "https://example.com/recipe/ground-beef-gyros"), // folded during digging
+		doneCard("Skillet Lasagna", "https://example.com/recipe/skillet-lasagna"),     // finished late
+		MultiRecipeCard{Title: "Still Extracting", ExtractionStatus: "extracting"},    // never folds
+	)
+	seen := map[string]bool{}
+	markResultSeen(seen, "https://example.com/recipe/ground-beef-gyros", "Ground Beef Gyros")
+
+	events := make(chan FinderEvent, 8)
+	shortlistEmitted := true
+	folded := svc.lateHarvest(context.Background(), events,
+		[]dugCollection{{entry: entry, title: "Best Weeknight Dinners"}},
+		seen, 4, 1, &shortlistEmitted, false)
+	close(events)
+
+	if len(folded) != 1 || folded[0].Result.URL != "https://example.com/recipe/skillet-lasagna" {
+		t.Fatalf("late harvest folded %+v, want exactly the late lasagna card", folded)
+	}
+	if folded[0].Via != "Best Weeknight Dinners" {
+		t.Errorf("late-folded via = %q, want the collection title", folded[0].Via)
+	}
+	var got []FinderEvent
+	for ev := range events {
+		got = append(got, ev)
+	}
+	if len(got) != 1 || got[0].Type != FinderEventExpanded || len(got[0].Items) != 1 {
+		t.Errorf("late harvest emitted %v, want one expanded event with one item", eventTypes(got))
 	}
 }

--- a/internal/service/recipe_finder_test.go
+++ b/internal/service/recipe_finder_test.go
@@ -119,11 +119,34 @@ func TestFindRecipes_HappyPath(t *testing.T) {
 		FreeText: "weeknight",
 	})
 
-	// Full happy-path event order.
+	// Full happy-path event order: instant results paint before the model call,
+	// final picks after curation.
 	if got := eventTypes(events); !sameTypes(got,
-		FinderEventSearching, FinderEventFound, FinderEventFiltering,
-		FinderEventShortlist, FinderEventWarming, FinderEventRefineReady, FinderEventDone) {
+		FinderEventSearching, FinderEventFound, FinderEventResults, FinderEventFiltering,
+		FinderEventShortlist, FinderEventPicks, FinderEventWarming, FinderEventRefineReady, FinderEventDone) {
 		t.Fatalf("unexpected event order: %v", got)
+	}
+
+	// The instant results event carries every candidate (none look like
+	// collections here), tappable before any model call, with no reasons yet.
+	instant, _ := firstEventOfType(events, FinderEventResults)
+	if len(instant.Items) != len(candidates) {
+		t.Fatalf("instant results has %d items, want %d", len(instant.Items), len(candidates))
+	}
+	for i, it := range instant.Items {
+		if it.Reason != "" {
+			t.Errorf("instant item %d has a reason %q before ranking", i, it.Reason)
+		}
+	}
+
+	// With nothing mined, picks pass the ranked shortlist through (no second
+	// model call) — same order, reasons intact.
+	picks, _ := firstEventOfType(events, FinderEventPicks)
+	if len(picks.Items) != 3 {
+		t.Fatalf("picks has %d items, want 3", len(picks.Items))
+	}
+	if picks.Items[0].Result.Title != candidates[0].Title || picks.Items[0].Reason == "" {
+		t.Errorf("picks[0] = %q (reason %q), want ranked top pick with reason", picks.Items[0].Result.Title, picks.Items[0].Reason)
 	}
 
 	// searching carries the deterministically-composed query.
@@ -232,8 +255,8 @@ func TestFindRecipes_DropsAllergenAvoid(t *testing.T) {
 
 	// Same overall trajectory (a shortlist still forms from the survivors).
 	if got := eventTypes(events); !sameTypes(got,
-		FinderEventSearching, FinderEventFound, FinderEventFiltering,
-		FinderEventShortlist, FinderEventWarming, FinderEventRefineReady, FinderEventDone) {
+		FinderEventSearching, FinderEventFound, FinderEventResults, FinderEventFiltering,
+		FinderEventShortlist, FinderEventPicks, FinderEventWarming, FinderEventRefineReady, FinderEventDone) {
 		t.Fatalf("unexpected event order: %v", got)
 	}
 


### PR DESCRIPTION
## Why

Part 2 of the agent-mode overhaul. Today the agent paints **nothing** until search + rank + digging all finish — 38s on a roundup-heavy query, for 4 results — and its "top picks" are whatever cards survived the 4s dig windows, in arrival order, with a fixed `from 'X'` string instead of a rationale.

## What

**Instant paint** — new additive SSE event `results` right after search (before any model call): the real candidates, minus obvious collections (canonical-cache `IsMultiPage` or near-certain URL/title pattern). A pattern false positive reappears in the ranked shortlist moments later. Time-to-first-paint drops from ~6–38s to ~2s.

**Late harvest** — cards keep extracting in the background after their collection's dig window closes; a final sweep right before the picks stage folds them in at zero added wait (plus a single grace window when digging folded nothing).

**Real top picks** — new additive SSE event `picks`: direct picks + mined recipes re-ranked **together** by one more cheap light-tier call. Mined recipes get a real model rationale + safety; provenance is kept in the new `via` field ("found inside 'Best 50 Dinners'"). No extra call when nothing was mined; skipped on paged runs; failure degrades to pre-pick order — curation can never erase results.

**Supporting changes** — warming targets the picks; finder sessions store `reason`/`safety`/`via` per result (history keeps the agent's value-add); additive `finder_runs` telemetry: `first_results_ms`, `picks_total`, `pick_rank_ok`, `picks_ms`.

## Compatibility

SSE contract is additive: build-90 clients ignore `results`/`picks` (verified: the app's event switch has no default case) and keep exactly today's behavior. Dashboard reads are `hasColumn`-guarded; new columns are additive.

## Verification

- Full offline suite green (new tests: instant-results withholding, picks curation across direct+mined, picks fallback, no-picks-on-paged-runs, late-harvest dedup + direct sweep test).
- **Live regression bar passed**: `TestExpandAndRankRecipes_Live` + `_ProdShapedStress` against real Gemini 2.5 Flash.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01My8N5v3zDNtM47E55bPP1v