### PR TITLE
feat: harden PUT /users/me — validate display name, re-verify on email change

### DIFF
--- a/internal/handlers/user.go
+++ b/internal/handlers/user.go
@@ -59,6 +59,12 @@ func (h *UserHandler) CreateUser(c *gin.Context) {
 		return
 	}
 
+	// Validate the optional display name
+	if err := h.Service.ValidateFirstName(newUser.FirstName); err != nil {
+		c.JSON(http.StatusBadRequest, gin.H{"error": err.Error()})
+		return
+	}
+
 	// Validate email
 	if err := h.Service.ValidateEmail(newUser.Email); err != nil {
 		c.JSON(http.StatusBadRequest, gin.H{"error": err.Error()})
@@ -354,13 +360,50 @@ func (h *UserHandler) UpdateUser(c *gin.Context) {
 		return
 	}
 
-	if err := h.Service.UpdateUser(user, req.FirstName, req.Email); err != nil {
-		logger.Get().Error("failed to update user", zap.Uint("user_id", user.ID), zap.Error(err))
-		c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
+	req.FirstName = strings.TrimSpace(req.FirstName)
+	req.Email = strings.TrimSpace(req.Email)
+
+	if err := h.Service.ValidateFirstName(req.FirstName); err != nil {
+		c.JSON(http.StatusBadRequest, gin.H{"error": err.Error()})
 		return
 	}
 
-	c.JSON(http.StatusOK, gin.H{"message": "User updated successfully"})
+	// Note the address change before the update rewrites the in-memory user.
+	emailChanged := req.Email != "" && !strings.EqualFold(req.Email, user.Email)
+	if emailChanged {
+		if err := h.Service.ValidateEmail(req.Email); err != nil {
+			c.JSON(http.StatusBadRequest, gin.H{"error": err.Error()})
+			return
+		}
+	}
+
+	if err := h.Service.UpdateUser(user, req.FirstName, req.Email); err != nil {
+		if errors.Is(err, repository.ErrEmailTaken) {
+			c.JSON(http.StatusConflict, gin.H{"error": "email already in use"})
+			return
+		}
+		logger.Get().Error("failed to update user", zap.Uint("user_id", user.ID), zap.Error(err))
+		c.JSON(http.StatusInternalServerError, gin.H{"error": "Failed to update user"})
+		return
+	}
+
+	// The address changed, so UpdateUser un-verified the account. Send a code to
+	// the new address — best-effort, exactly like signup: a mail hiccup must not
+	// fail the update, and the verify screen offers a resend.
+	verificationRequired := false
+	if emailChanged && h.EmailVerification != nil && h.EmailVerification.Enabled() {
+		verificationRequired = true
+		if err := h.EmailVerification.StartVerification(c.Request.Context(), user); err != nil {
+			logger.Get().Warn("failed to send verification email after address change",
+				zap.Uint("user_id", user.ID), zap.Error(err))
+		}
+	}
+
+	c.JSON(http.StatusOK, gin.H{
+		"message": "User updated successfully",
+		// Tells a client it has to collect a code before AI features work again.
+		"email_verification_required": verificationRequired,
+	})
 }
 
 // UpdateSettings updates a user's settings.

--- a/internal/repository/interfaces.go
+++ b/internal/repository/interfaces.go
@@ -137,7 +137,7 @@ type UserRepo interface {
 	GetUserAuthByUsername(username string) (*models.User, error)
 	GetUserAuthByEmail(email string) (*models.User, error)
 	UpdateUserFirstName(userID uint, firstName string) error
-	UpdateUserEmail(userID uint, email string) error
+	UpdateUserEmail(userID uint, email string, verifiedAt *time.Time) error
 	UpdateUserSettingsKeepScreenAwake(userID uint, keepScreenAwake bool) error
 	UpdatePersonalization(userID uint, update *models.PersonalizationUpdate) error
 	UsernameExists(username string) (bool, error)

--- a/internal/repository/user.go
+++ b/internal/repository/user.go
@@ -124,11 +124,18 @@ func (r *UserRepository) UpdateUserFirstName(userID uint, firstName string) erro
 	return err
 }
 
-// UpdateUserEmail updates a user's email address.
-func (r *UserRepository) UpdateUserEmail(userID uint, email string) error {
+// UpdateUserEmail updates a user's email address and, in the same statement,
+// its verification state: a nil verifiedAt marks the new address unverified.
+// Both columns move together so an account can never be left looking verified
+// on an address nobody proved. A map is used rather than a struct because GORM
+// skips zero values on struct updates, and nil is the value that matters here.
+func (r *UserRepository) UpdateUserEmail(userID uint, email string, verifiedAt *time.Time) error {
 	err := r.DB.Model(&models.User{}).
 		Where("id = ?", userID).
-		Update("Email", email).Error
+		Updates(map[string]interface{}{
+			"email":             email,
+			"email_verified_at": verifiedAt,
+		}).Error
 	if err != nil {
 		logger.Get().Error("failed to update user email", zap.Uint("user_id", userID), zap.Error(err))
 		return mapUserUniqueViolation(err)

--- a/internal/router/router.go
+++ b/internal/router/router.go
@@ -133,6 +133,8 @@ func SetupRouter(cfg *config.Config, database *gorm.DB) *gin.Engine {
 	emailVerificationService := service.NewEmailVerificationService(cfg, userRepo, emailVerificationRepo, emailSender)
 	emailVerificationHandler := handlers.NewEmailVerificationHandler(emailVerificationService)
 	userHandler.EmailVerification = emailVerificationService
+	// Lets UpdateUser decide whether a changed address starts out unverified.
+	userService.Verification = emailVerificationService
 
 	// Gate for AI-cost endpoints: throwaway signups must verify their email
 	// before they can spend AI quota. No-op while verification is disabled.

--- a/internal/service/profile_update_test.go
+++ b/internal/service/profile_update_test.go
@@ -1,0 +1,197 @@
+package service
+
+import (
+	"errors"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/windoze95/saltybytes-api/internal/models"
+	"github.com/windoze95/saltybytes-api/internal/repository"
+	"github.com/windoze95/saltybytes-api/internal/testutil"
+)
+
+// stubVerification stands in for EmailVerificationService.
+type stubVerification struct{ enabled bool }
+
+func (s stubVerification) Enabled() bool { return s.enabled }
+
+// newProfileHarness builds a user service with a verified account already in it.
+// The returned user is the object the repo holds — tests should pass a
+// sessionCopy of it to UpdateUser, not this pointer.
+func newProfileHarness(t *testing.T, verificationLive bool) (*UserService, *testutil.MockUserRepo, *models.User) {
+	t.Helper()
+
+	repo := testutil.NewMockUserRepo()
+	svc := &UserService{
+		Cfg:          verificationEnabledConfig(),
+		Repo:         repo,
+		Verification: stubVerification{enabled: verificationLive},
+	}
+
+	verifiedAt := time.Now()
+	user := &models.User{
+		Username:        "cook",
+		Email:           "cook@example.com",
+		EmailVerifiedAt: &verifiedAt,
+		Auth:            &models.UserAuth{AuthType: models.Standard},
+	}
+	repo.CreateUser(user)
+	return svc, repo, user
+}
+
+// sessionCopy mimics what the handler actually passes in: a user loaded from the
+// database, which is a *different* object from the row the repo will write.
+//
+// This matters. MockUserRepo hands back the very pointer it stores, so calling
+// UpdateUser with the harness's user would make every "did it persist?"
+// assertion vacuous — they'd pass on the service's in-memory mutation alone,
+// even if it never touched the repo.
+func sessionCopy(stored *models.User) *models.User {
+	c := *stored
+	return &c
+}
+
+func TestUpdateUser_EmailChangeUnverifiesAccount(t *testing.T) {
+	svc, repo, stored := newProfileHarness(t, true)
+	user := sessionCopy(stored)
+
+	if err := svc.UpdateUser(user, "", "new@example.com"); err != nil {
+		t.Fatalf("UpdateUser error: %v", err)
+	}
+
+	// The in-memory user has to move too: the handler mails user.Email next, and
+	// StartVerification refuses to send to an account that still looks verified.
+	if user.Email != "new@example.com" {
+		t.Errorf("in-memory email = %q, want new@example.com", user.Email)
+	}
+	if user.EmailVerified() {
+		t.Error("in-memory user still looks verified after an address change")
+	}
+
+	// And it has to be persisted, not just mutated in memory.
+	written, _ := repo.GetUserByID(stored.ID)
+	if written.Email != "new@example.com" {
+		t.Errorf("stored email = %q, want new@example.com", written.Email)
+	}
+	if written.EmailVerified() {
+		t.Error("stored account still verified on an address nobody proved")
+	}
+}
+
+func TestUpdateUser_EmailChangeAutoVerifiesWhileVerificationOff(t *testing.T) {
+	svc, repo, stored := newProfileHarness(t, false)
+
+	if err := svc.UpdateUser(sessionCopy(stored), "", "new@example.com"); err != nil {
+		t.Fatalf("UpdateUser error: %v", err)
+	}
+
+	written, _ := repo.GetUserByID(stored.ID)
+	if !written.EmailVerified() {
+		t.Error("with verification off, a changed address must be auto-verified — the gate is a no-op and nothing would ever send a code")
+	}
+}
+
+func TestUpdateUser_SameAddressDifferentCaseKeepsVerification(t *testing.T) {
+	svc, repo, stored := newProfileHarness(t, true)
+
+	if err := svc.UpdateUser(sessionCopy(stored), "", "Cook@Example.com"); err != nil {
+		t.Fatalf("UpdateUser error: %v", err)
+	}
+
+	written, _ := repo.GetUserByID(stored.ID)
+	if !written.EmailVerified() {
+		t.Error("retyping the same address in different case must not cost the user their verified status")
+	}
+}
+
+func TestUpdateUser_TakenEmailIsRejected(t *testing.T) {
+	svc, repo, stored := newProfileHarness(t, true)
+
+	otherVerified := time.Now()
+	repo.CreateUser(&models.User{
+		Username:        "taken",
+		Email:           "taken@example.com",
+		EmailVerifiedAt: &otherVerified,
+		Auth:            &models.UserAuth{AuthType: models.Standard},
+	})
+
+	err := svc.UpdateUser(sessionCopy(stored), "", "taken@example.com")
+	if !errors.Is(err, repository.ErrEmailTaken) {
+		t.Errorf("UpdateUser with a taken email = %v, want ErrEmailTaken", err)
+	}
+
+	written, _ := repo.GetUserByID(stored.ID)
+	if written.Email != "cook@example.com" || !written.EmailVerified() {
+		t.Error("a rejected email change must leave the account untouched")
+	}
+}
+
+func TestUpdateUser_FirstNameOnlyKeepsVerification(t *testing.T) {
+	svc, repo, stored := newProfileHarness(t, true)
+
+	if err := svc.UpdateUser(sessionCopy(stored), "Julia", ""); err != nil {
+		t.Fatalf("UpdateUser error: %v", err)
+	}
+
+	written, _ := repo.GetUserByID(stored.ID)
+	if written.FirstName != "Julia" {
+		t.Errorf("stored first name = %q, want Julia", written.FirstName)
+	}
+	if !written.EmailVerified() {
+		t.Error("changing only the display name must not touch verification")
+	}
+}
+
+func TestValidateFirstName(t *testing.T) {
+	svc := newTestUserService(testutil.NewMockUserRepo())
+
+	tests := []struct {
+		name      string
+		firstName string
+		wantErr   bool
+	}{
+		{"empty is allowed (optional)", "", false},
+		{"plain", "Julian", false},
+		{"accented", "José", false},
+		{"umlaut", "Zoë", false},
+		{"non-latin script", "李", false},
+		{"hyphenated", "Mary-Jane", false},
+		{"apostrophe", "O'Brien", false},
+		{"curly apostrophe", "O’Brien", false},
+		{"initials", "J. R.", false},
+		{"two words", "Ann Marie", false},
+		{"at the length limit", strings.Repeat("a", maxFirstNameLength), false},
+
+		{"over the length limit", strings.Repeat("a", maxFirstNameLength+1), true},
+		{"absurdly long", strings.Repeat("a", 5000), true},
+		{"digits", "Chef2000", true},
+		{"emoji", "Julian🍳", true},
+		{"newline", "Julian\nAdmin", true},
+		{"tab", "Julian\tAdmin", true},
+		{"control character", "Julian\x00", true},
+		{"punctuation only", "---", true},
+		{"symbols", "<script>", true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := svc.ValidateFirstName(tt.firstName)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("ValidateFirstName(%q) error = %v, wantErr %v", tt.firstName, err, tt.wantErr)
+			}
+		})
+	}
+}
+
+func TestValidateEmail_LengthCap(t *testing.T) {
+	svc := newTestUserService(testutil.NewMockUserRepo())
+
+	long := strings.Repeat("a", 250) + "@example.com" // valid shape, 262 chars
+	if err := svc.ValidateEmail(long); err == nil {
+		t.Error("ValidateEmail: an over-long address should fail")
+	}
+	if err := svc.ValidateEmail("fine@example.com"); err != nil {
+		t.Errorf("ValidateEmail: a normal address should pass, got %v", err)
+	}
+}

--- a/internal/service/user.go
+++ b/internal/service/user.go
@@ -7,6 +7,8 @@ import (
 	"strconv"
 	"strings"
 	"time"
+	"unicode"
+	"unicode/utf8"
 
 	"github.com/asaskevich/govalidator"
 	"github.com/windoze95/saltybytes-api/internal/config"
@@ -18,11 +20,35 @@ import (
 	"gorm.io/gorm"
 )
 
+// EmailVerificationStatus is the sliver of EmailVerificationService that
+// UserService needs: whether verification is actually live (switched on in
+// config AND backed by a working sender). A nil implementation means not live.
+type EmailVerificationStatus interface {
+	Enabled() bool
+}
+
 // UserService is the business logic layer for user-related operations.
 type UserService struct {
 	Cfg  *config.Config
 	Repo repository.UserRepo
+	// Verification is assigned by the router once the verification service
+	// exists. Nil (in tests, or before wiring) reads as "not live".
+	Verification EmailVerificationStatus
 }
+
+// verificationLive reports whether an address has to be proved before it counts
+// as verified.
+func (s *UserService) verificationLive() bool {
+	return s.Verification != nil && s.Verification.Enabled()
+}
+
+// Profile field bounds. Both columns are unbounded text, so these are the only
+// thing between a client and a 5,000-character display name. Username bounds
+// live in username_policy.go.
+const (
+	maxFirstNameLength = 50
+	maxEmailLength     = 254 // RFC 5321 caps the whole path at 254
+)
 
 // UserResponse is the response object for user-related operations.
 type UserResponse struct {
@@ -282,20 +308,54 @@ func (s *UserService) UpdatePersonalization(user *models.User, update *models.Pe
 	return s.Repo.UpdatePersonalization(user.ID, update)
 }
 
-// UpdateUser updates a user's profile fields (first name, email).
+// UpdateUser updates a user's profile fields (first name, email). Callers are
+// expected to have validated both already.
+//
+// Changing the address un-verifies the account. EmailVerifiedAt is what gates
+// the AI-cost endpoints and what the stale-signup sweep keys off, so it has to
+// mean "we verified THIS address" — otherwise anyone could verify a throwaway
+// and then swap in an address nobody ever proved. The caller sends the fresh
+// code; when verification isn't live the new address is marked verified
+// immediately, mirroring what signup does in that mode.
+//
+// The in-memory user is updated to match, so the caller mails the new address
+// and not the old one.
 func (s *UserService) UpdateUser(user *models.User, firstName, email string) error {
-	if email != "" && email != user.Email {
+	// EqualFold: retyping the same address with different capitalisation is not
+	// a change, and must not cost the user their verified status.
+	if email != "" && !strings.EqualFold(email, user.Email) {
 		if err := s.ValidateEmail(email); err != nil {
 			return err
 		}
-		if err := s.Repo.UpdateUserEmail(user.ID, email); err != nil {
+
+		// Same question signup asks — is this address claimable? — including
+		// the release of one squatted by a stale unverified signup, which also
+		// keeps the unique constraint from firing underneath us.
+		taken, err := s.EmailTakenForSignup(email)
+		if err != nil {
 			return err
 		}
+		if taken {
+			return repository.ErrEmailTaken
+		}
+
+		var verifiedAt *time.Time
+		if !s.verificationLive() {
+			now := time.Now()
+			verifiedAt = &now
+		}
+		if err := s.Repo.UpdateUserEmail(user.ID, email, verifiedAt); err != nil {
+			return err
+		}
+		user.Email = email
+		user.EmailVerifiedAt = verifiedAt
 	}
+
 	if firstName != "" {
 		if err := s.Repo.UpdateUserFirstName(user.ID, firstName); err != nil {
 			return err
 		}
+		user.FirstName = firstName
 	}
 	return nil
 }
@@ -331,6 +391,49 @@ func (s *UserService) ValidateUsername(username string) error {
 func (s *UserService) ValidateEmail(email string) error {
 	if !govalidator.IsEmail(email) {
 		return fmt.Errorf("invalid email format")
+	}
+	// RFC 5321 caps a path at 254 characters. govalidator's pattern doesn't,
+	// and the column is unbounded text.
+	if utf8.RuneCountInString(email) > maxEmailLength {
+		return fmt.Errorf("email must be %d characters or less", maxEmailLength)
+	}
+	return nil
+}
+
+// ValidateFirstName validates the optional display name.
+//
+// Names are a minefield, so the rule is "any letter, plus the punctuation that
+// shows up in real names": Mary-Jane, O'Brien, J. R., José, Zoë, 李 all pass.
+// Everything else is rejected — digits, emoji, symbols, and control characters,
+// which is what makes a newline-stuffed or 5,000-character name impossible.
+//
+// Deliberately NOT profanity-checked. The name is private: the app only ever
+// shows it back to its owner (the settings screen prefers it over the username),
+// it is not published and never reaches an AI prompt. A filter would buy no
+// moderation here and would reject people genuinely named Dick or Fanny. If
+// first names ever become visible to other users — a family roster, an author
+// byline on a shared recipe — revisit this.
+func (s *UserService) ValidateFirstName(firstName string) error {
+	if firstName == "" {
+		return nil // optional
+	}
+	if utf8.RuneCountInString(firstName) > maxFirstNameLength {
+		return fmt.Errorf("first name must be %d characters or less", maxFirstNameLength)
+	}
+
+	hasLetter := false
+	for _, r := range firstName {
+		switch {
+		case unicode.IsLetter(r):
+			hasLetter = true
+		case unicode.IsMark(r): // combining accents
+		case r == ' ' || r == '-' || r == '\'' || r == '’' || r == '.':
+		default:
+			return fmt.Errorf("first name can only contain letters, spaces, hyphens, apostrophes and periods")
+		}
+	}
+	if !hasLetter {
+		return fmt.Errorf("first name must contain at least one letter")
 	}
 	return nil
 }

--- a/internal/testutil/mocks.go
+++ b/internal/testutil/mocks.go
@@ -713,12 +713,13 @@ func (m *MockUserRepo) UpdateUserFirstName(userID uint, firstName string) error 
 	return nil
 }
 
-func (m *MockUserRepo) UpdateUserEmail(userID uint, email string) error {
+func (m *MockUserRepo) UpdateUserEmail(userID uint, email string, verifiedAt *time.Time) error {
 	m.mu.Lock()
 	defer m.mu.Unlock()
 
 	if u, ok := m.Users[userID]; ok {
 		u.Email = email
+		u.EmailVerifiedAt = verifiedAt
 	}
 	return nil
 }


### PR DESCRIPTION
Started as the `first_name` follow-up. `first_name` turned out to be the *smaller* problem.

## The real bug: an email change didn't un-verify the account

`email_verified_at` is what gates the AI-cost endpoints (as of this morning's flip) and what the stale-signup sweep keys off. But `PUT /users/me` swapped the address and left the verified flag set — so the flow below kept "verified" status on an address nobody ever proved:

1. Sign up with a throwaway address, enter the code → verified.
2. `PUT /users/me {"email": "anything@else.com"}` → address changes, `email_verified_at` stays set.

That makes `email_verified_at` mean "this account once proved *some* address," which is not what it's gating on.

**Fix:** changing the address clears verification and mails a fresh code to the **new** address (best-effort, exactly like signup). When verification isn't live, the new address is auto-verified instead — mirroring signup in that mode, since nothing would ever send a code. Email and verification state now move in a single `UPDATE`, so an account can't be left verified on an unproved address even if something fails midway.

## Also on that path

- **`first_name` was unvalidated free text** on an unbounded `text` column, at both signup and update. Now: any Unicode letter plus the punctuation real names use — `Mary-Jane`, `O'Brien`, `J. R.`, `José`, `Zoë`, `李` — and nothing else. Digits, emoji, symbols and control characters are rejected (so no newline-stuffed or 5,000-character names), capped at 50.
- **Deliberately NOT profanity-checked.** I checked where it surfaces: the app only ever shows it back to its owner, it's not published, and it never reaches an AI prompt. A filter would buy zero moderation and would reject people genuinely named Dick or Fanny. There's a comment saying to revisit if first names ever become visible to others.
- **A taken email returned 500.** Now 409 — the repo was already mapping the unique violation to `ErrEmailTaken`, the handler just wasn't checking it.
- **Email length capped at 254** (RFC 5321). The column is unbounded text and govalidator doesn't bound it.
- **Re-typing your own address in different case** is no longer treated as a change, so it can't cost you your verified status.

## Verification

`go test ./... -count=1` green. New tests cover the un-verify, the auto-verify-when-disabled path, the case-only no-op, the 409, and the `ValidateFirstName` table (including `José`/`李`/`O'Brien` passing and emoji/newline/digits failing).

Two things I checked rather than assumed:
- **The new tests are load-bearing.** `MockUserRepo` hands back the same pointer it stores, so a naive test would assert on the service's in-memory mutation and pass even if it never wrote to the repo. Tests pass a copy (`sessionCopy`) so the "did it persist?" assertions are real. Reverting the un-verify logic makes `TestUpdateUser_EmailChangeUnverifiesAccount` fail with *"stored account still verified on an address nobody proved"* — confirmed.
- **`StartVerification` refuses to send to an account that still looks verified**, and mails `user.Email` — so `UpdateUser` updates the in-memory user, or the code would go to the old address.

## Note

`TestVideoImport_NativeVideoUsed` flaked once during a full-suite run here — `waitForVideoJob` polls an async job against a hard 3s wall-clock deadline (`import_video_test.go:187`). Unrelated to this change (passes 3/3 isolated, 3/3 in the full package, suite green), but it can redden CI at random. Happy to fix separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0194PdH4wDTnz5SWfzyoKagc