### PR TITLE
feat(security): runaway lock for unlimited accounts + per-user AI spend attribution

### DIFF
--- a/internal/ai/attribution_test.go
+++ b/internal/ai/attribution_test.go
@@ -1,0 +1,37 @@
+package ai
+
+import (
+	"context"
+	"testing"
+	"time"
+)
+
+// Metered calls made under a user-tagged context must attribute the spend
+// to that user; untagged (system) work records user 0.
+func TestCostMiddleware_AttributesUserFromContext(t *testing.T) {
+	var got []UsageRecord
+	mw := &CostMiddleware{Sink: func(rec UsageRecord) { got = append(got, rec) }}
+
+	run := func(ctx context.Context) {
+		_, _ = runWithMiddleware(ctx, mw, AIOperation{
+			Name: "GenerateRecipe", Provider: "anthropic",
+			Model: "claude-sonnet-4", StartTime: time.Now(),
+		}, func(ctx context.Context) (string, error) {
+			recordUsage(ctx, TokenUsage{InputTokens: 100, OutputTokens: 50})
+			return "ok", nil
+		})
+	}
+
+	run(WithUserID(context.Background(), 42))
+	run(context.Background())
+
+	if len(got) != 2 {
+		t.Fatalf("recorded %d calls, want 2", len(got))
+	}
+	if got[0].UserID != 42 {
+		t.Errorf("tagged call attributed to %d, want 42", got[0].UserID)
+	}
+	if got[1].UserID != 0 {
+		t.Errorf("untagged call attributed to %d, want 0", got[1].UserID)
+	}
+}

--- a/internal/ai/middleware.go
+++ b/internal/ai/middleware.go
@@ -36,6 +36,27 @@ type usageKeyType struct{}
 // usageKey marks the per-call usage sink stored in the context.
 var usageKey usageKeyType
 
