### PR TITLE
fix(finder): backfill mined-card images from the recipe page

### DIFF
--- a/internal/service/finder_extraction_fix_test.go
+++ b/internal/service/finder_extraction_fix_test.go
@@ -35,7 +35,7 @@ func TestExtractJSONLDRecipeByTitle_MatchesByTitle(t *testing.T) {
 		`<script type="application/ld+json">` + fullJSONLDRecipe("Black Bean Tacos", "1 can black beans", "6 tortillas") + `</script>` +
 		`</head><body></body></html>`
 
-	def, _, ok := extractJSONLDRecipeByTitle(html, "Black Bean Tacos")
+	def, _, _, ok := extractJSONLDRecipeByTitle(html, "Black Bean Tacos")
 	if !ok || def == nil {
 		t.Fatalf("expected to extract a recipe by title, ok=%v", ok)
 	}
@@ -55,11 +55,11 @@ func TestExtractJSONLDRecipeByTitle_GraphAndNoMatch(t *testing.T) {
 		fullJSONLDRecipe("Lemon Garlic Salmon", "2 salmon fillets", "1 lemon") + `]}` +
 		`</script></head></html>`
 
-	def, _, ok := extractJSONLDRecipeByTitle(html, "Lemon Garlic Salmon")
+	def, _, _, ok := extractJSONLDRecipeByTitle(html, "Lemon Garlic Salmon")
 	if !ok || def == nil || len(def.Ingredients) != 2 {
 		t.Fatalf("expected salmon recipe from @graph, ok=%v", ok)
 	}
-	if _, _, ok := extractJSONLDRecipeByTitle(html, "Chocolate Lava Cake"); ok {
+	if _, _, _, ok := extractJSONLDRecipeByTitle(html, "Chocolate Lava Cake"); ok {
 		t.Errorf("expected no match for an absent title")
 	}
 }

--- a/internal/service/multi_recipe.go
+++ b/internal/service/multi_recipe.go
@@ -733,14 +733,15 @@ func (r *MultiRecipeResolver) extractAllRecipes(entry *MultiRecipeEntry) {
 }
 
 // extractJSONLDRecipeByTitle finds the JSON-LD Recipe block on the page whose
-// name matches wantTitle and parses it into a full RecipeDef. This lets an inline
+// name matches wantTitle and parses it into a full RecipeDef, plus the
+// recipe's own image URL when the block carries one. This lets an inline
 // (listicle) card be extracted from the SAME page HTML that detected it — free,
 // and immune to the AI-text truncation that silently drops recipes past the size
 // cap. Returns ok=false when no confident JSON-LD match exists.
-func extractJSONLDRecipeByTitle(html, wantTitle string) (*models.RecipeDef, []string, bool) {
+func extractJSONLDRecipeByTitle(html, wantTitle string) (*models.RecipeDef, []string, string, bool) {
 	wantToks := slugTokens(wantTitle)
 	if len(wantToks) == 0 {
-		return nil, nil, false
+		return nil, nil, "", false
 	}
 	re := regexp.MustCompile(`(?s)<script[^>]*type=["']application/ld\+json["'][^>]*>(.*?)</script>`)
 	for _, match := range re.FindAllStringSubmatch(html, -1) {
@@ -755,14 +756,14 @@ func extractJSONLDRecipeByTitle(html, wantTitle string) (*models.RecipeDef, []st
 			if !titleTokensMatch(recipe.Name, wantToks) {
 				continue
 			}
-			def, hashtags, _, err := jsonLDToRecipeDef(&recipe)
+			def, hashtags, imageURL, err := jsonLDToRecipeDef(&recipe)
 			if err != nil || def == nil || len(def.Ingredients) == 0 {
 				continue
 			}
-			return def, hashtags, true
+			return def, hashtags, imageURL, true
 		}
 	}
-	return nil, nil, false
+	return nil, nil, "", false
 }
 
 // collectJSONLDRecipeObjects returns the JSON strings of every Recipe-typed
@@ -925,7 +926,7 @@ func (r *MultiRecipeResolver) extractSingleCard(entry *MultiRecipeEntry, idx int
 	// collection/listicle of links, not inline recipes), fetch and extract that
 	// page directly — it carries the full recipe, usually via free JSON-LD.
 	if sourceURL != "" && sourceURL != entry.SourceURL {
-		if def, hashtags, _, ferr := r.ImportService.fetchAndExtractWithHTML(ctx, sourceURL); ferr == nil && def != nil && len(def.Ingredients) > 0 {
+		if def, hashtags, ownHTML, ferr := r.ImportService.fetchAndExtractWithHTML(ctx, sourceURL); ferr == nil && def != nil && len(def.Ingredients) > 0 {
 			def.SourceURL = sourceURL
 			ensureUnitSystem(def)
 			entry.mu.Lock()
@@ -934,6 +935,12 @@ func (r *MultiRecipeResolver) extractSingleCard(entry *MultiRecipeEntry, idx int
 			entry.Cards[idx].Hashtags = hashtags
 			// The recipe lives at its own page, so that URL is its cache key.
 			entry.Cards[idx].CachedURL = sourceURL
+			// Link-index cards usually detect without an image; the recipe's
+			// own page has the hero (og:image) — backfill so the card isn't a
+			// blank poster in the full-bleed views.
+			if entry.Cards[idx].ImageURL == "" {
+				entry.Cards[idx].ImageURL = pageImageURL(ownHTML)
+			}
 			entry.mu.Unlock()
 			if r.ImportService.CanonicalRepo != nil {
 				if normalizedURL, nerr := NormalizeURL(sourceURL); nerr == nil {
@@ -960,9 +967,16 @@ func (r *MultiRecipeResolver) extractSingleCard(entry *MultiRecipeEntry, idx int
 	// Inline recipe (no own recipe page): prefer the matching JSON-LD Recipe
 	// block from the SAME page HTML that detected the cards — free, and immune to
 	// the AI-text truncation that silently drops recipes past the size cap.
-	if def, hashtags, ok := extractJSONLDRecipeByTitle(pageHTML, title); ok {
+	if def, hashtags, recipeImage, ok := extractJSONLDRecipeByTitle(pageHTML, title); ok {
 		def.SourceURL = sourceURL
 		ensureUnitSystem(def)
+		if recipeImage != "" {
+			entry.mu.Lock()
+			if entry.Cards[idx].ImageURL == "" {
+				entry.Cards[idx].ImageURL = recipeImage
+			}
+			entry.mu.Unlock()
+		}
 		r.finishInlineCard(entry, idx, title, sourceURL, *def, hashtags, models.ExtractionJSONLD, log)
 		log.Info("inline recipe extracted from page JSON-LD", zap.Int("ingredients", len(def.Ingredients)))
 		record("inline_jsonld", true, "", "", nil)
@@ -1048,6 +1062,26 @@ func (r *MultiRecipeResolver) extractSingleCard(entry *MultiRecipeEntry, idx int
 // cardExtractAttempts is how many times a card's AI extraction is tried before
 // the card is marked failed (a single transient blip should not be terminal).
 const cardExtractAttempts = 2
+
+// pageImageURLRe matches the social-preview image meta tags (og:image /
+// twitter:image) in either attribute order.
+var pageImageURLRe = []*regexp.Regexp{
+	regexp.MustCompile(`(?is)<meta[^>]+(?:property|name)=["'](?:og:image|twitter:image)["'][^>]+content=["']([^"'<>\s]+)["']`),
+	regexp.MustCompile(`(?is)<meta[^>]+content=["']([^"'<>\s]+)["'][^>]+(?:property|name)=["'](?:og:image|twitter:image)["']`),
+}
+
+// pageImageURL scrapes a page's social-preview image — the recipe hero on
+// virtually every recipe site. Returns "" when none is declared.
+func pageImageURL(html string) string {
+	for _, re := range pageImageURLRe {
+		if m := re.FindStringSubmatch(html); m != nil {
+			if u := strings.TrimSpace(m[1]); strings.HasPrefix(u, "http") {
+				return u
+			}
+		}
+	}
+	return ""
+}
 
 // windowAroundTitle returns at most `window` bytes of text centered on the first
 // occurrence of the title (or its longest significant token), so a target recipe

--- a/internal/service/multi_recipe_dig_test.go
+++ b/internal/service/multi_recipe_dig_test.go
@@ -93,3 +93,45 @@ func TestExtractSingleCard_DigSkipsInlineAI(t *testing.T) {
 		}
 	})
 }
+
+func TestPageImageURL(t *testing.T) {
+	cases := []struct{ html, want string }{
+		{`<meta property="og:image" content="https://x.com/hero.jpg"/>`, "https://x.com/hero.jpg"},
+		{`<meta content="https://x.com/hero.jpg" property="og:image"/>`, "https://x.com/hero.jpg"},
+		{`<meta name="twitter:image" content="https://x.com/tw.jpg">`, "https://x.com/tw.jpg"},
+		{`<meta property="og:title" content="Hi">`, ""},
+		{`<meta property="og:image" content="/relative.jpg">`, ""},
+	}
+	for _, c := range cases {
+		if got := pageImageURL(c.html); got != c.want {
+			t.Errorf("pageImageURL(%q) = %q, want %q", c.html, got, c.want)
+		}
+	}
+}
+
+// TestExtractSingleCard_InlineJSONLDBackfillsImage: a card extracted from the
+// page's JSON-LD block picks up that recipe's own image when detection left
+// the card imageless.
+func TestExtractSingleCard_InlineJSONLDBackfillsImage(t *testing.T) {
+	page := "https://example.com/roundup-with-images"
+	html := `<html><head>
+<script type="application/ld+json">{"@type":"Recipe","name":"Pumpkin Chili","image":"https://example.com/pumpkin-chili.jpg","recipeIngredient":["2 cups pumpkin","1 lb beef"],"recipeInstructions":["Simmer."]}</script>
+<script type="application/ld+json">{"@type":"Recipe","name":"Wild Rice Soup","image":"https://example.com/wild-rice.jpg","recipeIngredient":["1 cup wild rice","4 cups broth"],"recipeInstructions":["Boil."]}</script>
+</head><body><h1>Roundup</h1></body></html>`
+
+	resolver := newResolverForTest(&testutil.MockTextProvider{}, &testutil.MockCanonicalRecipeRepo{})
+	entry := resolver.ResolveFromHTML(context.Background(), page, html)
+	if entry == nil {
+		t.Fatal("ResolveFromHTML returned nil for a multi-recipe page")
+	}
+	waitResolved(t, entry)
+
+	for _, card := range entry.GetCards() {
+		if card.ExtractionStatus != "done" {
+			t.Errorf("card %q status = %q, want done (inline JSON-LD)", card.Title, card.ExtractionStatus)
+		}
+		if card.ImageURL == "" {
+			t.Errorf("card %q has no image; want the JSON-LD recipe image backfilled", card.Title)
+		}
+	}
+}


### PR DESCRIPTION
Recipes mined out of link-index roundups rendered as blank gradient posters in the full-bleed views — detection only sees the collection page's link list, so cards carried no image. The hero image was available all along and being discarded twice:

- **Own-page path**: the card's recipe page is already fetched; its `og:image`/`twitter:image` now backfills `card.ImageURL` (new `pageImageURL` helper, both attribute orders, absolute URLs only).
- **Inline JSON-LD path**: `extractJSONLDRecipeByTitle` now returns the matched recipe's own `image`, threaded onto the card.

Offline suite green + new tests (`TestPageImageURL` table, inline-JSON-LD backfill).

Part 4 of the agent-mode overhaul (#119/#120/#121; e2e-verified in prod — this closes the last visual gap: image-less picks).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01My8N5v3zDNtM47E55bPP1v