### PR TITLE
fix(ai): schema-constrained JSON for all forced structured calls on the OpenAI-compat path

### DIFF
--- a/internal/ai/openai_maintier.go
+++ b/internal/ai/openai_maintier.go
@@ -170,30 +170,10 @@ func (p *OpenAICompatProvider) GenerateRecipe(ctx context.Context, req RecipeReq
 			return nil, fmt.Errorf("render user prompt: %w", err)
 		}
 
-		summaryDesc := p.prompts.Recipe.Summarize.Recipe
-
-		chatReq := openai.ChatCompletionRequest{
-			Model:     p.model,
-			MaxTokens: 4096,
-			Messages: []openai.ChatCompletionMessage{
-				{Role: openai.ChatMessageRoleSystem, Content: combineSystemPrompt(p.prompts.Recipe.Generate.SystemPrefix, sysSuffix)},
-				{Role: openai.ChatMessageRoleUser, Content: userPrompt},
-			},
-			Tools: []openai.Tool{{
-				Type: openai.ToolTypeFunction,
-				Function: &openai.FunctionDefinition{
-					Name:        "create_recipe",
-					Description: "Create a structured recipe definition with all required fields.",
-					Parameters:  schemaObject(recipeProperties(summaryDesc)),
-				},
-			}},
-			ToolChoice: openai.ToolChoice{
-				Type:     openai.ToolTypeFunction,
-				Function: openai.ToolFunction{Name: "create_recipe"},
-			},
-		}
-
-		return p.completeRecipe(ctx, chatReq)
+		return p.completeRecipe(ctx, p.prompts.Recipe.Summarize.Recipe, []openai.ChatCompletionMessage{
+			{Role: openai.ChatMessageRoleSystem, Content: combineSystemPrompt(p.prompts.Recipe.Generate.SystemPrefix, sysSuffix)},
+			{Role: openai.ChatMessageRoleUser, Content: userPrompt},
+		})
 	})
 }
 
@@ -217,8 +197,6 @@ func (p *OpenAICompatProvider) RegenerateRecipe(ctx context.Context, req Regener
 			return nil, fmt.Errorf("render system prompt: %w", err)
 		}
 
-		summaryDesc := p.prompts.Recipe.Summarize.Changes
-
 		userPrompt, err := config.RenderPrompt(p.prompts.Recipe.Regenerate.User, map[string]interface{}{
 			"Prompt": req.UserPrompt,
 		})
@@ -233,25 +211,7 @@ func (p *OpenAICompatProvider) RegenerateRecipe(ctx context.Context, req Regener
 		messages = append(messages, messagesToOpenAIParams(req.ExistingHistory)...)
 		messages = append(messages, openai.ChatCompletionMessage{Role: openai.ChatMessageRoleUser, Content: userPrompt})
 
-		chatReq := openai.ChatCompletionRequest{
-			Model:     p.model,
-			MaxTokens: 4096,
-			Messages:  messages,
-			Tools: []openai.Tool{{
-				Type: openai.ToolTypeFunction,
-				Function: &openai.FunctionDefinition{
-					Name:        "create_recipe",
-					Description: "Create a structured recipe definition with all required fields.",
-					Parameters:  schemaObject(recipeProperties(summaryDesc)),
-				},
-			}},
-			ToolChoice: openai.ToolChoice{
-				Type:     openai.ToolTypeFunction,
-				Function: openai.ToolFunction{Name: "create_recipe"},
-			},
-		}
-
-		return p.completeRecipe(ctx, chatReq)
+		return p.completeRecipe(ctx, p.prompts.Recipe.Summarize.Changes, messages)
 	})
 }
 
@@ -275,8 +235,6 @@ func (p *OpenAICompatProvider) ForkRecipe(ctx context.Context, req ForkRequest) 
 			return nil, fmt.Errorf("render system prompt: %w", err)
 		}
 
-		summaryDesc := p.prompts.Recipe.Summarize.Recipe
-
 		userPrompt, err := config.RenderPrompt(p.prompts.Recipe.Fork.User, map[string]interface{}{
 			"Prompt": req.UserPrompt,
 		})
@@ -290,44 +248,23 @@ func (p *OpenAICompatProvider) ForkRecipe(ctx context.Context, req ForkRequest) 
 		messages = append(messages, messagesToOpenAIParams(req.ExistingHistory)...)
 		messages = append(messages, openai.ChatCompletionMessage{Role: openai.ChatMessageRoleUser, Content: userPrompt})
 