+type userIDKeyType struct{}
+
+// userIDKey carries the requesting user's ID through the context so metered
+// calls can be attributed per account.
+var userIDKey userIDKeyType
+
+// WithUserID tags a context with the requesting user, attributing every AI
+// call made under it in ai_usage_logs. System-initiated work (warming,
+// detached jobs) simply never tags, recording user_id 0.
+func WithUserID(ctx context.Context, userID uint) context.Context {
+	return context.WithValue(ctx, userIDKey, userID)
+}
+
+// userIDFrom extracts the tagged user, 0 when untagged.
+func userIDFrom(ctx context.Context) uint {
+	if id, ok := ctx.Value(userIDKey).(uint); ok {
+		return id
+	}
+	return 0
+}
+
 // recordUsage reports a provider call's token usage to the in-flight sink so the
 // middleware can meter cost. A no-op if no sink is in the context.
 func recordUsage(ctx context.Context, u TokenUsage) {
@@ -128,6 +149,7 @@ func runWithMiddleware[T any](ctx context.Context, mw AIMiddleware, op AIOperati
 
 // UsageRecord is one metered AI call handed to a CostMiddleware sink.
 type UsageRecord struct {
+	UserID           uint
 	Operation        string
 	Provider         string
 	Model            string
@@ -164,6 +186,7 @@ func (m *CostMiddleware) After(ctx context.Context, result AIOperationResult) {
 		pricing = DefaultPricing
 	}
 	m.Sink(UsageRecord{
+		UserID:           userIDFrom(ctx),
 		Operation:        result.Operation.Name,
 		Provider:         result.Operation.Provider,
 		Model:            result.Operation.Model,

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -84,6 +84,13 @@ type EnvVars struct {
 	// this bounds the fleet — the last line against runaway AI cost. 0
 	// disables the guard.
 	AIDailyBudgetUSD float64 `env:"AI_DAILY_BUDGET_USD" envDefault:"0" optional:"true"`
+	// UnlimitedDailySpendCapUSD is the per-account runaway guard for the
+	// hidden unlimited tier: when one unlimited account's attributed AI spend
+	// over the trailing 24h exceeds this, the account is LOCKED (suspected
+	// compromise — unlimited accounts are operator accounts) and the operator
+	// is paged. Unlock manually: UPDATE users SET locked_at = NULL. 0
+	// disables the guard.
+	UnlimitedDailySpendCapUSD float64 `env:"UNLIMITED_DAILY_SPEND_CAP_USD" envDefault:"10" optional:"true"`
 	// Ntfy operational alerting (budget trips, AI-provider failures, email
 	// send failures). Disabled while NtfyURL or NtfyTopic is empty. NtfyToken
 	// is the optional Bearer token for authenticated/self-hosted servers.

--- a/internal/mcpserver/tools.go
+++ b/internal/mcpserver/tools.go
@@ -66,6 +66,9 @@ func (d *Deps) userForRequest(req *mcp.CallToolRequest, scope string) (*models.U
 	if err != nil {
 		return nil, fmt.Errorf("unauthorized: account not found")
 	}
+	if user.Locked() {
+		return nil, fmt.Errorf("this account has been locked; contact support")
+	}
 	return user, nil
 }
 

--- a/internal/middleware/context.go
+++ b/internal/middleware/context.go
@@ -4,6 +4,7 @@ import (
 	"net/http"
 
 	"github.com/gin-gonic/gin"
+	"github.com/windoze95/saltybytes-api/internal/ai"
 	"github.com/windoze95/saltybytes-api/internal/logger"
 	"github.com/windoze95/saltybytes-api/internal/service"
 	"github.com/windoze95/saltybytes-api/internal/util"
@@ -30,7 +31,20 @@ func AttachUserToContext(userService *service.UserService) gin.HandlerFunc {
 			return
 		}
 
+		// Locked accounts (runaway guard / suspected compromise) are dead in
+		// the water everywhere, with a distinct code so the app can explain.
+		if user.Locked() {
+			c.AbortWithStatusJSON(http.StatusForbidden, gin.H{
+				"error":      "This account has been locked. Contact support.",
+				"error_code": "account_locked",
+			})
+			return
+		}
+
 		c.Set("user", user)
+		// Tag the request context so every AI call this request makes is
+		// attributed to the user in ai_usage_logs.
+		c.Request = c.Request.WithContext(ai.WithUserID(c.Request.Context(), user.ID))
 		c.Next()
 	}
 }

--- a/internal/middleware/context_lock_test.go
+++ b/internal/middleware/context_lock_test.go
@@ -1,0 +1,45 @@
+package middleware
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/gin-gonic/gin"
+	"github.com/windoze95/saltybytes-api/internal/config"
+	"github.com/windoze95/saltybytes-api/internal/service"
+	"github.com/windoze95/saltybytes-api/internal/testutil"
+)
+
+// A locked account must be rejected at the auth layer — nothing
+// authenticated works until the lock is lifted.
+func TestAttachUserToContext_RejectsLockedAccounts(t *testing.T) {
+	repo := testutil.NewMockUserRepo()
+	user := testutil.TestUser()
+	now := time.Now()
+	user.LockedAt = &now
+	user.LockReason = "runaway guard"
+	repo.Users[user.ID] = user
+
+	svc := service.NewUserService(&config.Config{}, repo)
+
+	r := gin.New()
+	r.GET("/anything",
+		func(c *gin.Context) { c.Set("user_id", user.ID); c.Next() },
+		AttachUserToContext(svc),
+		func(c *gin.Context) { c.JSON(http.StatusOK, gin.H{"ok": true}) },
+	)
+
+	req := httptest.NewRequest("GET", "/anything", nil)
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, req)
+
+	if w.Code != http.StatusForbidden {
+		t.Fatalf("status = %d, want 403. body: %s", w.Code, w.Body.String())
+	}
+	if !strings.Contains(w.Body.String(), "account_locked") {
+		t.Errorf("body missing account_locked: %s", w.Body.String())
+	}
+}

--- a/internal/middleware/runaway_guard.go
+++ b/internal/middleware/runaway_guard.go
@@ -1,0 +1,99 @@
+package middleware
+
+import (
+	"fmt"
+	"net/http"
+	"sync"
+	"time"
+
+	"github.com/gin-gonic/gin"
+	"github.com/windoze95/saltybytes-api/internal/logger"
+	"github.com/windoze95/saltybytes-api/internal/models"
+	"github.com/windoze95/saltybytes-api/internal/notify"
+	"github.com/windoze95/saltybytes-api/internal/util"
+	"go.uber.org/zap"
+)
+
+// UnlimitedRunawayGuard protects the hidden unlimited tier against
+// compromise. Unlimited accounts bypass every quota, so a stolen operator
+// credential could burn AI spend freely up to the global daily switch —
+// while locking every real user out of it. This guard watches each
+// unlimited account's own attributed spend over the trailing 24 hours;
+// crossing capUSD LOCKS the account outright (every authenticated request
+// 403s until locked_at is cleared manually) and pages the operator.
+//
+// Per-user totals are cached for a minute; capped tiers pass straight
+// through (their caps already bound them); capUSD <= 0 disables. Spend
+// checks fail open — attribution gaps must not lock the operator out.
+func UnlimitedRunawayGuard(
+	capUSD float64,
+	sumUserSince func(userID uint, since time.Time) (float64, error),
+	lockUser func(userID uint, reason string) error,
+) gin.HandlerFunc {
+	if capUSD <= 0 {
+		return func(c *gin.Context) { c.Next() }
+	}
+
+	type cached struct {
+		spent float64
+		at    time.Time
+	}
+	var mu sync.Mutex
+	perUser := make(map[uint]cached)
+
+	return func(c *gin.Context) {
+		user, err := util.GetUserFromContext(c)
+		if err != nil || user == nil || user.Subscription == nil ||
+			user.Subscription.Tier != models.TierUnlimited {
+			c.Next()
+			return
+		}
+
+		now := time.Now()
+		mu.Lock()
+		entry, ok := perUser[user.ID]
+		if !ok || now.Sub(entry.at) > time.Minute {
+			spent, sErr := sumUserSince(user.ID, now.Add(-24*time.Hour))
+			if sErr != nil {
+				mu.Unlock()
+				logger.Get().Warn("runaway-guard spend check failed, allowing request",
+					zap.Uint("user_id", user.ID), zap.Error(sErr))
+				c.Next()
+				return
+			}
+			entry = cached{spent: spent, at: now}
+			perUser[user.ID] = entry
+		}
+		spent := entry.spent
+		mu.Unlock()
+
+		if spent < capUSD {
+			c.Next()
+			return
+		}
+
+		reason := fmt.Sprintf("runaway guard: $%.2f attributed AI spend in 24h (cap $%.2f)", spent, capUSD)
+		if lErr := lockUser(user.ID, reason); lErr != nil {
+			logger.Get().Error("runaway guard failed to lock account",
+				zap.Uint("user_id", user.ID), zap.Error(lErr))
+		} else {
+			logger.Get().Warn("runaway guard LOCKED unlimited account",
+				zap.Uint("user_id", user.ID), zap.String("username", user.Username),
+				zap.Float64("spent_usd", spent), zap.Float64("cap_usd", capUSD))
+		}
+		notify.Alert(
+			fmt.Sprintf("runaway-lock-%d", user.ID),
+			"SaltyBytes SECURITY: unlimited account locked",
+			fmt.Sprintf("Account %q spent $%.2f on AI in the last 24h (cap $%.2f) and has been locked — possible compromised credential. If it was you, raise UNLIMITED_DAILY_SPEND_CAP_USD; to unlock: UPDATE users SET locked_at = NULL, lock_reason = '' WHERE id = %d;",
+				user.Username, spent, capUSD, user.ID),
+			"",
+			time.Hour,
+		)
+
+		c.JSON(http.StatusForbidden, gin.H{
+			"error":      "This account has been locked. Contact support.",
+			"error_code": "account_locked",
+		})
+		c.Abort()
+	}
+}

--- a/internal/middleware/runaway_guard_test.go
+++ b/internal/middleware/runaway_guard_test.go
@@ -1,0 +1,128 @@
+package middleware
+
+import (
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/gin-gonic/gin"
+	"github.com/windoze95/saltybytes-api/internal/models"
+	"gorm.io/gorm"
+)
+
+func runawayRouter(capUSD float64, user *models.User,
+	sum func(uint, time.Time) (float64, error),
+	lock func(uint, string) error,
+) *gin.Engine {
+	r := gin.New()
+	r.POST("/ai",
+		func(c *gin.Context) { c.Set("user", user); c.Next() },
+		UnlimitedRunawayGuard(capUSD, sum, lock),
+		func(c *gin.Context) { c.JSON(http.StatusOK, gin.H{"ok": true}) },
+	)
+	return r
+}
+
+func unlimitedUser() *models.User {
+	return &models.User{
+		Model:    gorm.Model{ID: 4},
+		Username: "julian",
+		Subscription: &models.Subscription{
+			Tier: models.TierUnlimited,
+		},
+	}
+}
+
+func hitRunaway(r *gin.Engine) *httptest.ResponseRecorder {
+	req := httptest.NewRequest("POST", "/ai", nil)
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, req)
+	return w
+}
+
+func TestRunawayGuard_UnderCapPasses(t *testing.T) {
+	locked := int32(0)
+	r := runawayRouter(10, unlimitedUser(),
+		func(uint, time.Time) (float64, error) { return 9.99, nil },
+		func(uint, string) error { atomic.AddInt32(&locked, 1); return nil })
+
+	if w := hitRunaway(r); w.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200", w.Code)
+	}
+	if atomic.LoadInt32(&locked) != 0 {
+		t.Error("must not lock under the cap")
+	}
+}
+
+func TestRunawayGuard_OverCapLocksAndBlocks(t *testing.T) {
+	var lockedID uint
+	var lockedReason string
+	r := runawayRouter(10, unlimitedUser(),
+		func(uint, time.Time) (float64, error) { return 12.40, nil },
+		func(id uint, reason string) error { lockedID = id; lockedReason = reason; return nil })
+
+	w := hitRunaway(r)
+	if w.Code != http.StatusForbidden {
+		t.Fatalf("status = %d, want 403. body: %s", w.Code, w.Body.String())
+	}
+	if !strings.Contains(w.Body.String(), "account_locked") {
+		t.Errorf("body missing account_locked code: %s", w.Body.String())
+	}
+	if lockedID != 4 {
+		t.Errorf("locked user %d, want 4", lockedID)
+	}
+	if !strings.Contains(lockedReason, "$12.40") || !strings.Contains(lockedReason, "$10.00") {
+		t.Errorf("lock reason should carry spend and cap: %q", lockedReason)
+	}
+}
+
+func TestRunawayGuard_CappedTiersPassWithoutSpendCheck(t *testing.T) {
+	sums := int32(0)
+	premium := unlimitedUser()
+	premium.Subscription.Tier = models.TierPremium
+	r := runawayRouter(10, premium,
+		func(uint, time.Time) (float64, error) { atomic.AddInt32(&sums, 1); return 999, nil },
+		func(uint, string) error { return nil })
+
+	if w := hitRunaway(r); w.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200 (capped tiers are already bounded)", w.Code)
+	}
+	if atomic.LoadInt32(&sums) != 0 {
+		t.Error("capped tiers must not incur spend queries")
+	}
+}
+
+func TestRunawayGuard_DisabledPasses(t *testing.T) {
+	r := runawayRouter(0, unlimitedUser(),
+		func(uint, time.Time) (float64, error) { return 99999, nil },
+		func(uint, string) error { return nil })
+	if w := hitRunaway(r); w.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200 when disabled", w.Code)
+	}
+}
+
+func TestRunawayGuard_FailsOpenOnQueryError(t *testing.T) {
+	r := runawayRouter(10, unlimitedUser(),
+		func(uint, time.Time) (float64, error) { return 0, errors.New("db down") },
+		func(uint, string) error { return nil })
+	if w := hitRunaway(r); w.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200 (fail open)", w.Code)
+	}
+}
+
+func TestRunawayGuard_CachesPerUserSpend(t *testing.T) {
+	sums := int32(0)
+	r := runawayRouter(10, unlimitedUser(),
+		func(uint, time.Time) (float64, error) { atomic.AddInt32(&sums, 1); return 1, nil },
+		func(uint, string) error { return nil })
+	hitRunaway(r)
+	hitRunaway(r)
+	hitRunaway(r)
+	if got := atomic.LoadInt32(&sums); got != 1 {
+		t.Errorf("spend queried %d times for 3 quick requests, want 1", got)
+	}
+}

