### PR TITLE
Universal links: association files + canonical-id source resolution

### DIFF
--- a/internal/handlers/import.go
+++ b/internal/handlers/import.go
@@ -33,6 +33,23 @@ func NewImportHandler(importService *service.ImportService) *ImportHandler {
 	return &ImportHandler{Service: importService}
 }
 
+// GetCanonicalSource handles GET /v1/recipes/canonical/:id/source — resolves
+// a public recipe-page id (saltybytes.ai/r/<id>) to its source URL so the app
+// can open a shared link through its normal preview flow.
+func (h *ImportHandler) GetCanonicalSource(c *gin.Context) {
+	id, err := strconv.ParseUint(c.Param("id"), 10, 32)
+	if err != nil {
+		c.JSON(http.StatusBadRequest, gin.H{"error": "invalid id"})
+		return
+	}
+	title, sourceURL, err := h.Service.CanonicalSource(uint(id))
+	if err != nil || sourceURL == "" {
+		c.JSON(http.StatusNotFound, gin.H{"error": "recipe not found"})
+		return
+	}
+	c.JSON(http.StatusOK, gin.H{"title": title, "source_url": sourceURL})
+}
+
 // ImportFromURL handles POST /v1/recipes/import/url
 func (h *ImportHandler) ImportFromURL(c *gin.Context) {
 	user, err := util.GetUserFromContext(c)

--- a/internal/router/router.go
+++ b/internal/router/router.go
@@ -339,6 +339,9 @@ func SetupRouter(cfg *config.Config, database *gorm.DB) *gin.Engine {
 
 		// Recipe preview route (cheap extraction for pre-import preview)
 		apiProtected.POST("/recipes/preview/url", middleware.AttachUserToContext(userService), aiBudget, importHandler.PreviewFromURL)
+		// Universal-link resolution: saltybytes.ai/r/<id> carries only the
+		// canonical id; the app trades it for the source URL, then previews.
+		apiProtected.GET("/recipes/canonical/:id/source", importHandler.GetCanonicalSource)
 
 		// Recipe tree/branching routes
 		treeService := service.NewRecipeTreeService(cfg, recipeRepo)

--- a/internal/service/import.go
+++ b/internal/service/import.go
@@ -843,6 +843,29 @@ type PreviewResult struct {
 	FromCache bool `json:"from_cache,omitempty"`
 }
 
+// CanonicalSource resolves a canonical cache id to its title and source URL.
+// This is the glue for universal links: the public site's recipe pages live at
+// saltybytes.ai/r/<canonical id>, so a link opened in the app carries only the
+// id, and the app resolves it here before running its normal URL preview flow.
+// Multi-page markers and empty extractions are not resolvable.
+func (s *ImportService) CanonicalSource(id uint) (title, sourceURL string, err error) {
+	if s.CanonicalRepo == nil {
+		return "", "", fmt.Errorf("canonical cache not configured")
+	}
+	canonical, err := s.CanonicalRepo.GetByID(id)
+	if err != nil {
+		return "", "", err
+	}
+	if canonical.IsMultiPage || canonical.RecipeData.Title == "" {
+		return "", "", fmt.Errorf("canonical %d is not a servable recipe", id)
+	}
+	source := canonical.RecipeData.SourceURL
+	if source == "" {
+		source = canonical.OriginalURL
+	}
+	return canonical.RecipeData.Title, source, nil
+}
+
 // PreviewFromURL fetches a page and extracts recipe data without saving.
 // When a CanonicalRepo is configured, it checks the cache first and saves
 // extractions for future deduplication. Returns the recipe data and optional canonical ID.

--- a/internal/service/import_service_test.go
+++ b/internal/service/import_service_test.go
@@ -1039,3 +1039,45 @@ func TestCreateImportedRecipe_KeepsExistingPortions(t *testing.T) {
 		t.Errorf("Portions = %d, want 4 (unchanged)", repo.Recipes[recipeID].Portions)
 	}
 }
+
+func TestCanonicalSource(t *testing.T) {
+	entry := &models.CanonicalRecipe{
+		OriginalURL: "https://pinchofyum.com/bang-bang-salmon",
+		RecipeData: models.RecipeDef{
+			Title:     "Bang Bang Salmon",
+			SourceURL: "https://pinchofyum.com/bang-bang-salmon?utm=x",
+		},
+	}
+	entry.ID = 42
+	marker := &models.CanonicalRecipe{IsMultiPage: true}
+	marker.ID = 7
+
+	svc := &ImportService{CanonicalRepo: &testutil.MockCanonicalRecipeRepo{
+		GetByIDFunc: func(id uint) (*models.CanonicalRecipe, error) {
+			switch id {
+			case 42:
+				return entry, nil
+			case 7:
+				return marker, nil
+			}
+			return nil, fmt.Errorf("not found")
+		},
+	}}
+
+	title, source, err := svc.CanonicalSource(42)
+	if err != nil || title != "Bang Bang Salmon" || source != "https://pinchofyum.com/bang-bang-salmon?utm=x" {
+		t.Fatalf("CanonicalSource(42) = %q %q %v", title, source, err)
+	}
+	if _, _, err := svc.CanonicalSource(7); err == nil {
+		t.Fatal("multi-page marker must not resolve")
+	}
+	if _, _, err := svc.CanonicalSource(999); err == nil {
+		t.Fatal("missing id must not resolve")
+	}
+
+	// Falls back to the original URL when the extraction lacks a source.
+	entry.RecipeData.SourceURL = ""
+	if _, source, _ := svc.CanonicalSource(42); source != "https://pinchofyum.com/bang-bang-salmon" {
+		t.Fatalf("fallback source = %q", source)
+	}
+}

--- a/internal/web/web.go
+++ b/internal/web/web.go
@@ -64,6 +64,10 @@ func (h *Handler) Register(r *gin.Engine) {
 	r.GET("/robots.txt", h.Robots)
 	r.GET("/sitemap.xml", pages, h.Sitemap)
 	r.GET("/static/*filepath", h.Static)
+	// App association files (universal links / app links). The OAuth server
+	// owns the other /.well-known routes; these two are the app's.
+	r.GET("/.well-known/apple-app-site-association", h.AppleAASA)
+	r.GET("/.well-known/assetlinks.json", h.AssetLinks)
 	r.NoRoute(h.NotFound)
 }
 

--- a/internal/web/web_test.go
+++ b/internal/web/web_test.go
@@ -287,6 +287,30 @@ func TestStaticAssets(t *testing.T) {
 	}
 }
 
