### PR TITLE
web: decode HTML entities left in extracted recipe text

### DIFF
--- a/internal/web/web.go
+++ b/internal/web/web.go
@@ -10,6 +10,7 @@ import (
 	"encoding/hex"
 	"encoding/json"
 	"fmt"
+	htmlpkg "html"
 	"html/template"
 	"net/http"
 	"net/url"
@@ -188,6 +189,7 @@ func (h *Handler) Recipe(c *gin.Context) {
 	}
 
 	def := canonical.RecipeData
+	def = decodeEntities(def)
 	sourceURL := def.SourceURL
 	if sourceURL == "" {
 		sourceURL = canonical.OriginalURL
@@ -233,6 +235,23 @@ func (h *Handler) RecipeByURL(c *gin.Context) {
 		return
 	}
 	c.Redirect(http.StatusFound, fmt.Sprintf("/r/%d", canonical.ID))
+}
+
+// decodeEntities unescapes HTML entities that some source pages leave inside
+// extracted text ("&#8211;", "&amp;"). Rendering escapes everything again, so
+// without this the entity shows up literally on the page.
+func decodeEntities(def models.RecipeDef) models.RecipeDef {
+	def.Title = htmlpkg.UnescapeString(def.Title)
+	def.PortionSize = htmlpkg.UnescapeString(def.PortionSize)
+	for i := range def.Ingredients {
+		def.Ingredients[i].Name = htmlpkg.UnescapeString(def.Ingredients[i].Name)
+		def.Ingredients[i].OriginalText = htmlpkg.UnescapeString(def.Ingredients[i].OriginalText)
+		def.Ingredients[i].Unit = htmlpkg.UnescapeString(def.Ingredients[i].Unit)
+	}
+	for i := range def.Instructions {
+		def.Instructions[i] = htmlpkg.UnescapeString(def.Instructions[i])
+	}
+	return def
 }
 
 func ingredientLines(ingredients models.Ingredients) []ingredientLine {

--- a/internal/web/web_test.go
+++ b/internal/web/web_test.go
@@ -139,6 +139,27 @@ func TestRecipePage(t *testing.T) {
 	}
 }
 
+func TestRecipePage_DecodesSourceEntities(t *testing.T) {
+	entry := testCanonical()
+	entry.RecipeData.Ingredients = models.Ingredients{
+		{OriginalText: "1-2 tablespoons seasoning mix (the one I use &#8211; see notes)"},
+	}
+	entry.RecipeData.Title = "Salmon &amp; Salsa"
+	repo := &testutil.MockCanonicalRecipeRepo{
+		GetByIDFunc: func(id uint) (*models.CanonicalRecipe, error) { return entry, nil },
+	}
+	body := get(testRouter(repo), "/r/42").Body.String()
+	if strings.Contains(body, "&amp;#8211;") || strings.Contains(body, "#8211") {
+		t.Error("stored HTML entity leaked into the page text")
+	}
+	if !strings.Contains(body, "–") {
+		t.Error("expected the en dash to render")
+	}
+	if !strings.Contains(body, "Salmon &amp; Salsa") {
+		t.Error("decoded ampersand should re-escape exactly once on output")
+	}
+}
+
 func TestRecipePage_EscapesUntrustedContent(t *testing.T) {
 	entry := testCanonical()
 	entry.RecipeData.Title = `<script>alert("pwn")</script> Salmon`


### PR DESCRIPTION
Live follow-up to #124: pages rendered stored HTML entities literally (e.g. `&#8211;` visible on /r/423, spotted during post-deploy verification). Decode entities from extracted text before rendering; html/template still auto-escapes output, so the injection-safety test keeps passing. New regression test included.

🤖 Generated with [Claude Code](https://claude.com/claude-code)