### PR TITLE
feat(auth): garbage-collect abandoned unverified signups after 30 days

### DIFF
--- a/internal/repository/interfaces.go
+++ b/internal/repository/interfaces.go
@@ -127,6 +127,7 @@ type UserRepo interface {
 	EmailExists(email string) (bool, error)
 	SetEmailVerified(userID uint) error
 	ClearUserEmail(userID uint) error
+	DeleteAbandonedUnverifiedUsers(olderThan time.Time) (int64, error)
 	IncrementTokenVersion(userID uint) error
 	CreateSubscription(sub *models.Subscription) error
 	IncrementSubscriptionUsage(userID uint, column string) error

--- a/internal/repository/user.go
+++ b/internal/repository/user.go
@@ -290,6 +290,52 @@ func (r *UserRepository) ResetSubscriptionUsage(userID uint, nextReset time.Time
 	return nil
 }
 
+// DeleteAbandonedUnverifiedUsers hard-deletes "empty husk" accounts: never
+// email-verified, older than the cutoff, and with zero durable content (no
+// recipes created or collected, no family owned). These are abandoned
+// signups squatting usernames; hard deletion frees the username and email
+// for reuse (the unique constraints see soft-deleted rows, so soft delete
+// wouldn't). Accounts with any content are never touched — under the soft
+// gate an unverified account can still be a real, active user.
+func (r *UserRepository) DeleteAbandonedUnverifiedUsers(olderThan time.Time) (int64, error) {
+	var deleted int64
+	err := r.DB.Transaction(func(tx *gorm.DB) error {
+		var ids []uint
+		if err := tx.Raw(`
+			SELECT id FROM users
+			WHERE email_verified_at IS NULL
+			  AND created_at < ?
+			  AND NOT EXISTS (SELECT 1 FROM recipes rc WHERE rc.created_by_id = users.id)
+			  AND NOT EXISTS (SELECT 1 FROM user_collected_recipes uc WHERE uc.user_id = users.id)
+			  AND NOT EXISTS (SELECT 1 FROM families f WHERE f.owner_id = users.id)`,
+			olderThan).Scan(&ids).Error; err != nil {
+			return err
+		}
+		if len(ids) == 0 {
+			return nil
+		}
+
+		// Child rows first (the association FKs restrict deletes), then the
+		// user rows themselves — unscoped so the row is truly gone.
+		for _, table := range []string{
+			"email_verifications", "o_auth_auth_codes", "o_auth_tokens",
+			"finder_sessions", "video_imports",
+			"user_auths", "subscriptions", "user_settings", "personalizations",
+		} {
+			if err := tx.Exec(`DELETE FROM `+table+` WHERE user_id IN ?`, ids).Error; err != nil {
+				return err
+			}
+		}
+		res := tx.Exec(`DELETE FROM users WHERE id IN ?`, ids)
+		if res.Error != nil {
+			return res.Error
+		}
+		deleted = res.RowsAffected
+		return nil
+	})
+	return deleted, err
+}
+
 // UsernameExists checks if a username already exists.
 func (r *UserRepository) UsernameExists(username string) (bool, error) {
 	lowercaseUsername := strings.ToLower(username)

--- a/internal/router/router.go
+++ b/internal/router/router.go
@@ -109,6 +109,7 @@ func SetupRouter(cfg *config.Config, database *gorm.DB) *gin.Engine {
 	// User-related routes setup
 	userRepo := repository.NewUserRepository(database)
 	userService := service.NewUserService(cfg, userRepo)
+	userService.StartAbandonedAccountCleanup()
 	userHandler := handlers.NewUserHandler(userService)
 
 	// Signup email verification. Ships dark: without EMAIL_VERIFICATION_ENABLED

--- a/internal/service/user.go
+++ b/internal/service/user.go
@@ -11,8 +11,10 @@ import (
 	goaway "github.com/TwiN/go-away"
 	"github.com/asaskevich/govalidator"
 	"github.com/windoze95/saltybytes-api/internal/config"
+	"github.com/windoze95/saltybytes-api/internal/logger"
 	"github.com/windoze95/saltybytes-api/internal/models"
 	"github.com/windoze95/saltybytes-api/internal/repository"
+	"go.uber.org/zap"
 	"golang.org/x/crypto/bcrypt"
 	"gorm.io/gorm"
 )
@@ -202,6 +204,42 @@ func (s *UserService) GetUserWithAuthByID(userID uint) (*models.User, error) {
 // incrementing their token version.
 func (s *UserService) LogoutUser(userID uint) error {
 	return s.Repo.IncrementTokenVersion(userID)
+}
+
+// abandonedAccountAfter is how long an unverified, contentless signup may
+// sit before the cleanup sweeper garbage-collects it (freeing its username
+// and email for reuse).
+const abandonedAccountAfter = 30 * 24 * time.Hour
+
+// CleanupAbandonedAccounts runs one sweep of abandoned unverified signups.
+// Returns how many accounts were removed.
+func (s *UserService) CleanupAbandonedAccounts() (int64, error) {
+	return s.Repo.DeleteAbandonedUnverifiedUsers(time.Now().Add(-abandonedAccountAfter))
+}
+
+// StartAbandonedAccountCleanup sweeps shortly after boot and then every 12
+// hours. The boot sweep matters because frequent deploys restart the task —
+// a ticker alone might never fire between deployments.
+func (s *UserService) StartAbandonedAccountCleanup() {
+	sweep := func() {
+		n, err := s.CleanupAbandonedAccounts()
+		if err != nil {
+			logger.Get().Warn("abandoned-account cleanup failed", zap.Error(err))
+			return
+		}
+		if n > 0 {
+			logger.Get().Info("abandoned-account cleanup removed empty unverified signups", zap.Int64("count", n))
+		}
+	}
+	go func() {
+		time.Sleep(2 * time.Minute)
+		sweep()
+		ticker := time.NewTicker(12 * time.Hour)
+		defer ticker.Stop()
+		for range ticker.C {
+			sweep()
+		}
+	}()
 }
 
 // ToUserResponse converts a User to a UserResponse.

--- a/internal/service/user_login_test.go
+++ b/internal/service/user_login_test.go
@@ -4,6 +4,7 @@ import (
 	"errors"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/windoze95/saltybytes-api/internal/models"
 	"github.com/windoze95/saltybytes-api/internal/testutil"
@@ -167,5 +168,39 @@ func TestValidatePassword_RejectsOverBcryptLimit(t *testing.T) {
 	long := "Aa1!" + strings.Repeat("x", 72)
 	if err := svc.ValidatePassword(long); err == nil {
 		t.Error("ValidatePassword should reject passwords longer than 72 bytes")
+	}
+}
+
+func TestCleanupAbandonedAccounts_UsesThirtyDayCutoff(t *testing.T) {
+	repo := testutil.NewMockUserRepo()
+	svc := newTestUserService(repo)
+
+	// A 40-day-old unverified husk and a fresh unverified signup.
+	husk := &models.User{Username: "husk", Email: "husk@example.com", Auth: &models.UserAuth{AuthType: models.Standard}}
+	repo.CreateUser(husk)
+	husk.CreatedAt = time.Now().Add(-40 * 24 * time.Hour)
+
+	fresh := &models.User{Username: "fresh", Email: "fresh@example.com", Auth: &models.UserAuth{AuthType: models.Standard}}
+	repo.CreateUser(fresh)
+	fresh.CreatedAt = time.Now().Add(-2 * 24 * time.Hour)
+
+	n, err := svc.CleanupAbandonedAccounts()
+	if err != nil {
+		t.Fatalf("CleanupAbandonedAccounts error: %v", err)
+	}
+	if n != 1 {
+		t.Errorf("removed %d accounts, want 1 (only the 40-day husk)", n)
+	}
+
+	cutoffAge := time.Since(repo.LastCleanupCutoff)
+	if cutoffAge < 29*24*time.Hour || cutoffAge > 31*24*time.Hour {
+		t.Errorf("cleanup cutoff is %v old, want ~30 days", cutoffAge)
+	}
+
+	if _, err := repo.GetUserByID(husk.ID); err == nil {
+		t.Error("husk should be gone")
+	}
+	if _, err := repo.GetUserByID(fresh.ID); err != nil {
+		t.Error("fresh unverified signup must survive")
 	}
 }

--- a/internal/testutil/mocks.go
+++ b/internal/testutil/mocks.go
@@ -605,6 +605,9 @@ type MockUserRepo struct {
 	// GetUserAuthByEmail to simulate infrastructure failures (as opposed to
 	// gorm.ErrRecordNotFound, which the mock returns for unknown users).
 	GetUserAuthErr error
+	// LastCleanupCutoff records the cutoff passed to
+	// DeleteAbandonedUnverifiedUsers, for assertions.
+	LastCleanupCutoff time.Time
 }
 
 // NewMockUserRepo creates a new MockUserRepo with initialized maps.
@@ -757,6 +760,21 @@ func (m *MockUserRepo) EmailExists(email string) (bool, error) {
 		}
 	}
 	return false, nil
+}
+
+func (m *MockUserRepo) DeleteAbandonedUnverifiedUsers(olderThan time.Time) (int64, error) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	m.LastCleanupCutoff = olderThan
+	var deleted int64
+	for id, u := range m.Users {
+		if u.EmailVerifiedAt == nil && u.CreatedAt.Before(olderThan) {
+			delete(m.Users, id)
+			deleted++
+		}
+	}
+	return deleted, nil
 }
 
 func (m *MockUserRepo) SetEmailVerified(userID uint) error {


### PR DESCRIPTION
Completes the unverified-account lifecycle from #117:

- **48h**: a stale unverified signup releases its **email** when someone else registers it (already live).
- **30 days** (this PR): unverified accounts with **zero durable content** (no recipes created/collected, no family) are hard-deleted entirely, freeing username + email. Content-bearing accounts are never touched — under the soft gate, unverified users can be real users.

Runs 2 min after boot + every 12h (boot sweep matters because frequent deploys can restart the task before a long ticker ever fires). Children deleted before the user row inside one transaction (association FKs restrict).

Full suite green; new test pins the 30-day cutoff and that fresh unverified signups survive.

🤖 Generated with [Claude Code](https://claude.com/claude-code)