### PR TITLE
web: fire saltybytes://app/preview deep links from recipe pages

### DIFF
--- a/internal/web/templates/recipe.html
+++ b/internal/web/templates/recipe.html
@@ -1,5 +1,5 @@
 {{template "page_head" .Meta}}
-<body class="recipepage" data-rid="{{.ID}}" data-ios="{{.IOSURL}}" data-android="{{.AndroidURL}}">
+<body class="recipepage" data-rid="{{.ID}}" data-src="{{.SourceURL}}" data-ios="{{.IOSURL}}" data-android="{{.AndroidURL}}">
 
 <nav class="site-nav">
   <div class="wrap nav-row">
@@ -74,18 +74,21 @@
 <script>
 function openInApp() {
   var body = document.body;
-  var rid = body.getAttribute('data-rid');
+  var src = body.getAttribute('data-src');
   var ios = body.getAttribute('data-ios');
   var android = body.getAttribute('data-android');
   var ua = navigator.userAgent || '';
   var store = /android/i.test(ua) ? android : (/iphone|ipad|ipod/i.test(ua) ? ios : (ios || android));
   var fallback = store || '/#get';
+  if (!src) { window.location.href = fallback; return; }
   var timer = setTimeout(function () {
     if (!document.hidden) { window.location.href = fallback; }
   }, 1400);
   window.addEventListener('pagehide', function () { clearTimeout(timer); }, { once: true });
-  // If the app is installed it claims this scheme; otherwise the timer fires.
-  window.location.href = 'saltybytes://r/' + rid;
+  // The app registers the saltybytes:// scheme and routes /preview?u=<url>
+  // into its recipe-preview flow (instant for anything already extracted).
+  // The "app" authority is a dummy so the path parses the same everywhere.
+  window.location.href = 'saltybytes://app/preview?u=' + encodeURIComponent(src);
 }
 </script>
 </body>

--- a/internal/web/web_test.go
+++ b/internal/web/web_test.go
@@ -130,8 +130,8 @@ func TestRecipePage(t *testing.T) {
 		`application/ld+json`,
 		`"cookTime":"PT25M"`,
 		`<link rel="canonical" href="https://saltybytes.ai/r/42">`,
-		`data-rid="42"`,   // feeds the open-in-app deep-link script
-		`saltybytes://r/`, // the scheme the script attempts
+		`data-src="https://pinchofyum.com/bang-bang-salmon"`, // feeds the open-in-app deep link
+		`saltybytes://app/preview`,                           // the scheme the script attempts
 	} {
 		if !strings.Contains(body, want) {
 			t.Errorf("recipe page missing %q", want)


### PR DESCRIPTION
Companion to windoze95/saltybytes-app#69 (app registers the scheme + /preview route). The recipe page's open-in-app button now fires `saltybytes://app/preview?u=<source-url>` (the shape the app routes), falling back to the store link / #get as before; pages without a source URL skip the scheme attempt entirely.

🤖 Generated with [Claude Code](https://claude.com/claude-code)