### PR TITLE
feat(web): add Terms of Service page (/terms)

### DIFF
--- a/internal/web/templates/partials.html
+++ b/internal/web/templates/partials.html
@@ -73,6 +73,7 @@
     </div>
     <div class="foot-links">
       <a href="/privacy">Privacy</a>
+      <a href="/terms">Terms</a>
       <a href="mailto:windoze95@proton.me">Support</a>
       <a href="/#connector">AI&nbsp;connector</a>
     </div>

--- a/internal/web/templates/terms.html
+++ b/internal/web/templates/terms.html
@@ -1,0 +1,57 @@
+{{template "page_head" .Meta}}
+<body class="prose-page">
+{{template "site_nav" .}}
+<main class="wrap prose">
+  <h1>SaltyBytes Terms of Service</h1>
+  <p class="prose-date">Last updated: July 7, 2026</p>
+
+  <p>These Terms of Service (“Terms”) govern your use of the SaltyBytes app, website, and service (together, “SaltyBytes”, “we”, “our”), operated by Julian Dice. By creating an account or using SaltyBytes, you agree to these Terms. If you don't agree, please don't use the service.</p>
+
+  <h2>The service</h2>
+  <p>SaltyBytes helps you find real recipes from across the web, import and preview them, and keep them in your own collection. Recipes surfaced through search, preview, and import originate from third-party websites and creators; SaltyBytes organizes and reformats that content for your personal use and links back to the source. We may add, change, or remove features at any time.</p>
+
+  <h2>Your account</h2>
+  <p>You need an account to use most features. You're responsible for keeping your login credentials secure and for activity under your account. Provide accurate information when you sign up, and keep it current. SaltyBytes is not directed at children under 13, and you must be at least 13 (or the age of digital consent where you live) to use it.</p>
+
+  <h2>Acceptable use</h2>
+  <p>Use SaltyBytes only for lawful, personal, non-commercial recipe purposes. Don't: abuse, overload, or attempt to disrupt the service or its rate limits; scrape, resell, or redistribute the service or other users' content; reverse engineer or probe the service except as permitted by law; upload unlawful, infringing, or malicious content; or use the service to violate anyone else's rights. We may suspend or limit accounts that break these rules or put the service at risk.</p>
+
+  <h2>Your content</h2>
+  <p>You keep ownership of the recipes, notes, photos, files, and other content you add. You grant SaltyBytes a limited license to store, process, display, and transmit that content solely to operate and provide the service to you (including sending relevant content to our processors as described in our <a href="/privacy">Privacy Policy</a>). You're responsible for having the rights to the content you upload.</p>
+
+  <h2>Third-party sources</h2>
+  <p>Recipes and images that come from external websites remain the property of their original owners and are subject to those owners' terms. SaltyBytes is not responsible for the accuracy, availability, quality, or safety of third-party content, and inclusion of a source is not an endorsement. If you are a rights holder and believe content should be removed, contact us at <a href="mailto:windoze95@proton.me">windoze95@proton.me</a>.</p>
+
+  <h2>AI features, food safety, and allergens</h2>
+  <p>SaltyBytes uses AI to extract, summarize, search, and analyze recipes, including optional dietary and allergen checks. <strong>AI output can be incomplete or wrong.</strong> Allergen and dietary flags are best-effort assistance only and are <strong>not</strong> a substitute for reading actual ingredient labels, your own judgment, or professional medical advice. Always verify ingredients, quantities, cooking temperatures, and safety for yourself and anyone you cook for — especially where allergies, intolerances, or medical conditions are involved. You use recipes and AI output at your own risk. SaltyBytes does not provide medical, nutritional, or professional advice.</p>
+
+  <h2>AI assistant connectors</h2>
+  <p>You can connect SaltyBytes to third-party AI assistants (for example, the SaltyBytes connector in Claude or ChatGPT) through a scoped OAuth grant that you approve and can revoke at any time. Your use of those assistants is governed by their own terms and privacy policies, and SaltyBytes is not responsible for how their operators handle content you surface there.</p>
+
+  <h2>Subscriptions and purchases</h2>
+  <p>Some features may require a paid subscription. Purchases made through the Apple App Store or Google Play are billed by those platforms and governed by their terms; subscriptions renew automatically until cancelled, and you manage or cancel them through your app-store account. Except where required by law or the applicable store's policies, payments are non-refundable. Prices and plans may change on a going-forward basis.</p>
+
+  <h2>Intellectual property</h2>
+  <p>The SaltyBytes name, logo, software, and original site content are owned by us and protected by law. These Terms don't grant you any right to use our branding except as needed to use the service normally.</p>
+
+  <h2>Disclaimers</h2>
+  <p>SaltyBytes is provided “as is” and “as available”, without warranties of any kind, express or implied, including merchantability, fitness for a particular purpose, accuracy, and non-infringement. We don't warrant that the service will be uninterrupted, error-free, or that any recipe, extraction, or AI result will be accurate or safe.</p>
+
+  <h2>Limitation of liability</h2>
+  <p>To the fullest extent permitted by law, SaltyBytes and its operator will not be liable for any indirect, incidental, special, consequential, or punitive damages, or for any loss arising from your use of (or inability to use) the service, reliance on any content or AI output, or any food prepared using the service. Our total liability for any claim relating to the service will not exceed the greater of the amount you paid us in the twelve months before the claim or USD 50. Some jurisdictions don't allow certain limitations, so parts of this section may not apply to you.</p>
+
+  <h2>Termination</h2>
+  <p>You can stop using SaltyBytes and delete your account at any time (see the <a href="/privacy">Privacy Policy</a> for how). We may suspend or terminate access if you violate these Terms or to protect the service or its users. Sections that by their nature should survive termination (such as content licenses you've granted, disclaimers, and limitations of liability) will survive.</p>
+
+  <h2>Changes</h2>
+  <p>We may update these Terms as the service evolves, and we'll note the date at the top. Meaningful changes will be called out in release notes. Continuing to use SaltyBytes after an update means you accept the revised Terms.</p>
+
+  <h2>Governing law</h2>
+  <p>These Terms are governed by the laws of the United States and the state in which the operator resides, without regard to conflict-of-laws rules. Any dispute will be brought in the courts located there, unless applicable law gives you the right to bring it elsewhere.</p>
+
+  <h2>Contact</h2>
+  <p>Questions about these Terms: <a href="mailto:windoze95@proton.me">windoze95@proton.me</a></p>
+</main>
+{{template "site_footer" .}}
+</body>
+</html>

--- a/internal/web/web.go
+++ b/internal/web/web.go
@@ -61,6 +61,7 @@ func (h *Handler) Register(r *gin.Engine) {
 	r.GET("/r/:id", pages, h.Recipe)
 	r.GET("/r", pages, h.RecipeByURL)
 	r.GET("/privacy", pages, h.Privacy)
+	r.GET("/terms", pages, h.Terms)
 	r.GET("/robots.txt", h.Robots)
 	r.GET("/sitemap.xml", pages, h.Sitemap)
 	r.GET("/static/*filepath", h.Static)
@@ -387,6 +388,15 @@ func (h *Handler) Privacy(c *gin.Context) {
 		Year: time.Now().Year(),
 	}
 	h.render(c, http.StatusOK, "privacy.html", data, 3600)
+}
+
+// Terms renders the terms of service.
+func (h *Handler) Terms(c *gin.Context) {
+	data := simplePage{
+		Meta: h.meta("Terms — SaltyBytes", "The terms for using SaltyBytes: your account, your content, AI and food-safety disclaimers, and the usual legal basics.", "/terms"),
+		Year: time.Now().Year(),
+	}
+	h.render(c, http.StatusOK, "terms.html", data, 3600)
 }
 
 type notFoundData struct {


### PR DESCRIPTION
## Why
The ChatGPT Apps Directory submission form **requires** a Terms of Service URL, and `saltybytes.ai` only had `/privacy`. This adds `/terms`.

## Changes
- **`internal/web/templates/terms.html`** — new ToS page, mirrors `privacy.html` structure/partials/tone. Covers: the service, accounts (13+), acceptable use, your content + processing license, third-party recipe sources, **AI + food-safety/allergen disclaimers**, AI-assistant connectors (scoped OAuth), subscriptions/IAP (Apple/Google billing), IP, "as is" warranty disclaimer, limitation of liability, termination, changes, governing law, contact.
- **`internal/web/web.go`** — `GET /terms` route + `Terms` handler (mirrors `Privacy`, `simplePage`, 1h cache).
- **`internal/web/templates/partials.html`** — footer gains a `/terms` link.

## Notes
- Static/server-rendered, no new deps or data. `go build ./...`, `go vet`, and `go test ./internal/web/...` pass.
- Baseline ToS for a solo-operator recipe app; operator + contact match the existing privacy page (Julian Dice / windoze95@proton.me).

🤖 Generated with [Claude Code](https://claude.com/claude-code)