### PR TITLE
fix(mcp): poll for late ChatGPT window.openai delivery (+ temp diagnostic)

### DIFF
--- a/internal/mcpserver/widget/app.html
+++ b/internal/mcpserver/widget/app.html
@@ -700,6 +700,31 @@ const resizeObserver = new ResizeObserver(() => {
   }).catch(() => { /* not an MCP Apps postMessage host */ });
   resizeObserver.observe(document.body);
 })();
+
+// ChatGPT can set window.openai.toolOutput a tick after mount without firing
+// "openai:set_globals" — poll briefly so we don't miss a late delivery. If nothing
+// has rendered after a few seconds, surface what the host actually exposes instead
+// of sitting on the loading note. (Diagnostic string removed once ChatGPT render
+// is confirmed.)
+(function watchOpenAI() {
+  let n = 0;
+  const timer = setInterval(() => {
+    n++;
+    const oa = openAIHost();
+    if (oa && oa.toolOutput) { clearInterval(timer); applyOpenAIGlobals(oa); return; }
+    if (n >= 24) {
+      clearInterval(timer);
+      if (root.textContent.indexOf("Warming up") !== -1) {
+        const o = openAIHost();
+        const info = o
+          ? "openai present; keys: " + Object.keys(o).slice(0, 14).join(", ") + "; toolOutput " + (o.toolOutput ? "set" : "absent")
+          : "window.openai ABSENT in this iframe";
+        clearRoot();
+        root.appendChild(el("div", "note", "SaltyBytes debug — " + info));
+      }
+    }
+  }, 250);
+})();
 </script>
 </body>
 </html>


### PR DESCRIPTION
Follow-up to #135. The window.openai render path alone didn't clear the stuck-loading widget in ChatGPT. Adds a short poll for `window.openai.toolOutput` (handles a late delivery with no `openai:set_globals` event) and a temporary in-widget diagnostic that reports what the host exposes, to see inside the cross-origin sandbox. JS syntax-checked; go build + mcpserver tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)