--- a/internal/models/ai_usage.go
+++ b/internal/models/ai_usage.go
@@ -10,6 +10,11 @@ type AIUsageLog struct {
 	ID        uint      `gorm:"primarykey"`
 	CreatedAt time.Time `gorm:"index"`
 
+	// UserID attributes the call to the requesting user (0 = system-initiated
+	// work like cache warming, or a path that runs outside a request context).
+	// Powers the per-account runaway guard.
+	UserID uint `gorm:"index;default:0"`
+
 	Operation string `gorm:"size:64;index"` // e.g. "ExtractRecipeFromText"
 	Provider  string `gorm:"size:32;index"` // e.g. "anthropic"
 	Model     string `gorm:"size:96;index"` // e.g. "claude-haiku-4-5-20251001"

--- a/internal/models/user.go
+++ b/internal/models/user.go
@@ -19,7 +19,13 @@ type User struct {
 	// immediately at signup while email verification is disabled). Nil means
 	// unverified: AI-cost endpoints are gated and a stale signup releases its
 	// email address for reuse.
-	EmailVerifiedAt  *time.Time
+	EmailVerifiedAt *time.Time
+	// LockedAt, when set, disables the account entirely (every authenticated
+	// request 403s, including MCP). Set automatically by the unlimited-tier
+	// runaway guard on suspected compromise; cleared manually
+	// (UPDATE users SET locked_at = NULL, lock_reason = '').
+	LockedAt         *time.Time
+	LockReason       string
 	Auth             *UserAuth        `gorm:"foreignKey:UserID"`
 	Subscription     *Subscription    `gorm:"foreignKey:UserID"`
 	Settings         *UserSettings    `gorm:"foreignKey:UserID"`
@@ -30,6 +36,11 @@ type User struct {
 // EmailVerified reports whether the user's email address is verified.
 func (u *User) EmailVerified() bool {
 	return u.EmailVerifiedAt != nil
+}
+
+// Locked reports whether the account is administratively locked.
+func (u *User) Locked() bool {
+	return u.LockedAt != nil
 }
 
 // EmailVerification holds the pending 6-digit signup verification code for a

--- a/internal/repository/ai_usage.go
+++ b/internal/repository/ai_usage.go
@@ -32,3 +32,14 @@ func (r *AIUsageRepository) SumCostSince(since time.Time) (float64, error) {
 		Scan(&total).Error
 	return total, err
 }
+
+// SumCostByUserSince returns one user's attributed AI cost recorded at or
+// after the given instant. Backs the unlimited-tier runaway guard.
+func (r *AIUsageRepository) SumCostByUserSince(userID uint, since time.Time) (float64, error) {
+	var total float64
+	err := r.DB.Model(&models.AIUsageLog{}).
+		Where("user_id = ? AND created_at >= ?", userID, since).
+		Select("COALESCE(SUM(cost_usd), 0)").
+		Scan(&total).Error
+	return total, err
+}

--- a/internal/repository/interfaces.go
+++ b/internal/repository/interfaces.go
@@ -138,6 +138,7 @@ type UserRepo interface {
 	SetEmailVerified(userID uint) error
 	ClearUserEmail(userID uint) error
 	DeleteAbandonedUnverifiedUsers(olderThan time.Time) (int64, error)
+	LockUser(userID uint, reason string) error
 	IncrementTokenVersion(userID uint) error
 	CreateSubscription(sub *models.Subscription) error
 	IncrementSubscriptionUsage(userID uint, column string) error

--- a/internal/repository/user.go
+++ b/internal/repository/user.go
@@ -291,6 +291,22 @@ func (r *UserRepository) ResetSubscriptionUsage(userID uint, nextReset time.Time
 	return nil
 }
 
+// LockUser administratively locks an account (runaway guard / suspected
+// compromise): every authenticated request 403s until locked_at is cleared
+// manually.
+func (r *UserRepository) LockUser(userID uint, reason string) error {
+	err := r.DB.Model(&models.User{}).
+		Where("id = ?", userID).
+		Updates(map[string]interface{}{
+			"locked_at":   time.Now(),
+			"lock_reason": reason,
+		}).Error
+	if err != nil {
+		logger.Get().Error("failed to lock user", zap.Uint("user_id", userID), zap.Error(err))
+	}
+	return err
+}
+
 // DeleteAbandonedUnverifiedUsers hard-deletes "empty husk" accounts: never
 // email-verified, older than the cutoff, and with zero durable content (no
 // recipes created or collected, no family owned). These are abandoned

--- a/internal/router/router.go
+++ b/internal/router/router.go
@@ -154,6 +154,7 @@ func SetupRouter(cfg *config.Config, database *gorm.DB) *gin.Engine {
 		Sink: func(rec ai.UsageRecord) {
 			go func() {
 				if err := aiUsageRepo.Insert(&models.AIUsageLog{
+					UserID:           rec.UserID,
 					Operation:        rec.Operation,
 					Provider:         rec.Provider,
 					Model:            rec.Model,
@@ -174,6 +175,10 @@ func SetupRouter(cfg *config.Config, database *gorm.DB) *gin.Engine {
 	// the UTC day rolls over (0 = disabled). Complements the per-user quotas
 	// and the video-specific budget.
 	aiBudget := middleware.AIBudgetGuard(cfg.EnvVars.AIDailyBudgetUSD, cfg.EnvVars.DashboardURL, aiUsageRepo.SumCostSince)
+
+	// Per-account runaway lock for the hidden unlimited tier (suspected
+	// credential compromise). Capped tiers pass straight through.
+	runawayGuard := middleware.UnlimitedRunawayGuard(cfg.EnvVars.UnlimitedDailySpendCapUSD, aiUsageRepo.SumCostByUserSince, userRepo.LockUser)
 
 	aiMW := ai.NewMiddlewareChain(&ai.LoggingMiddleware{}, costMW, &ai.ErrorAlertMiddleware{})
 	textProvider.WithMiddleware(aiMW)
@@ -322,23 +327,23 @@ func SetupRouter(cfg *config.Config, database *gorm.DB) *gin.Engine {
 		// List the authenticated user's recipes
 		apiProtected.GET("/recipes", middleware.AttachUserToContext(userService), recipeHandler.ListRecipes)
 		// Regenerate a recipe in place based on a previous recipe and the user's chat
-		apiProtected.PUT("/recipes/:recipe_id/chat", middleware.AttachUserToContext(userService), verifiedOnly, aiBudget, recipeHandler.RegenerateRecipe)
+		apiProtected.PUT("/recipes/:recipe_id/chat", middleware.AttachUserToContext(userService), verifiedOnly, aiBudget, runawayGuard, recipeHandler.RegenerateRecipe)
 
-		apiProtected.POST("/recipes/:recipe_id/fork", middleware.AttachUserToContext(userService), verifiedOnly, aiBudget, recipeHandler.GenerateRecipeWithFork)
+		apiProtected.POST("/recipes/:recipe_id/fork", middleware.AttachUserToContext(userService), verifiedOnly, aiBudget, runawayGuard, recipeHandler.GenerateRecipeWithFork)
 
 		// Recipe import routes
-		apiProtected.POST("/recipes/import/url", middleware.AttachUserToContext(userService), aiBudget, importHandler.ImportFromURL)
-		apiProtected.POST("/recipes/import/photo", middleware.AttachUserToContext(userService), verifiedOnly, aiBudget, importHandler.ImportFromPhoto)
-		apiProtected.POST("/recipes/import/files", middleware.AttachUserToContext(userService), verifiedOnly, aiBudget, importHandler.ImportFromFiles)
-		apiProtected.POST("/recipes/import/voice", middleware.AttachUserToContext(userService), verifiedOnly, aiBudget, importHandler.ImportFromVoice)
-		apiProtected.POST("/recipes/import/video", middleware.AttachUserToContext(userService), verifiedOnly, aiBudget, importHandler.ImportFromVideo)
+		apiProtected.POST("/recipes/import/url", middleware.AttachUserToContext(userService), aiBudget, runawayGuard, importHandler.ImportFromURL)
+		apiProtected.POST("/recipes/import/photo", middleware.AttachUserToContext(userService), verifiedOnly, aiBudget, runawayGuard, importHandler.ImportFromPhoto)
+		apiProtected.POST("/recipes/import/files", middleware.AttachUserToContext(userService), verifiedOnly, aiBudget, runawayGuard, importHandler.ImportFromFiles)
+		apiProtected.POST("/recipes/import/voice", middleware.AttachUserToContext(userService), verifiedOnly, aiBudget, runawayGuard, importHandler.ImportFromVoice)
+		apiProtected.POST("/recipes/import/video", middleware.AttachUserToContext(userService), verifiedOnly, aiBudget, runawayGuard, importHandler.ImportFromVideo)
 		apiProtected.GET("/recipes/import/video/:id", middleware.AttachUserToContext(userService), importHandler.GetVideoImportStatus)
-		apiProtected.POST("/recipes/import/text", middleware.AttachUserToContext(userService), verifiedOnly, aiBudget, importHandler.ImportFromText)
+		apiProtected.POST("/recipes/import/text", middleware.AttachUserToContext(userService), verifiedOnly, aiBudget, runawayGuard, importHandler.ImportFromText)
 		apiProtected.POST("/recipes/import/manual", middleware.AttachUserToContext(userService), importHandler.ImportManual)
 		apiProtected.POST("/recipes/import/canonical", middleware.AttachUserToContext(userService), importHandler.ImportFromCanonical)
 
 		// Recipe preview route (cheap extraction for pre-import preview)
-		apiProtected.POST("/recipes/preview/url", middleware.AttachUserToContext(userService), aiBudget, importHandler.PreviewFromURL)
+		apiProtected.POST("/recipes/preview/url", middleware.AttachUserToContext(userService), aiBudget, runawayGuard, importHandler.PreviewFromURL)
 		// Universal-link resolution: saltybytes.ai/r/<id> carries only the
 		// canonical id; the app trades it for the source URL, then previews.
 		apiProtected.GET("/recipes/canonical/:id/source", importHandler.GetCanonicalSource)
@@ -365,16 +370,16 @@ func SetupRouter(cfg *config.Config, database *gorm.DB) *gin.Engine {
 	apiProtected.PUT("/family/members/:member_id", middleware.AttachUserToContext(userService), familyHandler.UpdateMember)
 	apiProtected.DELETE("/family/members/:member_id", middleware.AttachUserToContext(userService), familyHandler.DeleteMember)
 	apiProtected.PUT("/family/members/:member_id/dietary", middleware.AttachUserToContext(userService), familyHandler.UpdateDietaryProfile)
-	apiProtected.POST("/family/members/:member_id/dietary/interview", middleware.AttachUserToContext(userService), verifiedOnly, aiBudget, familyHandler.DietaryInterview)
+	apiProtected.POST("/family/members/:member_id/dietary/interview", middleware.AttachUserToContext(userService), verifiedOnly, aiBudget, runawayGuard, familyHandler.DietaryInterview)
 
 	// Allergen analysis routes setup
 	allergenRepo := repository.NewAllergenRepository(database)
 	allergenService := service.NewAllergenService(cfg, allergenRepo, familyRepo, recipeRepo, mainTextProvider, subService)
 	allergenHandler := handlers.NewAllergenHandler(allergenService)
 
-	apiProtected.POST("/recipes/:recipe_id/allergens/analyze", middleware.AttachUserToContext(userService), verifiedOnly, aiBudget, allergenHandler.AnalyzeRecipe)
+	apiProtected.POST("/recipes/:recipe_id/allergens/analyze", middleware.AttachUserToContext(userService), verifiedOnly, aiBudget, runawayGuard, allergenHandler.AnalyzeRecipe)
 	apiProtected.GET("/recipes/:recipe_id/allergens", middleware.AttachUserToContext(userService), allergenHandler.GetAnalysis)
-	apiProtected.POST("/recipes/:recipe_id/allergens/check-family", middleware.AttachUserToContext(userService), verifiedOnly, aiBudget, allergenHandler.CheckFamily)
+	apiProtected.POST("/recipes/:recipe_id/allergens/check-family", middleware.AttachUserToContext(userService), verifiedOnly, aiBudget, runawayGuard, allergenHandler.CheckFamily)
 
 	// User update routes
 	apiProtected.PUT("/users/me", middleware.AttachUserToContext(userService), userHandler.UpdateUser)
@@ -407,8 +412,8 @@ func SetupRouter(cfg *config.Config, database *gorm.DB) *gin.Engine {
 	searchHandler := &handlers.SearchHandler{Service: searchService, MultiResolver: multiResolver, WarmService: warmService}
 	apiProtected.GET("/recipes/search", middleware.AttachUserToContext(userService), searchHandler.SearchRecipes)
 	apiProtected.GET("/recipes/search/resolve/:multi_id", middleware.AttachUserToContext(userService), searchHandler.ResolveMultiRecipe)
-	apiProtected.POST("/recipes/search/check-multi", middleware.AttachUserToContext(userService), aiBudget, searchHandler.CheckMultiRecipe)
-	apiProtected.POST("/recipes/search/warm", middleware.AttachUserToContext(userService), aiBudget, searchHandler.WarmRecipes)
+	apiProtected.POST("/recipes/search/check-multi", middleware.AttachUserToContext(userService), aiBudget, runawayGuard, searchHandler.CheckMultiRecipe)
+	apiProtected.POST("/recipes/search/warm", middleware.AttachUserToContext(userService), aiBudget, runawayGuard, searchHandler.WarmRecipes)
 
 	// Recipe finder — a guided agent that finds REAL recipes by driving search +
 	// a single cheap ranking call (light tier), streamed over SSE. Gated by the
@@ -426,7 +431,7 @@ func SetupRouter(cfg *config.Config, database *gorm.DB) *gin.Engine {
 	finderService.Runs = repository.NewFinderRunRepository(database)
 	importService.Events = repository.NewExtractionEventRepository(database)
 	finderHandler := &handlers.FinderHandler{Service: finderService, SubService: subService}
-	apiProtected.POST("/recipes/find", middleware.AttachUserToContext(userService), verifiedOnly, aiBudget, finderHandler.FindRecipes)
+	apiProtected.POST("/recipes/find", middleware.AttachUserToContext(userService), verifiedOnly, aiBudget, runawayGuard, finderHandler.FindRecipes)
 	apiProtected.GET("/recipes/finder/sessions", middleware.AttachUserToContext(userService), finderSessionHandler.ListSessions)
 	apiProtected.GET("/recipes/finder/sessions/:session_id", middleware.AttachUserToContext(userService), finderSessionHandler.GetSession)
 	apiProtected.DELETE("/recipes/finder/sessions/:session_id", middleware.AttachUserToContext(userService), finderSessionHandler.DeleteSession)

--- a/internal/testutil/mocks.go
+++ b/internal/testutil/mocks.go
@@ -762,6 +762,20 @@ func (m *MockUserRepo) EmailExists(email string) (bool, error) {
 	return false, nil
 }
 
+func (m *MockUserRepo) LockUser(userID uint, reason string) error {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	u, ok := m.Users[userID]
+	if !ok {
+		return fmt.Errorf("user not found")
+	}
+	now := time.Now()
+	u.LockedAt = &now
+	u.LockReason = reason
+	return nil
+}
+
 func (m *MockUserRepo) DeleteAbandonedUnverifiedUsers(olderThan time.Time) (int64, error) {
 	m.mu.Lock()
 	defer m.mu.Unlock()


### PR DESCRIPTION
## Why

The hidden unlimited tier (#128) bypasses every quota. A compromised operator credential could burn AI spend up to the global $25/day switch — denying AI to every real user daily — and nothing would stop the account itself.

## What

1. **Per-user spend attribution** — `AttachUserToContext` tags the request context (`ai.WithUserID`); `CostMiddleware` reads the tag; `ai_usage_logs` gains an additive `user_id` column (0 = system work: warming, detached video jobs). This is also the foundation the dashboard needs for per-user cost views later.
2. **`UnlimitedRunawayGuard`** on all 15 AI routes: an unlimited account whose own attributed 24h spend exceeds `UNLIMITED_DAILY_SPEND_CAP_USD` (**default $10**, env-tunable, 0 disables) is **locked on the spot** — and the operator is paged via ntfy with the spend figure and the unlock SQL. Capped tiers skip the check entirely (their caps already bound them); 60s per-user cache; fails open so attribution gaps can't lock the operator out spuriously.
3. **Lock enforcement at the auth layer** — locked accounts 403 `account_locked` on every authenticated route, and the MCP connector rejects them too. Unlock is deliberately manual: `UPDATE users SET locked_at = NULL, lock_reason = ''`.

## Notes

- Additive schema only (`users.locked_at`/`lock_reason`, `ai_usage_logs.user_id`) — dashboard unaffected.
- Defense stack now: per-user tier caps → per-account runaway lock ($10/24h unlimited) → global $25/day AI switch → video $25/day → AWS budget alarms.
- Full suite green; new tests: guard (under/over/lock-reason/capped-tier-skip/disabled/fail-open/cache), locked-account auth rejection, context attribution.

🤖 Generated with [Claude Code](https://claude.com/claude-code)