+func TestWellKnownAssociationFiles(t *testing.T) {
+	r := testRouter(&testutil.MockCanonicalRecipeRepo{})
+
+	aasa := get(r, "/.well-known/apple-app-site-association")
+	if aasa.Code != http.StatusOK || !strings.Contains(aasa.Header().Get("Content-Type"), "application/json") {
+		t.Fatalf("AASA: expected 200 json, got %d %s", aasa.Code, aasa.Header().Get("Content-Type"))
+	}
+	for _, want := range []string{"2M54LKDR89.codes.julian.saltybytes", `"/r/*"`, "webcredentials"} {
+		if !strings.Contains(aasa.Body.String(), want) {
+			t.Errorf("AASA missing %q", want)
+		}
+	}
+
+	links := get(r, "/.well-known/assetlinks.json")
+	if links.Code != http.StatusOK || !strings.Contains(links.Header().Get("Content-Type"), "application/json") {
+		t.Fatalf("assetlinks: expected 200 json, got %d %s", links.Code, links.Header().Get("Content-Type"))
+	}
+	for _, want := range []string{"codes.julian.saltybytes", "delegate_permission/common.handle_all_urls", "6E:E1:3B:60"} {
+		if !strings.Contains(links.Body.String(), want) {
+			t.Errorf("assetlinks missing %q", want)
+		}
+	}
+}
+
 func TestPrivacyPage(t *testing.T) {
 	w := get(testRouter(&testutil.MockCanonicalRecipeRepo{}), "/privacy")
 	if w.Code != http.StatusOK {

--- a/internal/web/wellknown.go
+++ b/internal/web/wellknown.go
@@ -1,0 +1,63 @@
+package web
+
+import (
+	"net/http"
+
+	"github.com/gin-gonic/gin"
+)
+
+// Universal links (iOS) and App Links (Android) association files. All values
+// here are public by design (they also ship inside the app binaries).
+//
+//   - Apple team id 2M54LKDR89, bundle id codes.julian.saltybytes. The app's
+//     Associated Domains entitlement lists applinks:saltybytes.ai (+ www), and
+//     Apple's CDN fetches this file to let https://saltybytes.ai/r/... links
+//     open the app directly. Only /r and /r/* are app-claimed — the rest of
+//     the site stays in the browser.
+//   - Android package codes.julian.saltybytes. Fingerprints: the Play
+//     app-signing certificate (Play Console → App integrity — what
+//     Play-installed builds are signed with) plus the upload key (covers
+//     CI-built APKs installed directly during testing).
+const appleAppSiteAssociation = `{
+  "applinks": {
+    "details": [
+      {
+        "appIDs": ["2M54LKDR89.codes.julian.saltybytes"],
+        "components": [
+          { "/": "/r", "comment": "share links resolved by source URL" },
+          { "/": "/r/*", "comment": "public recipe pages" }
+        ]
+      }
+    ]
+  },
+  "webcredentials": {
+    "apps": ["2M54LKDR89.codes.julian.saltybytes"]
+  }
+}`
+
+const androidAssetLinks = `[
+  {
+    "relation": ["delegate_permission/common.handle_all_urls"],
+    "target": {
+      "namespace": "android_app",
+      "package_name": "codes.julian.saltybytes",
+      "sha256_cert_fingerprints": [
+        "6E:E1:3B:60:D1:F1:8C:A8:6A:F4:9E:81:A2:E8:EE:54:B2:44:C4:9E:12:21:77:C7:65:14:1D:0E:5A:B8:BB:51",
+        "BE:77:3A:3E:13:69:07:B7:9E:2D:E8:D4:5D:AB:59:D2:17:20:C4:84:AE:C5:FF:94:00:7E:05:67:F8:5E:53:13"
+      ]
+    }
+  }
+]`
+
+// AppleAASA serves /.well-known/apple-app-site-association. Apple requires
+// application/json with no redirects.
+func (h *Handler) AppleAASA(c *gin.Context) {
+	c.Header("Cache-Control", "public, max-age=3600")
+	c.Data(http.StatusOK, "application/json", []byte(appleAppSiteAssociation))
+}
+
+// AssetLinks serves /.well-known/assetlinks.json for Android App Links.
+func (h *Handler) AssetLinks(c *gin.Context) {
+	c.Header("Cache-Control", "public, max-age=3600")
+	c.Data(http.StatusOK, "application/json", []byte(androidAssetLinks))
+}


### PR DESCRIPTION
Server half of universal links (app half: windoze95/saltybytes-app#70).

- `/.well-known/apple-app-site-association` — team `2M54LKDR89`, bundle `codes.julian.saltybytes`, app-claimed paths scoped to `/r` and `/r/*` only (+`webcredentials` for future passkeys/autofill).
- `/.well-known/assetlinks.json` — Play **app-signing** cert (from Play Console → App integrity) + upload cert, so App Links verify for both Play-installed and CI-built installs.
- `GET /v1/recipes/canonical/:id/source` — universal links to `/r/<id>` carry only the canonical id; the app resolves it here (title + source URL) and runs its normal preview flow. IsMultiPage markers / empty extractions 404.

Infra already done out-of-band today: ASSOCIATED_DOMAINS capability enabled on the App ID via the ASC API, new provisioning profile "SaltyBytes App Store UL" issued (both dist certs), `IOS_PROVISIONING_PROFILE_BASE64` secret rotated.

Tests: association-file assertions in `internal/web`, `TestCanonicalSource` in `internal/service`; full suite green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)