### PR TITLE
fix(test): give the async polling helpers a deadline that survives a loaded suite

### DIFF
--- a/internal/handlers/import_video_handler_test.go
+++ b/internal/handlers/import_video_handler_test.go
@@ -185,7 +185,7 @@ func TestImportFromVideo_Accepted_AndPoll(t *testing.T) {
 
 	// Poll the status endpoint until the async job completes.
 	path := "/recipes/import/video/" + itoa(accepted.Job.ID)
-	deadline := time.Now().Add(3 * time.Second)
+	deadline := time.Now().Add(testutil.AsyncDeadline)
 	var lastStatus string
 	for time.Now().Before(deadline) {
 		gw := httptest.NewRecorder()

--- a/internal/service/import_video_test.go
+++ b/internal/service/import_video_test.go
@@ -184,7 +184,7 @@ func newVideoTestService(repo *testutil.MockRecipeRepo, vrepo *testutil.MockVide
 // waitForVideoJob polls until the job reaches a terminal state or times out.
 func waitForVideoJob(t *testing.T, svc *ImportService, id uint) *models.VideoImport {
 	t.Helper()
-	deadline := time.Now().Add(3 * time.Second)
+	deadline := time.Now().Add(testutil.AsyncDeadline)
 	for time.Now().Before(deadline) {
 		job, err := svc.GetVideoImport(id)
 		if err == nil && (job.Status == models.VideoImportDone || job.Status == models.VideoImportFailed) {
@@ -470,7 +470,7 @@ func TestVideoImport_RefundsQuotaOnFailure(t *testing.T) {
 	}
 	// The refund runs in the goroutine after the job is marked failed; poll the
 	// lock-synchronized counter until it lands.
-	deadline := time.Now().Add(2 * time.Second)
+	deadline := time.Now().Add(testutil.AsyncDeadline)
 	for time.Now().Before(deadline) && userRepo.SubscriptionUsage(user.ID, "video_imports_used") != 0 {
 		time.Sleep(5 * time.Millisecond)
 	}

--- a/internal/service/multi_recipe_resolver_test.go
+++ b/internal/service/multi_recipe_resolver_test.go
@@ -63,7 +63,7 @@ func newResolverForTest(preview ai.TextProvider, canonicalRepo *testutil.MockCan
 // waitResolved polls the entry until background extraction finishes.
 func waitResolved(t *testing.T, entry *MultiRecipeEntry) {
 	t.Helper()
-	deadline := time.Now().Add(3 * time.Second)
+	deadline := time.Now().Add(testutil.AsyncDeadline)
 	for time.Now().Before(deadline) {
 		if entry.GetStatus() == "resolved" {
 			return

--- a/internal/testutil/async.go
+++ b/internal/testutil/async.go
@@ -1,0 +1,18 @@
+package testutil
+
+import "time"
+
+// AsyncDeadline bounds the test helpers that poll for a background goroutine to
+// finish (video import jobs, multi-recipe resolution, hub room teardown).
+//
+// It is deliberately generous, and that costs nothing: every one of those loops
+// exits the moment the work lands, so the happy path is unaffected. The deadline
+// only decides how long a genuinely stuck test waits before failing.
+//
+// A tight bound here is really a timing assertion on the Go scheduler. Under a
+// loaded parallel suite — `go test ./...` compiling and running every package at
+// once, which is exactly what the CI deploy gate does — a background goroutine
+// can be starved for seconds. That is how TestVideoImport_NativeVideoUsed failed
+// at a 3-second deadline while passing in isolation: nothing was broken, the
+// machine was just busy. Flaky gates get ignored, so buy the margin.
+const AsyncDeadline = 30 * time.Second

--- a/internal/ws/hub_rooms_test.go
+++ b/internal/ws/hub_rooms_test.go
@@ -3,6 +3,8 @@ package ws
 import (
 	"testing"
 	"time"
+
+	"github.com/windoze95/saltybytes-api/internal/testutil"
 )
 
 // roomExists checks the hub's room map under its lock.
@@ -16,7 +18,7 @@ func roomExists(h *Hub, roomID string) bool {
 // waitForRoomGone polls until the room disappears from the hub or times out.
 func waitForRoomGone(t *testing.T, h *Hub, roomID string) {
 	t.Helper()
-	deadline := time.Now().Add(2 * time.Second)
+	deadline := time.Now().Add(testutil.AsyncDeadline)
 	for roomExists(h, roomID) {
 		if time.Now().After(deadline) {
 			t.Fatalf("room %q was not removed from the hub", roomID)


### PR DESCRIPTION
## Why

`TestVideoImport_NativeVideoUsed` failed a full-suite run with `video import job 1 did not finish in time`, then passed 3/3 in isolation and 3/3 in the full package. Nothing was broken — the helper polls a background goroutine against a hard **3-second wall-clock deadline**, which is really a timing assertion on the Go scheduler. Under `go test ./...` (what the CI deploy gate runs) every package compiles and runs at once and a goroutine can be starved well past 3s. On my machine Microsoft Defender was also burning 168% CPU, which is exactly the kind of thing that tips it over.

This matters because that suite **is the deploy gate**. A gate that reddens at random gets ignored, and an ignored gate is worse than a slow one.

## What

Five helpers had 2–3s deadlines, all the same shape (*poll until the background work lands, fail on timeout*):

| File | What it waits for |
|---|---|
| `service/import_video_test.go:187` | video import job reaching a terminal state |
| `service/import_video_test.go:473` | the quota-refund counter |
| `service/multi_recipe_resolver_test.go:66` | multi-recipe resolution |
| `handlers/import_video_handler_test.go:188` | the video status endpoint |
| `ws/hub_rooms_test.go:19` | hub room teardown |

They now share `testutil.AsyncDeadline` (30s), with the rationale documented in one place.

## This costs nothing

None of these is a "prove X does *not* happen" assertion — I checked all six before touching them. Every loop exits the moment the work lands, so **the deadline is never actually waited on in a passing run**:

```
--- PASS: TestVideoImport_NativeVideoUsed (0.32s)   <- against a 30s ceiling
--- PASS: TestVideoImport_FreshExtraction  (0.41s)
--- PASS: TestHubBroadcast_RoomIsolation   (0.05s)
```

The deadline only bounds how long a *genuinely stuck* test waits before failing. Raising it trades a slower failure case for a reliable gate.

`finder_extraction_fix_test.go` already allows 90s and was left alone.

## Verification

`go test ./... -count=1` green twice; `go vet` and `gofmt` clean. I tried to force the flake under synthetic CPU load with the old 3s value, but 28 spinners on 14 cores starved the Go toolchain itself and the run never completed — not a useful experiment, so I verified the property that actually matters instead: the deadline is never reached on a passing run, so the increase is free.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0194PdH4wDTnz5SWfzyoKagc