-		chatReq := openai.ChatCompletionRequest{
-			Model:     p.model,
-			MaxTokens: 4096,
-			Messages:  messages,
-			Tools: []openai.Tool{{
-				Type: openai.ToolTypeFunction,
-				Function: &openai.FunctionDefinition{
-					Name:        "create_recipe",
-					Description: "Create a structured recipe definition with all required fields.",
-					Parameters:  schemaObject(recipeProperties(summaryDesc)),
-				},
-			}},
-			ToolChoice: openai.ToolChoice{
-				Type:     openai.ToolTypeFunction,
-				Function: openai.ToolFunction{Name: "create_recipe"},
-			},
-		}
-
-		return p.completeRecipe(ctx, chatReq)
+		return p.completeRecipe(ctx, p.prompts.Recipe.Summarize.Recipe, messages)
 	})
 }
 
-// completeRecipe issues a forced create_recipe chat completion and parses,
-// validates and stamps the resulting recipe. Shared by GenerateRecipe,
-// RegenerateRecipe and ForkRecipe (their only difference is prompt/history).
-func (p *OpenAICompatProvider) completeRecipe(ctx context.Context, chatReq openai.ChatCompletionRequest) (*RecipeResult, error) {
-	resp, err := p.createChatCompletion(ctx, chatReq)
-	if err != nil {
-		return nil, err
-	}
-
-	args, err := firstToolCallArguments(resp, "create_recipe")
+// completeRecipe issues a schema-constrained create_recipe completion and
+// parses, validates and stamps the resulting recipe. Shared by GenerateRecipe,
+// RegenerateRecipe, ForkRecipe and ExtractRecipeFromText (their only difference
+// is prompt/history). MaxTokens is generous because Gemini 2.5 models spend
+// completion budget on internal thinking before the recipe JSON.
+func (p *OpenAICompatProvider) completeRecipe(ctx context.Context, summaryDesc string, messages []openai.ChatCompletionMessage) (*RecipeResult, error) {
+	content, err := p.structuredCompletion(ctx, "create_recipe", schemaObject(recipeProperties(summaryDesc)), 8192, messages)
 	if err != nil {
 		return nil, err
 	}
 
 	var tr recipeToolResult
-	if err := json.Unmarshal([]byte(args), &tr); err != nil {
+	if err := json.Unmarshal([]byte(content), &tr); err != nil {
 		return nil, NewAIError(FailureContentParse, fmt.Errorf("failed to unmarshal recipe: %w", err), "failed to parse recipe tool result")
 	}
 
@@ -364,39 +301,16 @@ func (p *OpenAICompatProvider) AnalyzeAllergens(ctx context.Context, req Allerge
 			return nil, fmt.Errorf("render user prompt: %w", err)
 		}
 
-		chatReq := openai.ChatCompletionRequest{
-			Model:     p.model,
-			MaxTokens: 4096,
-			Messages: []openai.ChatCompletionMessage{
-				{Role: openai.ChatMessageRoleSystem, Content: sysPrompt},
-				{Role: openai.ChatMessageRoleUser, Content: userPrompt},
-			},
-			Tools: []openai.Tool{{
-				Type: openai.ToolTypeFunction,
-				Function: &openai.FunctionDefinition{
-					Name:        "analyze_allergens",
-					Description: "Analyze ingredients for allergen risks and return structured results.",
-					Parameters:  schemaObject(allergenProperties()),
-				},
-			}},
-			ToolChoice: openai.ToolChoice{
-				Type:     openai.ToolTypeFunction,
-				Function: openai.ToolFunction{Name: "analyze_allergens"},
-			},
-		}
-
-		resp, err := p.createChatCompletion(ctx, chatReq)
-		if err != nil {
-			return nil, err
-		}
-
-		args, err := firstToolCallArguments(resp, "analyze_allergens")
+		content, err := p.structuredCompletion(ctx, "analyze_allergens", schemaObject(allergenProperties()), 4096, []openai.ChatCompletionMessage{
+			{Role: openai.ChatMessageRoleSystem, Content: sysPrompt},
+			{Role: openai.ChatMessageRoleUser, Content: userPrompt},
+		})
 		if err != nil {
 			return nil, err
 		}
 
 		var tr allergenToolResult
-		if err := json.Unmarshal([]byte(args), &tr); err != nil {
+		if err := json.Unmarshal([]byte(content), &tr); err != nil {
 			return nil, NewAIError(FailureContentParse, fmt.Errorf("failed to unmarshal allergen analysis: %w", err), "failed to parse allergen tool result")
 		}
 		return toolResultToAllergenResult(&tr), nil
@@ -420,39 +334,16 @@ func (p *OpenAICompatProvider) ClassifyVoiceIntent(ctx context.Context, transcri
 			return nil, fmt.Errorf("render system prompt: %w", err)
 		}
 
-		chatReq := openai.ChatCompletionRequest{
-			Model:     p.model,
-			MaxTokens: 256,
-			Messages: []openai.ChatCompletionMessage{
-				{Role: openai.ChatMessageRoleSystem, Content: sysPrompt},
-				{Role: openai.ChatMessageRoleUser, Content: transcript},
-			},
-			Tools: []openai.Tool{{
-				Type: openai.ToolTypeFunction,
-				Function: &openai.FunctionDefinition{
-					Name:        "classify_voice_intent",
-					Description: "Classify a voice transcript into an app intent.",
-					Parameters:  schemaObject(voiceIntentProperties()),
-				},
-			}},
-			ToolChoice: openai.ToolChoice{
-				Type:     openai.ToolTypeFunction,
-				Function: openai.ToolFunction{Name: "classify_voice_intent"},
-			},
-		}
-
-		resp, err := p.createChatCompletion(ctx, chatReq)
-		if err != nil {
-			return nil, err
-		}
-
-		args, err := firstToolCallArguments(resp, "classify_voice_intent")
+		content, err := p.structuredCompletion(ctx, "classify_voice_intent", schemaObject(voiceIntentProperties()), 1024, []openai.ChatCompletionMessage{
+			{Role: openai.ChatMessageRoleSystem, Content: sysPrompt},
+			{Role: openai.ChatMessageRoleUser, Content: transcript},
+		})
 		if err != nil {
 			return nil, err
 		}
 
 		var tr voiceIntentToolResult
-		if err := json.Unmarshal([]byte(args), &tr); err != nil {
+		if err := json.Unmarshal([]byte(content), &tr); err != nil {
 			return nil, NewAIError(FailureContentParse, fmt.Errorf("failed to unmarshal voice intent: %w", err), "failed to parse voice intent tool result")
 		}
 		return toolResultToVoiceIntent(&tr), nil

--- a/internal/ai/openai_maintier_test.go
+++ b/internal/ai/openai_maintier_test.go
@@ -9,8 +9,8 @@ import (
 )
 
 // toolCallResponse builds a canned chat-completion response carrying a single
-// forced tool call (fnName + JSON args). Mirrors the shape the real providers
-// return so the offline tests exercise the same parse path.
+// forced tool call (fnName + JSON args). Still used by the DietaryInterview
+// tests — that flow keeps real tool calling (tool choice "auto").
 func toolCallResponse(fnName, args string) openai.ChatCompletionResponse {
 	return openai.ChatCompletionResponse{
 		Choices: []openai.ChatCompletionChoice{{
@@ -24,6 +24,24 @@ func toolCallResponse(fnName, args string) openai.ChatCompletionResponse {
 				}},
 			},
 			FinishReason: openai.FinishReasonToolCalls,
+		}},
+		Usage: openai.Usage{PromptTokens: 100, CompletionTokens: 60},
+	}
+}
+
+// structuredJSONResponse builds a canned chat-completion response whose content
+// is a schema-constrained JSON body — the shape the provider's
+// response_format=json_schema calls (create_recipe, analyze_allergens, ...)
+// return since the Gemini function-call parser workaround.
+func structuredJSONResponse(content string) openai.ChatCompletionResponse {
+	return openai.ChatCompletionResponse{
+		Choices: []openai.ChatCompletionChoice{{
+			Index: 0,
+			Message: openai.ChatCompletionMessage{
+				Role:    openai.ChatMessageRoleAssistant,
+				Content: content,
+			},
+			FinishReason: openai.FinishReasonStop,
 		}},
 		Usage: openai.Usage{PromptTokens: 100, CompletionTokens: 60},
 	}
@@ -45,7 +63,7 @@ func TestOpenAICompatProvider_GenerateRecipe(t *testing.T) {
 		"unit_system": "us_customary"
 	}`
 
-	srv := newMockOpenAIServer(t, toolCallResponse("create_recipe", recipeArgs))
+	srv := newMockOpenAIServer(t, structuredJSONResponse(recipeArgs))
 	defer srv.Close()
 
 	p := NewOpenAICompatProvider("test-key", srv.URL, "gemini-2.5-pro", "gemini", testPrompts())
@@ -78,7 +96,7 @@ func TestOpenAICompatProvider_GenerateRecipe_MissingTitleIsError(t *testing.T) {
 		"ingredients": [{"name": "flour", "unit": "cup", "amount": 1}],
 		"instructions": ["Mix."]
 	}`
-	srv := newMockOpenAIServer(t, toolCallResponse("create_recipe", badArgs))
+	srv := newMockOpenAIServer(t, structuredJSONResponse(badArgs))
 	defer srv.Close()
 
 	p := NewOpenAICompatProvider("test-key", srv.URL, "gemini-2.5-pro", "gemini", testPrompts())
@@ -105,7 +123,7 @@ func TestOpenAICompatProvider_AnalyzeAllergens(t *testing.T) {
 		"requires_review": false
 	}`
 
-	srv := newMockOpenAIServer(t, toolCallResponse("analyze_allergens", allergenArgs))
+	srv := newMockOpenAIServer(t, structuredJSONResponse(allergenArgs))
 	defer srv.Close()
 
 	p := NewOpenAICompatProvider("test-key", srv.URL, "gemini-2.5-pro", "gemini", testPrompts())
@@ -139,7 +157,7 @@ func TestOpenAICompatProvider_ClassifyVoiceIntent(t *testing.T) {
 	// Field names match voiceIntentToolResult json tags.
 	voiceArgs := `{"type": "scroll_down", "amount": "large", "target": "", "text": ""}`
 
-	srv := newMockOpenAIServer(t, toolCallResponse("classify_voice_intent", voiceArgs))
+	srv := newMockOpenAIServer(t, structuredJSONResponse(voiceArgs))
 	defer srv.Close()
 
 	p := NewOpenAICompatProvider("test-key", srv.URL, "gemini-2.5-pro", "gemini", testPrompts())

--- a/internal/ai/openai_text.go
+++ b/internal/ai/openai_text.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"strings"
 	"time"
 
 	openai "github.com/sashabaranov/go-openai"
@@ -117,27 +118,6 @@ func (p *OpenAICompatProvider) createChatCompletion(ctx context.Context, req ope
 	return nil, fmt.Errorf("%s chat completion: exhausted %d retries: %w", p.providerName, maxRetries, lastErr)
 }
 
-// firstToolCallArguments returns the JSON argument string of the first tool
-// call in the response, guarding against zero choices / zero tool calls. fnName
-// is used only for diagnostics; tool choice is forced so the first call is the
-// requested function. The empty-tool-call error carries finish_reason + token
-// usage: Gemini 2.5 models spend completion budget on thinking, so
-// finish_reason=length with a large completion count means the budget was
-// consumed before the tool call was emitted (raise MaxTokens).
-func firstToolCallArguments(resp *openai.ChatCompletionResponse, fnName string) (string, error) {
-	if resp == nil || len(resp.Choices) == 0 {
-		return "", NewAIError(FailureContentEmpty, errors.New("no choices in chat completion response"), "no choices in response")
-	}
-	calls := resp.Choices[0].Message.ToolCalls
-	if len(calls) == 0 {
-		return "", NewAIError(FailureContentEmpty,
-			fmt.Errorf("no %s tool call in chat completion response (finish_reason=%s, completion_tokens=%d)",
-				fnName, resp.Choices[0].FinishReason, resp.Usage.CompletionTokens),
-			"no tool call in response")
-	}
-	return calls[0].Function.Arguments, nil
-}
-
 // schemaObject wraps a property set into a JSON-schema object so the reused
 // *Properties helpers can serve as an OpenAI function's Parameters.
 func schemaObject(properties map[string]interface{}) map[string]interface{} {
@@ -147,8 +127,90 @@ func schemaObject(properties map[string]interface{}) map[string]interface{} {
 	}
 }
 
+// structuredCompletion issues a chat completion constrained to the given JSON
+// schema (response_format json_schema) and returns the raw JSON content.
+// Forced FUNCTION calls are avoided deliberately on this provider: Gemini's
+// OpenAI-compat function-call parser intermittently rejects large calls
+// wholesale (finish_reason=MALFORMED_FUNCTION_CALL / "no tool call", zero
+// output) — the exact failure #112 fixed for the finder's ranking, later seen
+// in prod against create_recipe extraction too. Schema-constrained JSON
+// sidesteps that parser; one resample covers residual empty responses.
+//
+// The schema-following instruction is appended to the first system message so
+// callers keep prompts that were written for the tool-call era.
+func (p *OpenAICompatProvider) structuredCompletion(ctx context.Context, name string, schema map[string]interface{}, maxTokens int, messages []openai.ChatCompletionMessage) (string, error) {
+	msgs := make([]openai.ChatCompletionMessage, len(messages))
+	copy(msgs, messages)
+	for i := range msgs {
+		if msgs[i].Role == openai.ChatMessageRoleSystem {
+			msgs[i].Content += fmt.Sprintf("\n\nRespond with ONLY a JSON object matching the %s schema.", name)
+			break
+		}
+	}
+
+	chatReq := openai.ChatCompletionRequest{
+		Model: p.model,
+		// Generous budgets everywhere: Gemini 2.5 models spend completion
+		// budget on internal thinking BEFORE the answer; billing is by actual
+		// tokens, so headroom is free.
+		MaxTokens: maxTokens,
+		Messages:  msgs,
+		ResponseFormat: &openai.ChatCompletionResponseFormat{
+			Type: openai.ChatCompletionResponseFormatTypeJSONSchema,
+			JSONSchema: &openai.ChatCompletionResponseFormatJSONSchema{
+				Name:   name,
+				Schema: jsonSchemaMap(schema),
+			},
+		},
+	}
+
+	var lastErr error
+	for attempt := 0; attempt < 2; attempt++ {
+		resp, err := p.createChatCompletion(ctx, chatReq)
+		if err != nil {
+			return "", err // transport errors already retried downstream
+		}
+		content := ""
+		finishReason := ""
+		if len(resp.Choices) > 0 {
+			content = stripCodeFences(resp.Choices[0].Message.Content)
+			finishReason = string(resp.Choices[0].FinishReason)
+		}
+		if content != "" {
+			return content, nil
+		}
+		lastErr = NewAIError(FailureContentEmpty,
+			fmt.Errorf("empty %s JSON response (finish_reason=%s, completion_tokens=%d)",
+				name, finishReason, resp.Usage.CompletionTokens),
+			"empty response")
+		logger.Get().Warn("structured completion empty, resampling",
+			zap.String("provider", p.providerName),
+			zap.String("schema", name),
+			zap.Int("attempt", attempt+1),
+		)
+	}
+	return "", lastErr
+}
+
+// stripCodeFences unwraps a ```json ... ``` fenced block some models emit
+// around structured output; plain content passes through untouched.
+func stripCodeFences(s string) string {
+	s = strings.TrimSpace(s)
+	if !strings.HasPrefix(s, "```") {
+		return s
+	}
+	s = strings.TrimPrefix(s, "```json")
+	s = strings.TrimPrefix(s, "```")
+	if i := strings.LastIndex(s, "```"); i >= 0 {
+		s = s[:i]
+	}
+	return strings.TrimSpace(s)
+}
+
 // ExtractRecipeFromText extracts a structured recipe from free-form text via a
-// forced create_recipe function call. Mirrors AnthropicProvider.ExtractRecipeFromText.
+// schema-constrained create_recipe completion. Mirrors
+// AnthropicProvider.ExtractRecipeFromText (which keeps the tool path — the
+// function-call rejection is specific to OpenAI-compat Gemini).
 func (p *OpenAICompatProvider) ExtractRecipeFromText(ctx context.Context, text string, unitSystem string) (*RecipeResult, error) {
 	op := AIOperation{
 		Name:      "ExtractRecipeFromText",
@@ -181,50 +243,10 @@ func (p *OpenAICompatProvider) ExtractRecipeFromText(ctx context.Context, text s
 			return nil, fmt.Errorf("render system prompt: %w", err)
 		}
 
-		summaryDesc := p.prompts.Recipe.Summarize.Recipe
-
-		req := openai.ChatCompletionRequest{
-			Model:     p.model,
-			MaxTokens: 4096,
-			Messages: []openai.ChatCompletionMessage{
-				{Role: openai.ChatMessageRoleSystem, Content: combineSystemPrompt(sysPrefix, sysSuffix)},
-				{Role: openai.ChatMessageRoleUser, Content: text},
-			},
-			Tools: []openai.Tool{{
-				Type: openai.ToolTypeFunction,
-				Function: &openai.FunctionDefinition{
-					Name:        "create_recipe",
-					Description: "Create a structured recipe definition with all required fields.",
-					Parameters:  schemaObject(recipeProperties(summaryDesc)),
-				},
-			}},
-			ToolChoice: openai.ToolChoice{
-				Type:     openai.ToolTypeFunction,
-				Function: openai.ToolFunction{Name: "create_recipe"},
-			},
-		}
-
-		resp, err := p.createChatCompletion(ctx, req)
-		if err != nil {
-			return nil, err
-		}
-
-		args, err := firstToolCallArguments(resp, "create_recipe")
-		if err != nil {
-			return nil, err
-		}
-
-		var tr recipeToolResult
-		if err := json.Unmarshal([]byte(args), &tr); err != nil {
-			return nil, NewAIError(FailureContentParse, fmt.Errorf("failed to unmarshal recipe: %w", err), "failed to parse recipe tool result")
-		}
-
-		result := toolResultToRecipeResult(&tr)
-		if err := validateRecipeResult(result); err != nil {
-			return nil, err
-		}
-		result.PromptVersion = config.PromptVersion(p.prompts)
-		return result, nil
+		return p.completeRecipe(ctx, p.prompts.Recipe.Summarize.Recipe, []openai.ChatCompletionMessage{
+			{Role: openai.ChatMessageRoleSystem, Content: combineSystemPrompt(sysPrefix, sysSuffix)},
+			{Role: openai.ChatMessageRoleUser, Content: text},
+		})
 	})
 }
 
@@ -244,39 +266,16 @@ func (p *OpenAICompatProvider) EstimatePortions(ctx context.Context, recipeDef i
 			return nil, fmt.Errorf("failed to marshal recipe: %w", err)
 		}
 
-		req := openai.ChatCompletionRequest{
-			Model:     p.model,
-			MaxTokens: 256,
-			Messages: []openai.ChatCompletionMessage{
-				{Role: openai.ChatMessageRoleSystem, Content: "You are a culinary expert. Estimate the number of portions and portion size for the given recipe."},
-				{Role: openai.ChatMessageRoleUser, Content: string(recipeJSON)},
-			},
-			Tools: []openai.Tool{{
-				Type: openai.ToolTypeFunction,
-				Function: &openai.FunctionDefinition{
-					Name:        "estimate_portions",
-					Description: "Estimate the number of portions and portion size for a recipe.",
-					Parameters:  schemaObject(portionProperties()),
-				},
-			}},
-			ToolChoice: openai.ToolChoice{
-				Type:     openai.ToolTypeFunction,
-				Function: openai.ToolFunction{Name: "estimate_portions"},
-			},
-		}
-
-		resp, err := p.createChatCompletion(ctx, req)
-		if err != nil {
-			return nil, err
-		}
-
-		args, err := firstToolCallArguments(resp, "estimate_portions")
+		content, err := p.structuredCompletion(ctx, "estimate_portions", schemaObject(portionProperties()), 2048, []openai.ChatCompletionMessage{
+			{Role: openai.ChatMessageRoleSystem, Content: "You are a culinary expert. Estimate the number of portions and portion size for the given recipe."},
+			{Role: openai.ChatMessageRoleUser, Content: string(recipeJSON)},
+		})
 		if err != nil {
 			return nil, err
 		}
 
 		var tr portionToolResult
-		if err := json.Unmarshal([]byte(args), &tr); err != nil {
+		if err := json.Unmarshal([]byte(content), &tr); err != nil {
 			return nil, NewAIError(FailureContentParse, fmt.Errorf("failed to unmarshal portion estimate: %w", err), "failed to parse portion tool result")
 		}
 		return toolResultToPortionEstimate(&tr), nil

--- a/internal/ai/openai_text_test.go
+++ b/internal/ai/openai_text_test.go
@@ -55,26 +55,7 @@ func TestOpenAICompatProvider_ExtractRecipeFromText(t *testing.T) {
 		"unit_system": "us_customary"
 	}`
 
-	canned := openai.ChatCompletionResponse{
-		Choices: []openai.ChatCompletionChoice{{
-			Index: 0,
-			Message: openai.ChatCompletionMessage{
-				Role: openai.ChatMessageRoleAssistant,
-				ToolCalls: []openai.ToolCall{{
-					ID:   "call_1",
-					Type: openai.ToolTypeFunction,
-					Function: openai.FunctionCall{
-						Name:      "create_recipe",
-						Arguments: recipeArgs,
-					},
-				}},
-			},
-			FinishReason: openai.FinishReasonToolCalls,
-		}},
-		Usage: openai.Usage{PromptTokens: 120, CompletionTokens: 80},
-	}
-
-	srv := newMockOpenAIServer(t, canned)
+	srv := newMockOpenAIServer(t, structuredJSONResponse(recipeArgs))
 	defer srv.Close()
 
 	p := NewOpenAICompatProvider("test-key", srv.URL, "gpt-4o-mini", "openai", testPrompts())
@@ -136,26 +117,7 @@ func TestOpenAICompatProvider_CookingQA(t *testing.T) {
 }
 
 func TestOpenAICompatProvider_EstimatePortions(t *testing.T) {
-	canned := openai.ChatCompletionResponse{
-		Choices: []openai.ChatCompletionChoice{{
-			Index: 0,
-			Message: openai.ChatCompletionMessage{
-				Role: openai.ChatMessageRoleAssistant,
-				ToolCalls: []openai.ToolCall{{
-					ID:   "call_1",
-					Type: openai.ToolTypeFunction,
-					Function: openai.FunctionCall{
-						Name:      "estimate_portions",
-						Arguments: `{"portions": 6, "portion_size": "1 bowl", "confidence": 0.9}`,
-					},
-				}},
-			},
-			FinishReason: openai.FinishReasonToolCalls,
-		}},
-		Usage: openai.Usage{PromptTokens: 40, CompletionTokens: 12},
-	}
-
-	srv := newMockOpenAIServer(t, canned)
+	srv := newMockOpenAIServer(t, structuredJSONResponse(`{"portions": 6, "portion_size": "1 bowl", "confidence": 0.9}`))
 	defer srv.Close()
 
 	p := NewOpenAICompatProvider("test-key", srv.URL, "gpt-4o-mini", "openai", testPrompts())
@@ -175,40 +137,66 @@ func TestOpenAICompatProvider_EstimatePortions(t *testing.T) {
 	}
 }
 
-func TestOpenAICompatProvider_NoToolCallIsError(t *testing.T) {
-	// A response with no tool call must surface a clear error rather than panic.
-	canned := openai.ChatCompletionResponse{
-		Choices: []openai.ChatCompletionChoice{{
-			Index:        0,
-			Message:      openai.ChatCompletionMessage{Role: openai.ChatMessageRoleAssistant, Content: "I cannot help."},
-			FinishReason: openai.FinishReasonStop,
-		}},
-		Usage: openai.Usage{PromptTokens: 10, CompletionTokens: 4},
-	}
-
-	srv := newMockOpenAIServer(t, canned)
+func TestOpenAICompatProvider_NonJSONContentIsError(t *testing.T) {
+	// A refusal / non-JSON body must surface a clear parse error, not a panic
+	// or a silent zero-value recipe.
+	srv := newMockOpenAIServer(t, structuredJSONResponse("I cannot help."))
 	defer srv.Close()
 
 	p := NewOpenAICompatProvider("test-key", srv.URL, "gpt-4o-mini", "openai", testPrompts())
 
 	if _, err := p.ExtractRecipeFromText(context.Background(), "text", "metric"); err == nil {
-		t.Error("expected error when response has no tool call, got nil")
+		t.Error("expected error for non-JSON structured response, got nil")
 	}
 }
 
-// TestOpenAICompatProvider_ExtractRecipeFromText_Live hits the real OpenAI API.
-// Gated behind OPENAI_LIVE_TEST (plus a real OPENAI_API_KEY) so it never runs in
-// CI / the offline suite.
+func TestOpenAICompatProvider_EmptyContentIsError(t *testing.T) {
+	// An empty body (e.g. the thinking budget consumed everything) must error
+	// after the resample, not succeed silently.
+	srv := newMockOpenAIServer(t, structuredJSONResponse(""))
+	defer srv.Close()
+
+	p := NewOpenAICompatProvider("test-key", srv.URL, "gpt-4o-mini", "openai", testPrompts())
+
+	if _, err := p.ExtractRecipeFromText(context.Background(), "text", "metric"); err == nil {
+		t.Error("expected error for empty structured response, got nil")
+	}
+}
+
+func TestStripCodeFences(t *testing.T) {
+	cases := []struct{ in, want string }{
+		{`{"a":1}`, `{"a":1}`},
+		{"```json\n{\"a\":1}\n```", `{"a":1}`},
+		{"```\n{\"a\":1}\n```", `{"a":1}`},
+		{"  {\"a\":1}  ", `{"a":1}`},
+	}
+	for _, c := range cases {
+		if got := stripCodeFences(c.in); got != c.want {
+			t.Errorf("stripCodeFences(%q) = %q, want %q", c.in, got, c.want)
+		}
+	}
+}
+
+// TestOpenAICompatProvider_ExtractRecipeFromText_Live hits a real
+// OpenAI-compatible endpoint. Gated behind OPENAI_LIVE_TEST so it never runs
+// in CI / the offline suite. Defaults to OpenAI gpt-4o-mini; set
+// LIGHT_API_KEY/LIGHT_BASE_URL/LIGHT_MODEL to run it against the prod light
+// tier (Gemini) — the config whose function-call parser motivated the
+// json_schema output path this test now covers.
 func TestOpenAICompatProvider_ExtractRecipeFromText_Live(t *testing.T) {
 	if os.Getenv("OPENAI_LIVE_TEST") == "" {
-		t.Skip("set OPENAI_LIVE_TEST=1 (and OPENAI_API_KEY) to run the live OpenAI extraction test")
+		t.Skip("set OPENAI_LIVE_TEST=1 (and an API key) to run the live extraction test")
 	}
-	apiKey := os.Getenv("OPENAI_API_KEY")
+	apiKey := firstNonEmptyEnv("LIGHT_API_KEY", "GEMINI_API_KEY", "OPENAI_API_KEY")
 	if apiKey == "" {
-		t.Skip("OPENAI_API_KEY not set; skipping live test")
+		t.Skip("no API key (LIGHT_API_KEY / GEMINI_API_KEY / OPENAI_API_KEY) set; skipping live test")
+	}
+	model := os.Getenv("LIGHT_MODEL")
+	if model == "" {
+		model = "gpt-4o-mini"
 	}
 
-	p := NewOpenAICompatProvider(apiKey, "", "gpt-4o-mini", "openai", testPrompts())
+	p := NewOpenAICompatProvider(apiKey, os.Getenv("LIGHT_BASE_URL"), model, "gemini", testPrompts())
 
 	const text = `Classic Guacamole
 


### PR DESCRIPTION
## Why

Part 3 of the agent-mode overhaul. PR #112 moved the finder's `rank_recipes` call off function calling because Gemini's OpenAI-compat function-call parser rejects large calls wholesale (`MALFORMED_FUNCTION_CALL` / "no tool call", zero output). The same disease was still hitting **every other forced tool call** on this provider: prod `ExtractRecipeFromText` (create_recipe) failed **18/24 calls over 3 days**, poisoning warm-path extraction and (until #119) collection digging.

## What

- Shared `structuredCompletion` helper: `response_format: json_schema` + schema-following instruction appended to the system message + one resample on empty bodies + code-fence stripping.
- Converted: `ExtractRecipeFromText`, `EstimatePortions`, `GenerateRecipe`/`RegenerateRecipe`/`ForkRecipe` (via `completeRecipe`), `AnalyzeAllergens`, `ClassifyVoiceIntent`.
- MaxTokens raised where Gemini 2.5 thinking shares the completion budget (create_recipe 4096→8192, portions 256→2048, voice 256→1024). Billed by actual tokens — headroom is free.
- `DietaryInterview` deliberately keeps real tool calling (tool choice `auto` is semantic: text turn = next question, tool call = save profile).
- Dead `firstToolCallArguments` removed.

Note: DeepSeek (a registry option for the light tier) supports `json_object` but not `json_schema` — that limitation already existed for the rank call since #112; the registry's validation probe fails closed on switch.

## Verification

- Full offline suite green (fixtures moved to content-mode responses; new empty-body, non-JSON-body, and fence-stripping tests).
- **Live**: `ExtractRecipeFromText_Live` passes against the prod light tier (Gemini 2.5 Flash, OpenAI-compat endpoint) — the exact config failing 75% in prod. The live test now honors `LIGHT_API_KEY`/`LIGHT_BASE_URL`/`LIGHT_MODEL`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01My8N5v3zDNtM47E55bPP1v